### PR TITLE
Improve count query handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   // After
   models.SelectJoins.Jets.InnerJoin.Pilots(ctx)
   ```
+  
+- Changed the `Count()` function on `Views` to clone the query instead of changing the existing one. This makes queries reusable and the `Count()` function to behave as one would expect.
+
+  ```go
+  // This now works as expected
+  query := models.Jets.Query(ctx, db, /** list of various mods **/)
+  count, err := query.Count()
+  items, err := query.All()
+  ```
 
 ### Removed
 

--- a/clause/group_by.go
+++ b/clause/group_by.go
@@ -12,6 +12,10 @@ type GroupBy struct {
 	With     string // ROLLUP | CUBE
 }
 
+func (g *GroupBy) SetGroups(groups ...any) {
+	g.Groups = groups
+}
+
 func (g *GroupBy) AppendGroup(e any) {
 	g.Groups = append(g.Groups, e)
 }
@@ -25,6 +29,13 @@ func (g *GroupBy) SetGroupByDistinct(distinct bool) {
 }
 
 func (g GroupBy) WriteSQL(w io.Writer, d bob.Dialect, start int) ([]any, error) {
+	var args []any
+
+	// don't write anything if there are no groups
+	if len(g.Groups) == 0 {
+		return args, nil
+	}
+
 	w.Write([]byte("GROUP BY "))
 	if g.Distinct {
 		w.Write([]byte("DISTINCT "))

--- a/clause/order_by.go
+++ b/clause/order_by.go
@@ -11,6 +11,10 @@ type OrderBy struct {
 	Expressions []OrderDef
 }
 
+func (o *OrderBy) SetOrderBy(orders ...OrderDef) {
+	o.Expressions = orders
+}
+
 func (o *OrderBy) AppendOrder(order OrderDef) {
 	o.Expressions = append(o.Expressions, order)
 }

--- a/clause/select.go
+++ b/clause/select.go
@@ -21,6 +21,10 @@ func (s *SelectList) SetSelect(columns ...any) {
 	s.Columns = columns
 }
 
+func (s *SelectList) SetPreloadSelect(columns ...any) {
+	s.PreloadColumns = columns
+}
+
 func (s *SelectList) AppendSelect(columns ...any) {
 	s.Columns = append(s.Columns, columns...)
 }

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -175,15 +175,36 @@ func (v *ViewQuery[T, Tslice]) Cursor() (scan.ICursor[T], error) {
 
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count() (int64, error) {
-	v.BaseQuery.Expression.SelectList.Columns = []any{"count(1)"}
 	if err := v.hook(); err != nil {
 		return 0, err
 	}
-	return bob.One(v.ctx, v.exec, v, scan.SingleColumnMapper[int64])
+	return bob.One(v.ctx, v.exec, asCountQuery(v.BaseQuery), scan.SingleColumnMapper[int64])
 }
 
 // Exists checks if there is any matching row
 func (v *ViewQuery[T, Tslice]) Exists() (bool, error) {
 	count, err := v.Count()
 	return count > 0, err
+}
+
+// asCountQuery clones and rewrites an existing query to a count query
+func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dialect.SelectQuery] {
+	// clone the original query, so it's not being modified silently
+	countQuery := query.Clone()
+	// only select the count
+	countQuery.Expression.SetSelect("count(1)")
+	// don't select any preload columns
+	countQuery.Expression.SetPreloadSelect()
+	// disable mapper mods
+	countQuery.Expression.SetMapperMods()
+	// disable loaders
+	countQuery.Expression.SetLoaders()
+	// set the limit to 1
+	countQuery.Expression.SetLimit(1)
+	// remove ordering
+	countQuery.Expression.SetOrderBy()
+	// remove group by
+	countQuery.Expression.SetGroups()
+
+	return countQuery
 }

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -219,6 +219,8 @@ func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dial
 	countQuery.Expression.SetLoaders()
 	// set the limit to 1
 	countQuery.Expression.SetLimit(1)
+	// remove ordering
+	countQuery.Expression.SetOrderBy()
 
 	return countQuery
 }

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -206,6 +206,7 @@ func (v *ViewQuery[T, Tslice]) Exists() (bool, error) {
 	return count > 0, err
 }
 
+// asCountQuery clones and rewrites an existing query to a count query
 func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dialect.SelectQuery] {
 	// clone the original query, so it's not being modified silently
 	countQuery := query.Clone()
@@ -221,6 +222,8 @@ func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dial
 	countQuery.Expression.SetLimit(1)
 	// remove ordering
 	countQuery.Expression.SetOrderBy()
+	// remove group by
+	countQuery.Expression.SetGroups()
 
 	return countQuery
 }

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -194,15 +194,36 @@ func (v *ViewQuery[T, Tslice]) Cursor() (scan.ICursor[T], error) {
 
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count() (int64, error) {
-	v.BaseQuery.Expression.SelectList.Columns = []any{"count(1)"}
 	if err := v.hook(); err != nil {
 		return 0, err
 	}
-	return bob.One(v.ctx, v.exec, v, scan.SingleColumnMapper[int64])
+	return bob.One(v.ctx, v.exec, asCountQuery(v.BaseQuery), scan.SingleColumnMapper[int64])
 }
 
 // Exists checks if there is any matching row
 func (v *ViewQuery[T, Tslice]) Exists() (bool, error) {
 	count, err := v.Count()
 	return count > 0, err
+}
+
+// asCountQuery clones and rewrites an existing query to a count query
+func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dialect.SelectQuery] {
+	// clone the original query, so it's not being modified silently
+	countQuery := query.Clone()
+	// only select the count
+	countQuery.Expression.SetSelect("count(1)")
+	// don't select any preload columns
+	countQuery.Expression.SetPreloadSelect()
+	// disable mapper mods
+	countQuery.Expression.SetMapperMods()
+	// disable loaders
+	countQuery.Expression.SetLoaders()
+	// set the limit to 1
+	countQuery.Expression.SetLimit(1)
+	// remove ordering
+	countQuery.Expression.SetOrderBy()
+	// remove group by
+	countQuery.Expression.SetGroups()
+
+	return countQuery
 }

--- a/load.go
+++ b/load.go
@@ -41,6 +41,10 @@ func (l *Load[Q]) SetLoadContext(ctx context.Context) {
 	l.loadContext = ctx
 }
 
+func (l *Load[Q]) SetMapperMods(mods ...scan.MapperMod) {
+	l.preloadMapperMods = mods
+}
+
 // GetMapperMods implements the [MapperModder] interface
 func (l *Load[Q]) GetMapperMods() []scan.MapperMod {
 	return l.preloadMapperMods
@@ -49,6 +53,11 @@ func (l *Load[Q]) GetMapperMods() []scan.MapperMod {
 // AppendMapperMod adds to the query's mapper mods
 func (l *Load[Q]) AppendMapperMod(f scan.MapperMod) {
 	l.preloadMapperMods = append(l.preloadMapperMods, f)
+}
+
+// SetLoaders sets the query's loaders
+func (l *Load[Q]) SetLoaders(loaders ...Loader) {
+	l.loadFuncs = loaders
 }
 
 // GetLoaders implements the [Loadable] interface

--- a/website/docs/models/view.md
+++ b/website/docs/models/view.md
@@ -80,3 +80,9 @@ userView.Query(ctx, db).Count()
 // Like One(), but only returns a boolean indicating if the model was found
 userView.Query(ctx, db).Exists()
 ```
