### PR TITLE
Fix incorrect database names in `bobgen-mysql` and `bobgen-sqlite` usage descriptions

### DIFF
--- a/gen/bobgen-mysql/driver/mysql.go
+++ b/gen/bobgen-mysql/driver/mysql.go
@@ -112,7 +112,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 	return dbinfo, err
 }
 
-// TableNames connects to the postgres database and
+// TableNames connects to the MySQL database and
 // retrieves all table names from the information_schema where the
 // table schema is schema. It uses a whitelist and blacklist.
 func (d *driver) TablesInfo(ctx context.Context, tableFilter drivers.Filter) (drivers.TablesInfo, error) {

--- a/gen/bobgen-mysql/main.go
+++ b/gen/bobgen-mysql/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	app := &cli.App{
 		Name:      "bobgen-mysql",
-		Usage:     "Generate models and factories from your PostgreSQL database",
+		Usage:     "Generate models and factories from your MySQL database",
 		UsageText: "bobgen-mysql [-c FILE]",
 		Version:   helpers.Version(),
 		Flags: []cli.Flag{

--- a/gen/bobgen-sqlite/main.go
+++ b/gen/bobgen-sqlite/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	app := &cli.App{
 		Name:      "bobgen-sqlite",
-		Usage:     "Generate models and factories from your PostgreSQL database",
+		Usage:     "Generate models and factories from your SQLite database",
 		UsageText: "bobgen-sqlite [-c FILE]",
 		Version:   helpers.Version(),
 		Flags: []cli.Flag{


### PR DESCRIPTION
I noticed the following small inconsistencies in the `bobgen-*` command descriptions while experimenting with factories and code generation.

**bobgen-mysql**

```sh
go run github.com/stephenafamo/bob/gen/bobgen-mysql@latest --help

NAME:
   bobgen-mysql - Generate models and factories from your **PostgreSQL** database
```

**bobgen-sqlite**

```sh
go run github.com/stephenafamo/bob/gen/bobgen-sqlite@latest --help

NAME:
   bobgen-sqlite - Generate models and factories from your **PostgreSQL** database

```

This pull request corrects them accordingly.