### PR TITLE
Allow expressions in Raw

### DIFF
--- a/expr/raw_test.go
+++ b/expr/raw_test.go
@@ -37,6 +37,30 @@ func TestStatement(t *testing.T) {
 			ExpectedSQL:  `SELECT a, b FROM alphabet WHERE c = ?1 AND d <= ?2`,
 			ExpectedArgs: []any{1, 2},
 		},
+		"expr args": {
+			Expression: Clause{
+				query: "SELECT a, b FROM alphabet WHERE c IN (?) AND d <= ?",
+				args:  []any{Arg(5, 6, 7), 2},
+			},
+			ExpectedSQL:  `SELECT a, b FROM alphabet WHERE c IN (?1, ?2, ?3) AND d <= ?4`,
+			ExpectedArgs: []any{5, 6, 7, 2},
+		},
+		"expr args group": {
+			Expression: Clause{
+				query: "SELECT a, b FROM alphabet WHERE c IN ? AND d <= ?",
+				args:  []any{ArgGroup(5, 6, 7), 2},
+			},
+			ExpectedSQL:  `SELECT a, b FROM alphabet WHERE c IN (?1, ?2, ?3) AND d <= ?4`,
+			ExpectedArgs: []any{5, 6, 7, 2},
+		},
+		"expr args quote": {
+			Expression: Clause{
+				query: "SELECT a, b FROM alphabet WHERE c = ? AND d <= ?",
+				args:  []any{Quote("AA"), 2},
+			},
+			ExpectedSQL:  `SELECT a, b FROM alphabet WHERE c = "AA" AND d <= ?1`,
+			ExpectedArgs: []any{2},
+		},
 	}
 
 	testutils.RunExpressionTests(t, dialect{}, examples)


### PR DESCRIPTION
This change checks for expressions in `Raw` and `RawQuery`, this enables for example doing "IN" with psql.Arg.

```go
q := psql.Select(
	sm.From("projects"),
	sm.Where(psql.RawQuery("id in (?) and deleted = ?", psql.Arg(1, 2, 5), 0)),
)

query, args, err := q.Build()
if err != nil {
	panic(err)
}

fmt.Println(query)
fmt.Printf("%+v\n", args)
```

```
SELECT 
*
FROM projects
WHERE id in ($1, $2, $3) and deleted = $4

[1 2 5 0]
```