### PR TITLE
Fix mysql TablesInfo method and make sure we don't exclude entire table when targeting columns

### DIFF
--- a/gen/bobgen-mysql/driver/mysql.go
+++ b/gen/bobgen-mysql/driver/mysql.go
@@ -124,14 +124,14 @@ func (d *driver) TablesInfo(ctx context.Context, tableFilter drivers.Filter) (dr
 	exclude := tableFilter.Except
 
 	if len(include) > 0 {
-		query += fmt.Sprintf(" and table_name in (%s)", strmangle.Placeholders(true, len(include), 3, 1))
+		query += fmt.Sprintf(" and table_name in (%s)", strmangle.Placeholders(false, len(include), 1, 1)) // third param is not used for ? placeholders
 		for _, w := range include {
 			args = append(args, w)
 		}
 	}
 
 	if len(exclude) > 0 {
-		query += fmt.Sprintf(" and table_name not in (%s)", strmangle.Placeholders(true, len(exclude), 3+len(include), 1))
+		query += fmt.Sprintf(" and table_name not in (%s)", strmangle.Placeholders(false, len(exclude), 1, 1)) // third param is not used for ? placeholders
 		for _, w := range exclude {
 			args = append(args, w)
 		}

--- a/gen/drivers/table.go
+++ b/gen/drivers/table.go
@@ -106,8 +106,11 @@ func ParseTableFilter(only, except map[string][]string) Filter {
 		filter.Only = append(filter.Only, name)
 	}
 
-	for name := range except {
-		filter.Except = append(filter.Except, name)
+	for name, cols := range except {
+		// If they only want to exclude some columns, then we don't want to exclude the whole table
+		if len(cols) == 0 {
+			filter.Except = append(filter.Except, name)
+		}
 	}
 
 	return filter


### PR DESCRIPTION
This fixes broken Only/Except config options for the bobgen-mysql. Previously when using these options this error would come:
```
unable to fetch table data: unable to get table names: Error 1054 (42S22): Unknown column '$3' in 'where clause'
```

Due to it not being able to handle indexPlaceholders (`$3`). 

This changes it to use `?` as placeholders instead.

It also fixes an issue with only excluding columns as described in the documentation (https://bob.stephenafamo.com/docs/code-generation/mysql). Previously it would remove the entire table before checking if it was only certain columns that needed to be removed.