### PR TITLE
Include WhereOr and WhereAnd to make it easier to combine multiple where clauses

### DIFF
--- a/dialect/mysql/dm/qm.go
+++ b/dialect/mysql/dm/qm.go
@@ -76,8 +76,8 @@ func StraightJoin(e any) bob.Mod[*dialect.DeleteQuery] {
 	return dialect.StraightJoin[*dialect.DeleteQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.DeleteQuery] {
-	return mods.Where[*dialect.DeleteQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.DeleteQuery] {
+	return mods.Where[*dialect.DeleteQuery]{E: e}
 }
 
 func OrderBy(e any) dialect.OrderBy[*dialect.DeleteQuery] {

--- a/dialect/mysql/sm/qm.go
+++ b/dialect/mysql/sm/qm.go
@@ -79,8 +79,8 @@ func StraightJoin(e any) bob.Mod[*dialect.SelectQuery] {
 	return dialect.StraightJoin[*dialect.SelectQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.SelectQuery] {
-	return mods.Where[*dialect.SelectQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.SelectQuery] {
+	return mods.Where[*dialect.SelectQuery]{E: e}
 }
 
 func Having(e any) bob.Mod[*dialect.SelectQuery] {

--- a/dialect/mysql/um/qm.go
+++ b/dialect/mysql/um/qm.go
@@ -55,8 +55,8 @@ func Set(from ...string) mods.Set[*dialect.UpdateQuery] {
 	return mods.Set[*dialect.UpdateQuery](from)
 }
 
-func Where(e any) bob.Mod[*dialect.UpdateQuery] {
-	return mods.Where[*dialect.UpdateQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.UpdateQuery] {
+	return mods.Where[*dialect.UpdateQuery]{E: e}
 }
 
 func OrderBy(e any) dialect.OrderBy[*dialect.UpdateQuery] {

--- a/dialect/mysql/where.go
+++ b/dialect/mysql/where.go
@@ -2,8 +2,15 @@ package mysql
 
 import (
 	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/mods"
 )
+
+type mod[Q interface{ AppendWhere(e ...any) }] struct {
+	e bob.Expression
+}
+
+func (d mod[Q]) Apply(q Q) {
+	q.AppendWhere(d.e)
+}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -15,52 +22,74 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
+func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: Or(exprs...),
+	}
+}
+
+func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: And(exprs...),
+	}
+}
+
 type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
+	return mod[Q]{w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mod[Q] {
+	return mod[Q]{w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mod[Q] {
+	return mod[Q]{w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
+	return mod[Q]{w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mod[Q] {
+	return mod[Q]{w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
+	return mod[Q]{w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.In(Arg(values...))}
+	return mod[Q]{w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.NotIn(Arg(values...))}
+	return mod[Q]{w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mod[Q] {
+	return mod[Q]{w.name.Like(Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -75,10 +104,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
+	return mod[Q]{w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
+	return mod[Q]{w.name.IsNotNull()}
 }

--- a/dialect/mysql/where.go
+++ b/dialect/mysql/where.go
@@ -2,15 +2,8 @@ package mysql
 
 import (
 	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/mods"
 )
-
-type mod[Q interface{ AppendWhere(e ...any) }] struct {
-	e bob.Expression
-}
-
-func (d mod[Q]) Apply(q Q) {
-	q.AppendWhere(d.e)
-}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -22,25 +15,25 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
-func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereOr[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: Or(exprs...),
+	return mods.Where[Q]{
+		E: Or(exprs...),
 	}
 }
 
-func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereAnd[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: And(exprs...),
+	return mods.Where[Q]{
+		E: And(exprs...),
 	}
 }
 
@@ -48,48 +41,48 @@ type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
-	return mod[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) mod[Q] {
-	return mod[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) mod[Q] {
-	return mod[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
-	return mod[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) mod[Q] {
-	return mod[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
-	return mod[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.In(Arg(values...))}
+	return mods.Where[Q]{E: w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.NotIn(Arg(values...))}
+	return mods.Where[Q]{E: w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) mod[Q] {
-	return mod[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.Like(Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -104,10 +97,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
-	return mod[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
-	return mod[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNotNull()}
 }

--- a/dialect/psql/dm/qm.go
+++ b/dialect/psql/dm/qm.go
@@ -62,8 +62,8 @@ func CrossJoin(e any) bob.Mod[*dialect.DeleteQuery] {
 	return dialect.CrossJoin[*dialect.DeleteQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.DeleteQuery] {
-	return mods.Where[*dialect.DeleteQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.DeleteQuery] {
+	return mods.Where[*dialect.DeleteQuery]{E: e}
 }
 
 func Returning(clauses ...any) bob.Mod[*dialect.DeleteQuery] {

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -67,8 +67,8 @@ func CrossJoin(e any) bob.Mod[*dialect.SelectQuery] {
 	return dialect.CrossJoin[*dialect.SelectQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.SelectQuery] {
-	return mods.Where[*dialect.SelectQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.SelectQuery] {
+	return mods.Where[*dialect.SelectQuery]{E: e}
 }
 
 func Having(e any) bob.Mod[*dialect.SelectQuery] {

--- a/dialect/psql/um/qm.go
+++ b/dialect/psql/um/qm.go
@@ -80,8 +80,8 @@ func CrossJoin(e any) bob.Mod[*dialect.UpdateQuery] {
 	return dialect.CrossJoin[*dialect.UpdateQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.UpdateQuery] {
-	return mods.Where[*dialect.UpdateQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.UpdateQuery] {
+	return mods.Where[*dialect.UpdateQuery]{E: e}
 }
 
 func Returning(clauses ...any) bob.Mod[*dialect.UpdateQuery] {

--- a/dialect/psql/where.go
+++ b/dialect/psql/where.go
@@ -3,8 +3,15 @@ package psql
 import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/expr"
-	"github.com/stephenafamo/bob/mods"
 )
+
+type mod[Q interface{ AppendWhere(e ...any) }] struct {
+	e bob.Expression
+}
+
+func (d mod[Q]) Apply(q Q) {
+	q.AppendWhere(d.e)
+}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -16,56 +23,78 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
+func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: Or(exprs...),
+	}
+}
+
+func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: And(exprs...),
+	}
+}
+
 type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
+	return mod[Q]{w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mod[Q] {
+	return mod[Q]{w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mod[Q] {
+	return mod[Q]{w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
+	return mod[Q]{w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mod[Q] {
+	return mod[Q]{w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
+	return mod[Q]{w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.In(Arg(values...))}
+	return mod[Q]{w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.NotIn(Arg(values...))}
+	return mod[Q]{w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mod[Q] {
+	return mod[Q]{w.name.Like(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) ILike(val C) bob.Mod[Q] {
-	return mods.Where[Q]{expr.OP("ILIKE", w.name, Arg(val))}
+func (w WhereMod[Q, C]) ILike(val C) mod[Q] {
+	return mod[Q]{expr.OP("ILIKE", w.name, Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -80,10 +109,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
+	return mod[Q]{w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
+	return mod[Q]{w.name.IsNotNull()}
 }

--- a/dialect/psql/where.go
+++ b/dialect/psql/where.go
@@ -3,15 +3,8 @@ package psql
 import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/expr"
+	"github.com/stephenafamo/bob/mods"
 )
-
-type mod[Q interface{ AppendWhere(e ...any) }] struct {
-	e bob.Expression
-}
-
-func (d mod[Q]) Apply(q Q) {
-	q.AppendWhere(d.e)
-}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -23,25 +16,25 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
-func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereOr[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: Or(exprs...),
+	return mods.Where[Q]{
+		E: Or(exprs...),
 	}
 }
 
-func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereAnd[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: And(exprs...),
+	return mods.Where[Q]{
+		E: And(exprs...),
 	}
 }
 
@@ -49,52 +42,52 @@ type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
-	return mod[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) mod[Q] {
-	return mod[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) mod[Q] {
-	return mod[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
-	return mod[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) mod[Q] {
-	return mod[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
-	return mod[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.In(Arg(values...))}
+	return mods.Where[Q]{E: w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.NotIn(Arg(values...))}
+	return mods.Where[Q]{E: w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) mod[Q] {
-	return mod[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.Like(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) ILike(val C) mod[Q] {
-	return mod[Q]{expr.OP("ILIKE", w.name, Arg(val))}
+func (w WhereMod[Q, C]) ILike(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: expr.OP("ILIKE", w.name, Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -109,10 +102,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
-	return mod[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
-	return mod[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNotNull()}
 }

--- a/dialect/sqlite/dm/qm.go
+++ b/dialect/sqlite/dm/qm.go
@@ -18,8 +18,8 @@ func From(name any) dialect.FromChain[*dialect.DeleteQuery] {
 	return dialect.From[*dialect.DeleteQuery](name)
 }
 
-func Where(e any) bob.Mod[*dialect.DeleteQuery] {
-	return mods.Where[*dialect.DeleteQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.DeleteQuery] {
+	return mods.Where[*dialect.DeleteQuery]{E: e}
 }
 
 func Returning(clauses ...any) bob.Mod[*dialect.DeleteQuery] {

--- a/dialect/sqlite/sm/qm.go
+++ b/dialect/sqlite/sm/qm.go
@@ -49,8 +49,8 @@ func CrossJoin(e any) bob.Mod[*dialect.SelectQuery] {
 	return dialect.CrossJoin[*dialect.SelectQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.SelectQuery] {
-	return mods.Where[*dialect.SelectQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.SelectQuery] {
+	return mods.Where[*dialect.SelectQuery]{E: e}
 }
 
 func Having(e any) bob.Mod[*dialect.SelectQuery] {

--- a/dialect/sqlite/um/qm.go
+++ b/dialect/sqlite/um/qm.go
@@ -88,8 +88,8 @@ func CrossJoin(e any) bob.Mod[*dialect.UpdateQuery] {
 	return dialect.CrossJoin[*dialect.UpdateQuery](e)
 }
 
-func Where(e any) bob.Mod[*dialect.UpdateQuery] {
-	return mods.Where[*dialect.UpdateQuery]{e}
+func Where(e bob.Expression) mods.Where[*dialect.UpdateQuery] {
+	return mods.Where[*dialect.UpdateQuery]{E: e}
 }
 
 func Returning(clauses ...any) bob.Mod[*dialect.UpdateQuery] {

--- a/dialect/sqlite/where.go
+++ b/dialect/sqlite/where.go
@@ -2,8 +2,15 @@ package sqlite
 
 import (
 	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/mods"
 )
+
+type mod[Q interface{ AppendWhere(e ...any) }] struct {
+	e bob.Expression
+}
+
+func (d mod[Q]) Apply(q Q) {
+	q.AppendWhere(d.e)
+}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -15,52 +22,74 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
+func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: Or(exprs...),
+	}
+}
+
+func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+	exprs := make([]bob.Expression, len(whereMods))
+	for i, mod := range whereMods {
+		exprs[i] = mod.e
+	}
+
+	return mod[Q]{
+		e: And(exprs...),
+	}
+}
+
 type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
+	return mod[Q]{w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mod[Q] {
+	return mod[Q]{w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mod[Q] {
+	return mod[Q]{w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
+	return mod[Q]{w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mod[Q] {
+	return mod[Q]{w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
+	return mod[Q]{w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.In(Arg(values...))}
+	return mod[Q]{w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) bob.Mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mods.Where[Q]{w.name.NotIn(Arg(values...))}
+	return mod[Q]{w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) bob.Mod[Q] {
-	return mods.Where[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mod[Q] {
+	return mod[Q]{w.name.Like(Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -75,10 +104,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
+	return mod[Q]{w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() bob.Mod[Q] {
-	return mods.Where[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
+	return mod[Q]{w.name.IsNotNull()}
 }

--- a/dialect/sqlite/where.go
+++ b/dialect/sqlite/where.go
@@ -2,15 +2,8 @@ package sqlite
 
 import (
 	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/mods"
 )
-
-type mod[Q interface{ AppendWhere(e ...any) }] struct {
-	e bob.Expression
-}
-
-func (d mod[Q]) Apply(q Q) {
-	q.AppendWhere(d.e)
-}
 
 type Filterable interface {
 	AppendWhere(...any)
@@ -22,25 +15,25 @@ func Where[Q Filterable, C any](name Expression) WhereMod[Q, C] {
 	}
 }
 
-func WhereOr[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereOr[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: Or(exprs...),
+	return mods.Where[Q]{
+		E: Or(exprs...),
 	}
 }
 
-func WhereAnd[Q Filterable](whereMods ...mod[Q]) mod[Q] {
+func WhereAnd[Q Filterable](whereMods ...mods.Where[Q]) mods.Where[Q] {
 	exprs := make([]bob.Expression, len(whereMods))
 	for i, mod := range whereMods {
-		exprs[i] = mod.e
+		exprs[i] = mod.E
 	}
 
-	return mod[Q]{
-		e: And(exprs...),
+	return mods.Where[Q]{
+		E: And(exprs...),
 	}
 }
 
@@ -48,48 +41,48 @@ type WhereMod[Q Filterable, C any] struct {
 	name Expression
 }
 
-func (w WhereMod[Q, C]) EQ(val C) mod[Q] {
-	return mod[Q]{w.name.EQ(Arg(val))}
+func (w WhereMod[Q, C]) EQ(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.EQ(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) NE(val C) mod[Q] {
-	return mod[Q]{w.name.NE(Arg(val))}
+func (w WhereMod[Q, C]) NE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.NE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LT(val C) mod[Q] {
-	return mod[Q]{w.name.LT(Arg(val))}
+func (w WhereMod[Q, C]) LT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) LTE(val C) mod[Q] {
-	return mod[Q]{w.name.LTE(Arg(val))}
+func (w WhereMod[Q, C]) LTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.LTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GT(val C) mod[Q] {
-	return mod[Q]{w.name.GT(Arg(val))}
+func (w WhereMod[Q, C]) GT(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GT(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) GTE(val C) mod[Q] {
-	return mod[Q]{w.name.GTE(Arg(val))}
+func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.GTE(Arg(val))}
 }
 
-func (w WhereMod[Q, C]) In(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.In(Arg(values...))}
+	return mods.Where[Q]{E: w.name.In(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) NotIn(slice ...C) mod[Q] {
+func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
-	return mod[Q]{w.name.NotIn(Arg(values...))}
+	return mods.Where[Q]{E: w.name.NotIn(Arg(values...))}
 }
 
-func (w WhereMod[Q, C]) Like(val C) mod[Q] {
-	return mod[Q]{w.name.Like(Arg(val))}
+func (w WhereMod[Q, C]) Like(val C) mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.Like(Arg(val))}
 }
 
 func WhereNull[Q Filterable, C any](name Expression) WhereNullMod[Q, C] {
@@ -104,10 +97,10 @@ type WhereNullMod[Q interface {
 	WhereMod[Q, C]
 }
 
-func (w WhereNullMod[Q, C]) IsNull() mod[Q] {
-	return mod[Q]{w.name.IsNull()}
+func (w WhereNullMod[Q, C]) IsNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNull()}
 }
 
-func (w WhereNullMod[Q, C]) IsNotNull() mod[Q] {
-	return mod[Q]{w.name.IsNotNull()}
+func (w WhereNullMod[Q, C]) IsNotNull() mods.Where[Q] {
+	return mods.Where[Q]{E: w.name.IsNotNull()}
 }

--- a/mods/mods.go
+++ b/mods/mods.go
@@ -50,10 +50,12 @@ func (j Join[Q]) Apply(q Q) {
 	q.AppendJoin(clause.Join(j))
 }
 
-type Where[Q interface{ AppendWhere(e ...any) }] []any
+type Where[Q interface{ AppendWhere(e ...any) }] struct {
+	E bob.Expression
+}
 
-func (d Where[Q]) Apply(q Q) {
-	q.AppendWhere(d...)
+func (w Where[Q]) Apply(q Q) {
+	q.AppendWhere(w.E)
 }
 
 type GroupBy[Q interface{ AppendGroup(any) }] struct {


### PR DESCRIPTION
Implements #77 

Makes it possible to do something like this

```go
	users, err := models.Users(
		ctx, db,
		psql.WhereOr(
			models.SelectWhere.Users.Name.IsNull(),
			models.SelectWhere.Users.Email.IsNotNull(),
		),
		psql.WhereAnd(
			models.SelectWhere.Users.Name.IsNull(),
			models.SelectWhere.Users.Email.IsNotNull(),
		),
	).All()
```