+
+:::tip
+
+The `Count()` function clones the current query which can be an expensive operation.
+
+:::


### PR DESCRIPTION
The `Count()` query does not properly strip any `Preload...()` (and `ThenLoad...()`) mods from the query.

This is especially cumbersome for queries where you need to filter the count based on a related table (to-one relation) with the  auto-generated code.
You have to build 2 different queries, one with `SelectJoins` for filtering and counting and another one with `Preload...(psql.PreloadAs(...))` to again filter and get the actual results (`All()`).

The fact that `Count()` also modifies the original query makes re-using queries harder than necessary. (related discussion: https://github.com/stephenafamo/bob/discussions/177)

My initial solution was to simply modify the `Count()` method to also strip the `PreloadColumns` and `Load` fields of the base query which makes it at least possible to use it `Count()` together with `Preload...()` and `ThenLoad...()` but that still wasn't as nice.

Now I:
* added `SetPreloadSelect` to override the preload columns
* added `SetOrderBy` to override ordering
* added `SetMapperMods` to override the mapping mods
* added `SetLoaders` to override the loaders
* added `asCountQuery`
  * which clones the original query so we can freely modify it for the count query without affecting the original one
  * modified the `Count` method on `View` to pass the cloned and modified query

I guess there's an even nicer way to do it but I'm not that familiar with bob's code-base (yet) to come up with something better. :smile: 

@stephenafamo: Let me know if this is a good approach and I'll add the `asCountQuery` variations for mysql and sqlite as well.