### PR TITLE
Implement named args and binding

### DIFF
--- a/bound_query.go
+++ b/bound_query.go
@@ -6,10 +6,7 @@ import (
 	"reflect"
 
 	"github.com/stephenafamo/bob/internal/mappings"
-	"github.com/stephenafamo/scan"
 )
-
-var mapperSource, _ = scan.NewStructMapperSource()
 
 type MismatchedArgsError struct {
 	Expected int

--- a/bound_query.go
+++ b/bound_query.go
@@ -1,0 +1,169 @@
+package bob
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/stephenafamo/bob/internal/mappings"
+	"github.com/stephenafamo/scan"
+)
+
+var mapperSource, _ = scan.NewStructMapperSource()
+
+type MismatchedArgsError struct {
+	Expected int
+	Got      int
+}
+
+func (e MismatchedArgsError) Error() string {
+	return fmt.Sprintf("expected %d args, got %d", e.Expected, e.Got)
+}
+
+type DuplicateArgError struct{ Name string }
+
+func (e DuplicateArgError) Error() string {
+	return fmt.Sprintf("duplicate arg %s", e.Name)
+}
+
+type MissingArgError struct{ Name string }
+
+func (e MissingArgError) Error() string {
+	return fmt.Sprintf("missing arg %s", e.Name)
+}
+
+type binder[T any] interface {
+	ToArgs(T) []any
+}
+
+type BoundQuery[T any] struct {
+	query  []byte
+	binder binder[T]
+	start  int
+}
+
+func (b BoundQuery[T]) Bind(args T) BaseQuery[*cached] {
+	realArgs := b.binder.ToArgs(args)
+
+	return BaseQuery[*cached]{
+		Expression: &cached{
+			query: b.query,
+			args:  realArgs,
+			start: b.start,
+		},
+	}
+}
+
+func BindNamed[T any](q Query) (BoundQuery[T], error) {
+	return BindNamedN[T](q, 1)
+}
+
+func BindNamedN[T any](q Query, start int) (BoundQuery[T], error) {
+	query, args, err := BuildN(q, start)
+	if err != nil {
+		return BoundQuery[T]{}, err
+	}
+
+	binder, err := makeStructBinder[T](args)
+	if err != nil {
+		return BoundQuery[T]{}, err
+	}
+
+	return BoundQuery[T]{
+		query:  []byte(query),
+		binder: binder,
+		start:  start,
+	}, nil
+}
+
+type structBinder[T any] struct {
+	args   []string
+	fields []string
+}
+
+func (b structBinder[T]) Inspect() []string {
+	names := make([]string, len(b.args))
+	for _, name := range b.args {
+		if name == "" {
+			continue
+		}
+
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func (b structBinder[T]) ToArgs(arg T) []any {
+	val := reflect.ValueOf(arg)
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return make([]any, len(b.args))
+		}
+		val = val.Elem()
+	}
+
+	values := make([]any, len(b.args))
+
+ArgLoop:
+	for index, argName := range b.args {
+		for _, fieldName := range b.fields {
+			if fieldName == argName {
+				field := val.Field(index)
+				values[index] = field.Interface()
+				continue ArgLoop
+			}
+		}
+	}
+
+	return values
+}
+
+func makeStructBinder[Arg any](args []any) (structBinder[Arg], error) {
+	var x Arg
+	typ := reflect.TypeOf(x)
+
+	isStruct := typ.Kind() == reflect.Struct
+	if typ.Kind() == reflect.Ptr {
+		isStruct = typ.Elem().Kind() == reflect.Struct
+	}
+
+	if !isStruct {
+		return structBinder[Arg]{}, errors.New("bind type must be a struct")
+	}
+
+	givenArgs := make([]any, len(args))
+	argPositions := make([]string, len(args))
+	for pos, arg := range args {
+		if name, ok := arg.(namedArg); ok {
+			argPositions[pos] = string(name)
+			continue
+		}
+
+		if name, ok := arg.(named); ok && len(name.names) == 1 {
+			argPositions[pos] = string(name.names[0])
+			continue
+		}
+
+		givenArgs[pos] = arg
+	}
+
+	fieldPositions := mappings.GetMappings(reflect.TypeOf(x)).All
+	fmt.Println(fieldPositions)
+
+	// check if all positions have matching fields
+ArgLoop:
+	for _, name := range argPositions {
+		for _, field := range fieldPositions {
+			if field == name {
+				continue ArgLoop
+			}
+		}
+		return structBinder[Arg]{}, MissingArgError{Name: name}
+	}
+
+	return structBinder[Arg]{
+		args:   argPositions,
+		fields: fieldPositions,
+	}, nil
+}

