### PR TITLE
Update One Code Example

### DIFF
--- a/website/docs/sql-executor/one.md
+++ b/website/docs/sql-executor/one.md
@@ -27,7 +27,7 @@ if err != nil {
 q := psql.Select(...)
 
 // user is of type userObj{}
-user, err := bob.Exec(ctx, db, q, scan.StructMapper[userObj]())
+user, err := bob.One(ctx, db, q, scan.StructMapper[userObj]())
 if err != nil {
     // ...
 }


### PR DESCRIPTION
Function Exec was called in code example for One. Because One takes one more argument than Exec, the Code from the documentation did not work.