### PR TITLE
Allow limit and offset to be arguments in postgresql

### DIFF
--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -100,17 +100,19 @@ func (s SelectQuery) WriteSQL(w io.Writer, d bob.Dialect, start int) ([]any, err
 	}
 	args = append(args, orderArgs...)
 
-	_, err = bob.ExpressIf(w, d, start+len(args), s.Limit,
+	limitArgs, err := bob.ExpressIf(w, d, start+len(args), s.Limit,
 		s.Limit.Count != nil, "\n", "")
 	if err != nil {
 		return nil, err
 	}
+	args = append(args, limitArgs...)
 
-	_, err = bob.ExpressIf(w, d, start+len(args), s.Offset,
+	offsetArgs, err := bob.ExpressIf(w, d, start+len(args), s.Offset,
 		s.Offset.Count != nil, "\n", "")
 	if err != nil {
 		return nil, err
 	}
+	args = append(args, offsetArgs...)
 
 	_, err = bob.ExpressIf(w, d, start+len(args), s.Fetch,
 		s.Fetch.Count != nil, "\n", "")

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -110,6 +110,17 @@ func TestSelect(t *testing.T) {
 			ExpectedSQL:  "SELECT id, name FROM users WHERE (id, employee_id) IN (($1, $2), ($3, $4))",
 			ExpectedArgs: []any{100, 200, 300, 400},
 		},
+		"simple limit offset arg": {
+			Doc:          "Simple select with limit and offset as argument",
+			ExpectedSQL:  "SELECT id, name FROM users LIMIT $1 OFFSET $2",
+			ExpectedArgs: []any{10, 15},
+			Query: psql.Select(
+				sm.Columns("id", "name"),
+				sm.From("users"),
+				sm.Offset(psql.Arg(15)),
+				sm.Limit(psql.Arg(10)),
+			),
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -104,13 +104,13 @@ func OrderBy(e any) dialect.OrderBy[*dialect.SelectQuery] {
 	})
 }
 
-func Limit(count int64) bob.Mod[*dialect.SelectQuery] {
+func Limit(count any) bob.Mod[*dialect.SelectQuery] {
 	return mods.Limit[*dialect.SelectQuery]{
 		Count: count,
 	}
 }
 
-func Offset(count int64) bob.Mod[*dialect.SelectQuery] {
+func Offset(count any) bob.Mod[*dialect.SelectQuery] {
 	return mods.Offset[*dialect.SelectQuery]{
 		Count: count,
 	}


### PR DESCRIPTION
Fixes #63 