--- a/bound_query_test.go
+++ b/bound_query_test.go
@@ -1,6 +1,74 @@
 package bob
 
-import "testing"
+import (
+	"testing"
 
-func TestMapBinding(t *testing.T) {
+	"github.com/google/go-cmp/cmp"
+)
+
+func (s structBinder[Arg]) Equal() {
+}
+
+type binderTests[Arg any] struct {
+	arg   Arg
+	final []any
+}
+
+type structBinderTest[Arg any] struct {
+	expected structBinder[Arg]
+	args     []binderTests[Arg]
+}
+
+func testBinder[Arg any](t *testing.T, origin []any, tests []binderTests[Arg]) {
+	t.Helper()
+	binder, err := makeStructBinder[Arg](origin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		if diff := cmp.Diff(binder.ToArgs(test.arg), test.final); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}
+
+func TestStructBinding(t *testing.T) {
+	t.Run("no args", func(t *testing.T) {
+		testBinder(t, []any{}, []binderTests[struct{}]{
+			{
+				arg:   struct{}{},
+				final: []any{},
+			},
+		})
+	})
+
+	t.Run("no named", func(t *testing.T) {
+		testBinder(t, []any{1, 2, 3, 4}, []binderTests[struct{}]{
+			{
+				arg:   struct{}{},
+				final: []any{1, 2, 3, 4},
+			},
+		})
+	})
+
+	t.Run("all named", func(t *testing.T) {
+		testBinder(t, []any{namedArg("one"), namedArg("two"), namedArg("three"), namedArg("four")}, []binderTests[struct{ One, Two, Three, Four int }]{
+			{
+				arg:   struct{ One, Two, Three, Four int }{One: 1, Two: 2, Three: 3, Four: 4},
+				final: []any{1, 2, 3, 4},
+			},
+		})
+	})
+
+	t.Run("mixed named", func(t *testing.T) {
+		testBinder(t, []any{1, 2, namedArg("three"), 4}, []binderTests[struct {
+			Three int
+		}]{
+			{
+				arg:   struct{ Three int }{Three: 3},
+				final: []any{1, 2, 3, 4},
+			},
+		})
+	})
 }

--- a/bound_query_test.go
+++ b/bound_query_test.go
@@ -14,11 +14,6 @@ type binderTests[Arg any] struct {
 	final []any
 }
 
-type structBinderTest[Arg any] struct {
-	expected structBinder[Arg]
-	args     []binderTests[Arg]
-}
-
 func testBinder[Arg any](t *testing.T, origin []any, tests []binderTests[Arg]) {
 	t.Helper()
 	binder, err := makeStructBinder[Arg](origin)

--- a/bound_query_test.go
+++ b/bound_query_test.go
@@ -6,9 +6,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func (s structBinder[Arg]) Equal() {
-}
-
 type binderTests[Arg any] struct {
 	arg   Arg
 	final []any

--- a/bound_query_test.go
+++ b/bound_query_test.go
@@ -1,0 +1,6 @@
+package bob
+
+import "testing"
+
+func TestMapBinding(t *testing.T) {
+}

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -78,16 +78,6 @@ func (v *View[T, Tslice]) Query(ctx context.Context, exec bob.Executor, queryMod
 	return q
 }
 
-// Prepare a statement that will be mapped to the view's type
-func (v *View[T, Tslice]) Prepare(ctx context.Context, exec bob.Preparer, queryMods ...bob.Mod[*dialect.SelectQuery]) (bob.QueryStmt[T, Tslice], error) {
-	return v.PrepareQuery(ctx, exec, v.Query(ctx, nil, queryMods...))
-}
-
-// Prepare a statement from an existing query that will be mapped to the view's type
-func (v *View[T, Tslice]) PrepareQuery(ctx context.Context, exec bob.Preparer, q bob.Query) (bob.QueryStmt[T, Tslice], error) {
-	return bob.PrepareQueryx[T, Tslice](ctx, exec, q, v.scanner, v.afterSelect(ctx, exec))
-}
-
 func (v *View[T, Ts]) afterSelect(ctx context.Context, exec bob.Executor) bob.ExecOption[T] {
 	return func(es *bob.ExecSettings[T]) {
 		es.AfterSelect = func(ctx context.Context, retrieved []T) error {

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -97,16 +97,6 @@ func (v *View[T, Tslice]) Query(ctx context.Context, exec bob.Executor, queryMod
 	return q
 }
 
-// Prepare a statement that will be mapped to the view's type
-func (v *View[T, Tslice]) Prepare(ctx context.Context, exec bob.Preparer, queryMods ...bob.Mod[*dialect.SelectQuery]) (bob.QueryStmt[T, Tslice], error) {
-	return v.PrepareQuery(ctx, exec, v.Query(ctx, nil, queryMods...))
-}
-
-// Prepare a statement from an existing query that will be mapped to the view's type
-func (v *View[T, Tslice]) PrepareQuery(ctx context.Context, exec bob.Preparer, q bob.Query) (bob.QueryStmt[T, Tslice], error) {
-	return bob.PrepareQueryx[T, Tslice](ctx, exec, q, v.scanner, v.afterSelect(ctx, exec))
-}
-
 func (v *View[T, Ts]) afterSelect(ctx context.Context, exec bob.Executor) bob.ExecOption[T] {
 	return func(es *bob.ExecSettings[T]) {
 		es.AfterSelect = func(ctx context.Context, retrieved []T) error {

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -97,16 +97,6 @@ func (v *View[T, Tslice]) Query(ctx context.Context, exec bob.Executor, queryMod
 	return q
 }
 
-// Prepare a statement that will be mapped to the view's type
-func (v *View[T, Tslice]) Prepare(ctx context.Context, exec bob.Preparer, queryMods ...bob.Mod[*dialect.SelectQuery]) (bob.QueryStmt[T, Tslice], error) {
-	return v.PrepareQuery(ctx, exec, v.Query(ctx, nil, queryMods...))
-}
-
-// Prepare a statement from an existing query that will be mapped to the view's type
-func (v *View[T, Tslice]) PrepareQuery(ctx context.Context, exec bob.Preparer, q bob.Query) (bob.QueryStmt[T, Tslice], error) {
-	return bob.PrepareQueryx[T, Tslice](ctx, exec, q, scan.StructMapper[T](), v.afterSelect(ctx, exec))
-}
-
 func (v *View[T, Ts]) afterSelect(ctx context.Context, exec bob.Executor) bob.ExecOption[T] {
 	return func(es *bob.ExecSettings[T]) {
 		es.AfterSelect = func(ctx context.Context, retrieved []T) error {

--- a/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
@@ -6,6 +6,7 @@ var (
 {{- end}}
 
 {{define "setter_insert_mod" -}}
+{{$.Importer.Import "github.com/stephenafamo/bob"}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/im" $.Dialect)}}
 {{$table := .Table}}
 {{$tAlias := .Aliases.Table $table.Key -}}

--- a/gen/templates/models/01_types.go.tpl
+++ b/gen/templates/models/01_types.go.tpl
@@ -49,9 +49,6 @@ type {{$tAlias.UpSingular}}Slice []*{{$tAlias.UpSingular}}
 {{- end}}
 {{- end}}
 
-// {{$tAlias.UpPlural}}Stmt is a prepared statment on {{$table.Name}}
-type {{$tAlias.UpPlural}}Stmt = bob.QueryStmt[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice]
-
 {{if .Table.Relationships -}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/dialect" $.Dialect)}}
 // {{$tAlias.DownSingular}}R is where relationships are stored.

--- a/gen/templates/models/01_types.go.tpl
+++ b/gen/templates/models/01_types.go.tpl
@@ -1,6 +1,5 @@
 {{$table := .Table}}
 {{$tAlias := .Aliases.Table $table.Key -}}
-{{$.Importer.Import "github.com/stephenafamo/bob"}}
 
 // {{$tAlias.UpSingular}} is an object representing the database table.
 type {{$tAlias.UpSingular}} struct {
@@ -128,6 +127,7 @@ func (s {{$tAlias.UpSingular}}Setter) Apply(q *dialect.UpdateQuery) {
 {{- end}}
 
 {{block "setter_insert_mod" . -}}
+{{$.Importer.Import "github.com/stephenafamo/bob"}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/im" $.Dialect)}}
 {{$table := .Table}}
 {{$tAlias := .Aliases.Table $table.Key -}}
@@ -157,6 +157,7 @@ type {{$tAlias.DownSingular}}ColumnNames struct {
 }
 
 {{if $table.Relationships -}}
+{{$.Importer.Import "github.com/stephenafamo/bob"}}
 type {{$tAlias.DownSingular}}RelationshipJoins[Q dialect.Joinable] struct {
 	{{range $table.Relationships -}}
 	{{- $relAlias := $tAlias.Relationship .Name -}}

--- a/gen/templates/models/09_rel_query.go.tpl
+++ b/gen/templates/models/09_rel_query.go.tpl
@@ -1,6 +1,5 @@
 {{$table := .Table}}
 {{$tAlias := .Aliases.Table $table.Key -}}
-{{$.Importer.Import "github.com/stephenafamo/bob"}}
 {{if $table.Relationships -}}{{$.Importer.Import "github.com/stephenafamo/bob/mods"}}{{end}}
 
 {{range $rel := $table.Relationships -}}

--- a/named.go
+++ b/named.go
@@ -1,0 +1,66 @@
+package bob
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"io"
+)
+
+type RawNamedArgError struct {
+	Name string
+}
+
+func (e RawNamedArgError) Error() string {
+	return fmt.Sprintf("raw named arg %q used without rebinding", e.Name)
+}
+
+// named args should ONLY be used to prepare statements
+type namedArg string
+
+// Value implements the driver.Valuer interface.
+// it always returns an error because named args should only be used to prepare statements
+func (n namedArg) Value() (driver.Value, error) {
+	return nil, RawNamedArgError{string(n)}
+}
+
+// Named args should ONLY be used to prepare statements
+func Named(names ...string) Expression {
+	return named{names: names}
+}
+
+// NamedGroup is like Named, but wraps in parentheses
+func NamedGroup(names ...string) Expression {
+	return named{names: names}
+}
+
+type named struct {
+	names   []string
+	grouped bool
+}
+
+func (a named) WriteSQL(w io.Writer, d Dialect, start int) ([]any, error) {
+	if len(a.names) == 0 {
+		return nil, nil
+	}
+
+	args := make([]any, len(a.names))
+
+	if a.grouped {
+		w.Write([]byte("("))
+	}
+
+	for k, name := range a.names {
+		if k > 0 {
+			w.Write([]byte(", "))
+		}
+
+		d.WriteArg(w, start+k)
+		args[k] = namedArg(name)
+	}
+
+	if a.grouped {
+		w.Write([]byte(")"))
+	}
+
+	return args, nil
+}


### PR DESCRIPTION
Here is another attempt at binding named args.

Using it will look something like this:

```go
package main

import (
	"context"
	"fmt"

	"github.com/stephenafamo/bob"

	_ "github.com/jackc/pgx/v5/stdlib"
	"github.com/stephenafamo/bob/dialect/psql"
	"github.com/stephenafamo/bob/dialect/psql/sm"
)

type Args struct {
	In1 int
	In2 int
	In3 int
	Id1 int
}

func main() {
	query := psql.Select(
		sm.Columns("id", "name"),
		sm.From("users"),
		sm.Where(psql.Quote("id").In(bob.Named("in1", "in2", "in3"))),
		sm.Where(psql.Raw("id >= ?", bob.Named("id1"))),
	)

	// Use as a regular query
	{
		bound, err := bob.BindNamed[*Args](query)
		if err != nil {
			panic(err)
		}

		queryStr, args, err := bound.Bind(nil).Build()
		if err != nil {
			panic(err)
		}

		fmt.Println(queryStr)
		fmt.Println(args)
	}

	// Use in prepared statements
	{
		ctx := context.Background()
		db, err := bob.Open("pgx", "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable")

		stmt, err := bob.Prepare[Args](ctx, db, query)
		if err != nil {
			panic(err)
		}

		_ = stmt
	}
}
```

@RangelReale let me know your thougts on this design.

1. The binding process can be used on any query, not just statements.
2. For a bob prepared statement, the `bob.InTx` method can be used to get a transaction specific version.