### PR TITLE
Add support for []byte primary key types to gen

### DIFF
--- a/gen/templates/models/07_slice_methods.go.tpl
+++ b/gen/templates/models/07_slice_methods.go.tpl
@@ -44,7 +44,13 @@ func (o {{$tAlias.UpSingular}}Slice) ReloadAll(ctx context.Context, exec bob.Exe
 		for _, new := range o2 {
 			{{range $column := $table.Constraints.Primary.Columns -}}
 			{{- $colAlias := $tAlias.Column $column -}}
+			{{- $colTyp := ($table.GetColumn $column).Type -}}
+			{{- if $colTyp | eq "[]byte" -}}
+			{{- $.Importer.Import "bytes" -}}
+			if !bytes.Equal(new.{{$colAlias}}, old.{{$colAlias}}) {
+			{{else -}}
 			if new.{{$colAlias}} != old.{{$colAlias}} {
+			{{end -}}
 				continue
 			}
 			{{end -}}


### PR DESCRIPTION
Add type check during slice method generation to support []byte primary key type (BINARY in SQL land). Currently, this causes an error because comparison between []byte values is not supported using the equals operator. Using a BINARY(16) for the primary key is common in MySQL, since there is no native uuid type.