### PR TITLE
fix: add tests for field and method with the same name

### DIFF
--- a/gen/bobgen-psql/driver/testdatabase.sql
+++ b/gen/bobgen-psql/driver/testdatabase.sql
@@ -22,8 +22,11 @@ create table users (
 	parent_id int,
     party_id int UNIQUE,
 
+	referrer int,
+
 	foreign key (parent_id) references users (id),
-	foreign key (party_id) references users (id)
+	foreign key (party_id) references users (id),
+	foreign key (referrer) references users (id)
 );
 
 comment on column users.email_validated is 'Has the email address been tested?';


### PR DESCRIPTION
In case relational columns don't follow the convention suffix `_id`, the code generation breaks.