### PR TITLE
Fix multi sided relationships attachment

### DIFF
--- a/gen/templates/models/11_rel_ops.go.tpl
+++ b/gen/templates/models/11_rel_ops.go.tpl
@@ -113,9 +113,9 @@
     for i := range {{$sideAlias.DownPlural}}{{$side.Position}} {
       setter := &{{$sideAlias.UpSingular}}Setter{
         {{range $map := $side.Mapped -}}
+          {{$colName := $sideAlias.Column $map.Column -}}
           {{if $rel.NeedsMany .ExtPosition -}}
             {{$sideC := $sideTable.GetColumn .Column -}}
-            {{$colName := $sideAlias.Column $map.Column -}}
             {{if .HasValue -}}
               {{if $sideC.Nullable }}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull" -}}
@@ -146,6 +146,10 @@
                 {{$colName}}: omit.From({{$colVal}}),
               {{- end}}
             {{- end}}
+          {{- else}}
+            {{$a := $.Aliases.Table .ExternalTable -}}
+            {{$colVal := printf "%s%d.%s" $a.DownSingular $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
+            {{$colName}}: omit.From({{$colVal}}), 
           {{- end}}
         {{- end}}
       }

--- a/gen/templates/models/11_rel_ops.go.tpl
+++ b/gen/templates/models/11_rel_ops.go.tpl
@@ -114,8 +114,8 @@
       setter := &{{$sideAlias.UpSingular}}Setter{
         {{range $map := $side.Mapped -}}
           {{$colName := $sideAlias.Column $map.Column -}}
+          {{$sideC := $sideTable.GetColumn .Column -}}
           {{if $rel.NeedsMany .ExtPosition -}}
-            {{$sideC := $sideTable.GetColumn .Column -}}
             {{if .HasValue -}}
               {{if $sideC.Nullable }}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull" -}}
@@ -150,7 +150,6 @@
             {{$a := $.Aliases.Table .ExternalTable -}}
             {{$t := getTable $.Tables .ExternalTable -}}
             {{$c := $t.GetColumn .ExternalColumn -}}
-            {{$sideC := $sideTable.GetColumn .Column -}}
             {{$colVal := printf "%s%d.%s" $a.DownSingular $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
             {{if and $sideC.Nullable $c.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}

--- a/gen/templates/models/11_rel_ops.go.tpl
+++ b/gen/templates/models/11_rel_ops.go.tpl
@@ -114,10 +114,13 @@
       setter := &{{$sideAlias.UpSingular}}Setter{
         {{range $map := $side.Mapped -}}
           {{$colName := $sideAlias.Column $map.Column -}}
-          {{$sideC := $sideTable.GetColumn .Column -}}
+          {{$sideColumn := $sideTable.GetColumn .Column -}}
+          {{$tableAlias := $.Aliases.Table .ExternalTable -}}
+          {{$table := getTable $.Tables .ExternalTable -}}
+          {{$column := $table.GetColumn .ExternalColumn -}}
           {{if $rel.NeedsMany .ExtPosition -}}
             {{if .HasValue -}}
-              {{if $sideC.Nullable }}
+              {{if $sideColumn.Nullable }}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull" -}}
                 {{$colName}}: omitnull.From({{index .Value 1}}),
               {{else}}
@@ -125,20 +128,17 @@
                 {{$colName}}: omit.From({{index .Value 1}}),
               {{end}}
             {{- else -}}
-              {{$a := $.Aliases.Table .ExternalTable -}}
-              {{$t := getTable $.Tables .ExternalTable -}}
-              {{$c := $t.GetColumn .ExternalColumn -}}
-              {{$colVal := printf "%s%d.%s" $a.DownSingular $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
+              {{$colVal := printf "%s%d.%s" $tableAlias.DownSingular $map.ExtPosition ($tableAlias.Column $map.ExternalColumn) -}}
               {{if $rel.NeedsMany .ExtPosition -}}
-                {{$colVal = printf "%s%d[i].%s" $a.DownPlural $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
+                {{$colVal = printf "%s%d[i].%s" $tableAlias.DownPlural $map.ExtPosition ($tableAlias.Column $map.ExternalColumn) -}}
               {{end -}}
-              {{if and $sideC.Nullable $c.Nullable -}}
+              {{if and $sideColumn.Nullable $column.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
                 {{$colName}}: omitnull.FromNull({{$colVal}}),
-              {{else if $sideC.Nullable -}}
+              {{else if $sideColumn.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
                 {{$colName}}: omitnull.From({{$colVal}}),
-              {{else if $c.Nullable -}}
+              {{else if $column.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omit"}}
                 {{$colName}}: omit.FromCond({{$colVal}}.GetOrZero(), {{$colVal}}.IsSet()),
               {{else -}}
@@ -147,17 +147,15 @@
               {{- end}}
             {{- end}}
           {{- else}}
-            {{$a := $.Aliases.Table .ExternalTable -}}
-            {{$t := getTable $.Tables .ExternalTable -}}
-            {{$c := $t.GetColumn .ExternalColumn -}}
-            {{$colVal := printf "%s%d.%s" $a.DownSingular $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
-            {{if and $sideC.Nullable $c.Nullable -}}
+
+            {{$colVal := printf "%s%d.%s" $tableAlias.DownSingular $map.ExtPosition ($tableAlias.Column $map.ExternalColumn) -}}
+            {{if and $sideColumn.Nullable $column.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
                 {{$colName}}: omitnull.FromNull({{$colVal}}),
-              {{else if $sideC.Nullable -}}
+              {{else if $sideColumn.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
                 {{$colName}}: omitnull.From({{$colVal}}),
-              {{else if $c.Nullable -}}
+              {{else if $column.Nullable -}}
                 {{$.Importer.Import "github.com/aarondl/opt/omit"}}
                 {{$colName}}: omit.FromCond({{$colVal}}.GetOrZero(), {{$colVal}}.IsSet()),
               {{else -}}

--- a/gen/templates/models/11_rel_ops.go.tpl
+++ b/gen/templates/models/11_rel_ops.go.tpl
@@ -148,8 +148,23 @@
             {{- end}}
           {{- else}}
             {{$a := $.Aliases.Table .ExternalTable -}}
+            {{$t := getTable $.Tables .ExternalTable -}}
+            {{$c := $t.GetColumn .ExternalColumn -}}
+            {{$sideC := $sideTable.GetColumn .Column -}}
             {{$colVal := printf "%s%d.%s" $a.DownSingular $map.ExtPosition ($a.Column $map.ExternalColumn) -}}
-            {{$colName}}: omit.From({{$colVal}}), 
+            {{if and $sideC.Nullable $c.Nullable -}}
+                {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
+                {{$colName}}: omitnull.FromNull({{$colVal}}),
+              {{else if $sideC.Nullable -}}
+                {{$.Importer.Import "github.com/aarondl/opt/omitnull"}}
+                {{$colName}}: omitnull.From({{$colVal}}),
+              {{else if $c.Nullable -}}
+                {{$.Importer.Import "github.com/aarondl/opt/omit"}}
+                {{$colName}}: omit.FromCond({{$colVal}}.GetOrZero(), {{$colVal}}.IsSet()),
+              {{else -}}
+                {{$.Importer.Import "github.com/aarondl/opt/omit"}}
+                {{$colName}}: omit.From({{$colVal}}),
+              {{- end}}
           {{- end}}
         {{- end}}
       }


### PR DESCRIPTION
When having a multisided relationship like this:

```yml
 users:
    - name: "users_to_teams_through_team_users"
      sides:
        - from: "users"
          to: "team_user"
          columns:
          - [id,user_id]
        - from: "team_user"
          to: "teams"
          columns:
          - [team_id,id]

```

With the following tables:
```sql
CREATE TABLE `users` (
  `id` int unsigned NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

CREATE TABLE `teams` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

CREATE TABLE `team_user` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `team_id` int unsigned NOT NULL,
  `user_id` int unsigned NOT NULL,
  PRIMARY KEY (`id`),
  KEY `team_user_team_id_user_id_index` (`team_id`,`user_id`)
) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

It produces the wrong sql for attaching `users` to `teams` and vice-versa. Notice that the `TeamID` is missing, which results in it not being attached properly.

`models/teams.go`
```golang
func attachTeamUsers0(ctx context.Context, exec bob.Executor, count int, teamUsers1 TeamUserSlice, team0 *Team, users2 UserSlice) (TeamUserSlice, error) {
	for i := range teamUsers1 {
		setter := &TeamUserSetter{
			UserID: omit.From(users2[i].ID),
		}

		err := TeamUsers.Update(ctx, exec, setter, teamUsers1[i])
		if err != nil {
			return nil, fmt.Errorf("attachTeamUsers0, update %d: %w", i, err)
		}
	}

	return teamUsers1, nil
}
```

This change makes sure the `team0` variable is used, so the output becomes the following:

```golang
func attachTeamUsers0(ctx context.Context, exec bob.Executor, count int, teamUsers1 TeamUserSlice, team0 *Team, users2 UserSlice) (TeamUserSlice, error) {
	for i := range teamUsers1 {
		setter := &TeamUserSetter{
			TeamID: omit.From(team0.ID),
			UserID: omit.From(users2[i].ID),
		}

		err := TeamUsers.Update(ctx, exec, setter, teamUsers1[i])
		if err != nil {
			return nil, fmt.Errorf("attachTeamUsers0, update %d: %w", i, err)
		}
	}

	return teamUsers1, nil
}
```

I don't know if the changes I made are optimal or (even wrong for some) however for my code base it produced the correct output.
