### PR TITLE
Bug fixes

### DIFF
--- a/dialect/mysql/table.go
+++ b/dialect/mysql/table.go
@@ -137,6 +137,10 @@ func (t *Table[T, Tslice, Tset]) Insert(ctx context.Context, exec bob.Executor, 
 		return *new(T), err
 	}
 
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
+	}
+
 	return slice[0], nil
 }
 
@@ -245,6 +249,10 @@ func (t *Table[T, Tslice, Tset]) Upsert(ctx context.Context, exec bob.Executor, 
 	slice, err := t.UpsertMany(ctx, exec, updateOnConflict, updateCols, row)
 	if err != nil {
 		return *new(T), err
+	}
+
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
 	}
 
 	return slice[0], nil

--- a/dialect/psql/table.go
+++ b/dialect/psql/table.go
@@ -2,6 +2,7 @@ package psql
 
 import (
 	"context"
+	"database/sql"
 	"reflect"
 
 	"github.com/stephenafamo/bob"
@@ -77,6 +78,10 @@ func (t *Table[T, Tslice, Tset]) Insert(ctx context.Context, exec bob.Executor, 
 	slice, err := t.InsertMany(ctx, exec, row)
 	if err != nil {
 		return *new(T), err
+	}
+
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
 	}
 
 	return slice[0], nil
@@ -170,6 +175,10 @@ func (t *Table[T, Tslice, Tset]) Upsert(ctx context.Context, exec bob.Executor, 
 	slice, err := t.UpsertMany(ctx, exec, updateOnConflict, conflictCols, updateCols, row)
 	if err != nil {
 		return *new(T), err
+	}
+
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
 	}
 
 	return slice[0], nil

--- a/dialect/sqlite/table.go
+++ b/dialect/sqlite/table.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"reflect"
 
 	"github.com/stephenafamo/bob"
@@ -77,6 +78,10 @@ func (t *Table[T, Tslice, Tset]) Insert(ctx context.Context, exec bob.Executor, 
 	slice, err := t.InsertMany(ctx, exec, row)
 	if err != nil {
 		return *new(T), err
+	}
+
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
 	}
 
 	return slice[0], nil
@@ -169,6 +174,10 @@ func (t *Table[T, Tslice, Tset]) Upsert(ctx context.Context, exec bob.Executor, 
 	slice, err := t.UpsertMany(ctx, exec, updateOnConflict, conflictCols, updateCols, row)
 	if err != nil {
 		return *new(T), err
+	}
+
+	if len(slice) == 0 {
+		return *new(T), sql.ErrNoRows
 	}
 
 	return slice[0], nil

--- a/gen/relationships.go
+++ b/gen/relationships.go
@@ -492,8 +492,8 @@ func inferModify(side orm.RelSide, tables []drivers.Table) string {
 	t1 := drivers.GetTable(tables, side.From)
 	t2 := drivers.GetTable(tables, side.To)
 
-	isT1PK := sliceMatch(side.FromColumns, t1.Constraints.Primary.Columns)
-	isT2PK := sliceMatch(side.ToColumns, t2.Constraints.Primary.Columns)
+	isT1PK := t1.Constraints.Primary != nil && sliceMatch(side.FromColumns, t1.Constraints.Primary.Columns)
+	isT2PK := t2.Constraints.Primary != nil && sliceMatch(side.ToColumns, t2.Constraints.Primary.Columns)
 
 	switch {
 	case isT1PK && !isT2PK:

--- a/gen/templates/factory/singleton/bobfactory_enums.go.tpl
+++ b/gen/templates/factory/singleton/bobfactory_enums.go.tpl
@@ -1,4 +1,4 @@
-{{if $.Enums}}
+{{- if $.Enums}}
 {{$.Importer.Import "models" $.ModelsPackage}}
 
 type (
@@ -6,4 +6,4 @@ type (
 		{{$enum.Type}} = models.{{$enum.Type}}
 	{{end}}
 )
-{{end}}
+{{end -}}


### PR DESCRIPTION
* Fix panic when inferring `modify` for relationships with no primary key
* Skip factory enum generation if there are no enums
* Return `sql.ErrNoRows` when Insert/Upsert returns nothing