### PR TITLE
config option to disable required rels for use in factories

### DIFF
--- a/gen/templates.go
+++ b/gen/templates.go
@@ -359,7 +359,7 @@ func columnSetter(i Importer, aliases Aliases, tables []drivers.Table, fromTName
 
 func relIsRequired(t drivers.Table, r orm.Relationship) bool {
 	// The relationship is not required, if its not using foreign keys
-	if r.NoForeign {
+	if r.NeverRequired {
 		return false
 	}
 

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -358,6 +358,11 @@ func columnSetter(i Importer, aliases Aliases, tables []drivers.Table, fromTName
 }
 
 func relIsRequired(t drivers.Table, r orm.Relationship) bool {
+	// The relationship is not required, if its not using foreign keys
+	if r.NoForeign {
+		return false
+	}
+
 	firstSide := r.Sides[0]
 	if firstSide.Modify == "to" {
 		return false

--- a/orm/relationship.go
+++ b/orm/relationship.go
@@ -70,8 +70,9 @@ type Relationship struct {
 	Ignored bool
 	// Do not create the inverse of a user configured relationship
 	NoReverse bool `yaml:"no_reverse"`
-	// Makes sure the factories does not require the relationship to be set
-	NoForeign bool `yaml:"no_foreign"`
+	// Makes sure the factories does not require the relationship to be set.
+	// Useful if you're not using foreign keys
+	NeverRequired bool `yaml:"never_required"`
 }
 
 func (r Relationship) Validate() error {

--- a/orm/relationship.go
+++ b/orm/relationship.go
@@ -70,6 +70,8 @@ type Relationship struct {
 	Ignored bool
 	// Do not create the inverse of a user configured relationship
 	NoReverse bool `yaml:"no_reverse"`
+	// Makes sure the factories does not require the relationship to be set
+	NoForeign bool `yaml:"no_foreign"`
 }
 
 func (r Relationship) Validate() error {

--- a/website/docs/code-generation/configuration.md
+++ b/website/docs/code-generation/configuration.md
@@ -197,6 +197,7 @@ We can manually describe relationships in the configuration:
 relationships:
   users: # The table name
     - name: "custom_videos_relationship" # A unique identifier used to configure aliases
+      no_foreign: true # If true, the factory will not generate the relationship, even if it's not set already.
       sides:
         - from: "users" # Name of the source of the relationship
           to: "videos" # Table name of the other side of the relation

--- a/website/docs/code-generation/configuration.md
+++ b/website/docs/code-generation/configuration.md
@@ -197,7 +197,7 @@ We can manually describe relationships in the configuration:
 relationships:
   users: # The table name
     - name: "custom_videos_relationship" # A unique identifier used to configure aliases
-      never_required: true # If true, the factory will not generate the relationship, even if it's not set already.
+      never_required: true # If true, the relationship would never be assumed to be required. This means that the factory will never auto-generate related objects for it.
       sides:
         - from: "users" # Name of the source of the relationship
           to: "videos" # Table name of the other side of the relation

--- a/website/docs/code-generation/configuration.md
+++ b/website/docs/code-generation/configuration.md
@@ -197,7 +197,7 @@ We can manually describe relationships in the configuration:
 relationships:
   users: # The table name
     - name: "custom_videos_relationship" # A unique identifier used to configure aliases
-      no_foreign: true # If true, the factory will not generate the relationship, even if it's not set already.
+      never_required: true # If true, the factory will not generate the relationship, even if it's not set already.
       sides:
         - from: "users" # Name of the source of the relationship
           to: "videos" # Table name of the other side of the relation


### PR DESCRIPTION
Since we in our project don't use foreign keys, it can sometimes be annoying to work with the factories since they create relationships that hasn't been set.

This is a way to opt out of this behaviour.

It also allows to define relationships that might not always be true (for instance same id column used to reference different tables)