### PR TITLE
Fix Count() with Offset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           PSQL_DRIVER_TEST_DSN: postgresql://user:pass@localhost:5432/driver_droppable?sslmode=disable
           MYSQL_DIALECT_TEST_DSN: root:pass@(localhost:3306)/dialect_droppable?tls=skip-verify&multiStatements=true
           MYSQL_DRIVER_TEST_DSN: root:pass@(localhost:3306)/driver_droppable?tls=skip-verify&multiStatements=true
-        run: go test -race -covermode atomic -coverprofile=covprofile.out -coverpkg=github.com/stephenafamo/bob/... ./...
+        run: go test -timeout 20m -race -covermode atomic -coverprofile=covprofile.out -coverpkg=github.com/stephenafamo/bob/... ./...
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fixed bug in `Count()` queries not removing the offset from the original query
+
 ## [v0.27.0] - 2024-06-05
 
 ### Added

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -205,6 +205,8 @@ func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dial
 	countQuery.Expression.SetOrderBy()
 	// remove group by
 	countQuery.Expression.SetGroups()
+	// remove offset
+	countQuery.Expression.SetOffset(0)
 
 	return countQuery
 }

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -224,6 +224,8 @@ func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dial
 	countQuery.Expression.SetOrderBy()
 	// remove group by
 	countQuery.Expression.SetGroups()
+	// remove offset
+	countQuery.Expression.SetOffset(0)
 
 	return countQuery
 }

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -224,6 +224,8 @@ func asCountQuery(query bob.BaseQuery[*dialect.SelectQuery]) bob.BaseQuery[*dial
 	countQuery.Expression.SetOrderBy()
 	// remove group by
 	countQuery.Expression.SetGroups()
+	// remove offset
+	countQuery.Expression.SetOffset(0)
 
 	return countQuery
 }


### PR DESCRIPTION
The `Count()` query wasn't removing the `OFFSET` which makes it fail for original queries with an offset.

Note: I also increased the test timeout to 20m since the default 10m are not enough (any more)