### PR TITLE
sort relationships and imports to avoid random output

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -10,10 +10,12 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"text/template"
 
 	"github.com/stephenafamo/bob/gen/drivers"
+	"github.com/stephenafamo/bob/orm"
 	"github.com/volatiletech/strmangle"
 	"golang.org/x/mod/modfile"
 )
@@ -98,6 +100,13 @@ func Run[T any](ctx context.Context, s *State, driver drivers.Interface[T], plug
 	}
 	if err := validateRelationships(relationships); err != nil {
 		return fmt.Errorf("validating relationships: %w", err)
+	}
+
+	// Lets sort the relationships so that we can have a consistent output
+	for _, rels := range relationships {
+		slices.SortFunc(rels, func(a, b orm.Relationship) int {
+			return strings.Compare(a.Name, b.Name)
+		})
 	}
 
 	if s.Config.Aliases == nil {

--- a/gen/importers/imports.go
+++ b/gen/importers/imports.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -72,6 +73,10 @@ func (l List) GetSorted() (List, List) {
 		third = append(third, pkg)
 
 	}
+
+	// Make sure the lists are sorted, so that the output is consistent
+	sort.Sort(std)
+	sort.Sort(third)
 
 	return std, third
 }


### PR DESCRIPTION
Sort the parts of the generated code that are not the same each time you run bobgen. This way it's much easier to see if your config/db changes actually were picked up properly.