### PR TITLE
Fix mysql alias in insert statement

### DIFF
--- a/dialect/mysql/table.go
+++ b/dialect/mysql/table.go
@@ -159,7 +159,7 @@ func (t *Table[T, Tslice, Tset]) InsertMany(ctx context.Context, exec bob.Execut
 	}
 
 	q := Insert(
-		im.Into(t.NameAs(ctx), internal.FilterNonZero(t.setMapping.NonGenerated)...),
+		im.Into(t.Name(ctx), internal.FilterNonZero(t.setMapping.NonGenerated)...),
 	)
 
 	// To prevent unnecessary work, we will do this before we add the rows


### PR DESCRIPTION
MySQL cannot use aliasing when inserting, as far as I'm aware.

I get this error when running a 
```
models.Users.Insert(ctx,exec,setter)
```

```
 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AS `users`
```

The generated sql looks something like:
```
INSERT INTO `users` AS `users`  (`id`, `created_at`, `updated_at`)
VALUES ((DEFAULT), (DEFAULT), (DEFAULT))
```
Previously Bob used `t.Name`. It was changed in this commit https://github.com/stephenafamo/bob/commit/5a2c154d851c59b2220487d9c862871c4ed6fe2b

