### PR TITLE
Changed the default `shared_schema` options for the psql and atlas drivers

### DIFF
--- a/gen/bobgen-atlas/driver/atlas.go
+++ b/gen/bobgen-atlas/driver/atlas.go
@@ -119,10 +119,6 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 		return nil, err
 	}
 
-	if d.config.SharedSchema == "" {
-		d.config.SharedSchema = realm.Schemas[0].Name
-	}
-
 	d.loadEnums(realm)
 	dbinfo = &DBInfo{
 		Enums:  d.getEnums(),

--- a/gen/bobgen-psql/driver/psql.go
+++ b/gen/bobgen-psql/driver/psql.go
@@ -60,10 +60,6 @@ func New(config Config) Interface {
 		config.Schemas = pq.StringArray{"public"}
 	}
 
-	if config.SharedSchema == "" {
-		config.SharedSchema = config.Schemas[0]
-	}
-
 	if config.UUIDPkg == "" {
 		config.UUIDPkg = "gofrs"
 	}


### PR DESCRIPTION
Updated the shared schema config to not default to the first schema. Verbose is better. Currently only updated the psql and atlas drivers. Related to the conversation in #187 