### PR TITLE
Fix panic for generated factories. Affecting all nullable columns

### DIFF
--- a/gen/templates/factory/singleton/bobfactory_random.go.tpl
+++ b/gen/templates/factory/singleton/bobfactory_random.go.tpl
@@ -86,5 +86,9 @@ func random[T any](f *faker.Faker) T {
 // randomNull is like [Random], but for null types
 // it will often also generate a null value
 func randomNull[T any](f *faker.Faker) null.Val[T] {
+  if f == nil {
+      f = &defaultFaker
+  }
+
   return null.FromCond(random[T](f), f.BoolWithChance(50))
 }


### PR DESCRIPTION
If you have a null column, the code generated in the factories, will cause a panic:

```go 
// in models/factory/users.go

func ensureCreatableUser(m *models.UserSetter) {
	if m.Name.IsUnset() {
		m.Name = omitnull.FromNull(randomNull[string](nil))
	}
	if m.Email.IsUnset() {
		m.Email = omit.From(random[string](nil))
	}
	if m.Password.IsUnset() {
		m.Password = omit.From(random[string](nil))
// etc...
```

Since it will call `randomNull` without a faker instance it will panic.

```golang
// randomNull is like [Random], but for null types
// it will often also generate a null value
func randomNull[T any](f *faker.Faker) null.Val[T] {
	return null.FromCond(random[T](f), f.BoolWithChance(50)) // panic when f.BoolWithChance(50) is called
}

```

The code was generated with `go run github.com/stephenafamo/bob/gen/bobgen-mysql@v0.25.0`