### PR TITLE
Add PreloadAs PreloadOption to override the join alias

### DIFF
--- a/dialect/mysql/load.go
+++ b/dialect/mysql/load.go
@@ -44,6 +44,10 @@ func PreloadWhere(f ...func(from, to string) []bob.Expression) PreloadOption {
 	return internal.PreloadWhere[*dialect.SelectQuery](f)
 }
 
+func PreloadAs(alias string) PreloadOption {
+	return internal.PreloadAs[*dialect.SelectQuery](alias)
+}
+
 func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...PreloadOption) Preloader {
 	settings := internal.NewPreloadSettings[T, Ts, *dialect.SelectQuery](cols)
 	for _, o := range opts {
@@ -64,6 +68,9 @@ func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...Preloa
 
 		for i, side := range rel.Sides {
 			alias = fmt.Sprintf("%s_%d", side.To, internal.RandInt())
+			if settings.Alias != "" {
+				alias = settings.Alias
+			}
 			on := make([]bob.Expression, 0, len(side.FromColumns)+len(side.FromWhere)+len(side.ToWhere))
 			for i, fromCol := range side.FromColumns {
 				toCol := side.ToColumns[i]

--- a/dialect/psql/load.go
+++ b/dialect/psql/load.go
@@ -44,6 +44,10 @@ func PreloadWhere(f ...func(from, to string) []bob.Expression) PreloadOption {
 	return internal.PreloadWhere[*dialect.SelectQuery](f)
 }
 
+func PreloadAs(alias string) PreloadOption {
+	return internal.PreloadAs[*dialect.SelectQuery](alias)
+}
+
 func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...PreloadOption) Preloader {
 	settings := internal.NewPreloadSettings[T, Ts, *dialect.SelectQuery](cols)
 	for _, o := range opts {
@@ -64,6 +68,9 @@ func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...Preloa
 
 		for i, side := range rel.Sides {
 			alias = fmt.Sprintf("%s_%d", side.To, internal.RandInt())
+			if settings.Alias != "" {
+				alias = settings.Alias
+			}
 			on := make([]bob.Expression, 0, len(side.FromColumns)+len(side.FromWhere)+len(side.ToWhere))
 			for i, fromCol := range side.FromColumns {
 				toCol := side.ToColumns[i]

--- a/dialect/sqlite/load.go
+++ b/dialect/sqlite/load.go
@@ -44,6 +44,10 @@ func PreloadWhere(f ...func(from, to string) []bob.Expression) PreloadOption {
 	return internal.PreloadWhere[*dialect.SelectQuery](f)
 }
 
+func PreloadAs(alias string) PreloadOption {
+	return internal.PreloadAs[*dialect.SelectQuery](alias)
+}
+
 func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...PreloadOption) Preloader {
 	settings := internal.NewPreloadSettings[T, Ts, *dialect.SelectQuery](cols)
 	for _, o := range opts {
@@ -64,6 +68,9 @@ func Preload[T any, Ts ~[]T](rel orm.Relationship, cols []string, opts ...Preloa
 
 		for i, side := range rel.Sides {
 			alias = fmt.Sprintf("%s_%d", side.To, internal.RandInt())
+			if settings.Alias != "" {
+				alias = settings.Alias
+			}
 			on := make([]bob.Expression, 0, len(side.FromColumns)+len(side.FromWhere)+len(side.ToWhere))
 			for i, fromCol := range side.FromColumns {
 				toCol := side.ToColumns[i]

--- a/internal/load.go
+++ b/internal/load.go
@@ -53,10 +53,17 @@ type PreloadSettings[Q loadable] struct {
 	SubLoaders  []Preloader[Q]
 	ExtraLoader *AfterPreloader
 	Mods        [][]preloadfilter
+	Alias       string
 }
 
 type PreloadOption[Q loadable] interface {
 	ModifyPreloadSettings(*PreloadSettings[Q])
+}
+
+type PreloadAs[Q loadable] string
+
+func (o PreloadAs[Q]) ModifyPreloadSettings(el *PreloadSettings[Q]) {
+	el.Alias = string(o)
 }
 
 type PreloadOnly[Q loadable] []string

--- a/website/docs/code-generation/relationships.md
+++ b/website/docs/code-generation/relationships.md
@@ -89,6 +89,7 @@ The mod function accepts options:
 
 1. `OnlyColumns`: In the related model, load only these columns.
 1. `ExceptColumns`: In the related model, do not load these columns.
+1. `PreloadAs`: Explicitly sets the table alias for the related model to allow using columns of the related model for the query.
 1. `Loaders`: Other loaders mods can be given as an option to the preloader to load nested relationships. This works for both other preloaders and then-loaders.
 
 ```go
@@ -98,6 +99,14 @@ jet, err := models.Jets(ctx, db,
         psql.ThenLoadPilotLicences(), // will load the pilot's licences
     ),
 ).One()
+```
+
+```go
+jets, err := models.Jets(ctx, db,
+	models.PreloadJetPilot(psql.PreloadAs("pilot")), // "LEFT JOIN "pilots" AS "pilot" ON ("jet"."pilot_id" = "pilot"."id") 
+	models.PreloadJetCoPilot(psql.PreloadAs("copilot")), // "LEFT JOIN "pilots" AS "copilot" ON ("jet"."copilot_id" = "copilot"."id") 
+	sm.OrderBy(psql.Quote("pilot", models.ColumnNames.Pilot.LastName)) // ORDER BY "pilot"."last_name" DESC 
+).All()
 ```
 
 ### ThenLoad


### PR DESCRIPTION
Adds a new `PreloadAs` PreloadOption which allows to explicitly control the alias for the auto-generated PreloadFooBar functions.