### PR TITLE
Load index information for MySQL, PostgreSQL, and SQLite tables

### DIFF
--- a/gen/bobgen-atlas/driver/atlas.mysql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.mysql_golden.json
@@ -83,6 +83,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_multi_keys",
@@ -138,6 +139,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -166,6 +168,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1536,6 +1539,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1586,6 +1590,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": null,
 				"foreign": null,
@@ -1609,6 +1614,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1648,6 +1654,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1720,6 +1727,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-atlas/driver/atlas.psql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.psql_golden.json
@@ -17,6 +17,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -45,6 +46,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1833,6 +1835,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1883,6 +1886,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1929,6 +1933,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -2001,6 +2006,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
@@ -61,6 +61,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_autoinckeywordtest",
@@ -116,6 +117,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_autoinctest",
@@ -188,6 +190,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_has_generated_columns",
@@ -216,6 +219,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -244,6 +248,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1504,6 +1509,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1532,6 +1538,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1571,6 +1578,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1643,6 +1651,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-mysql/driver/mysql.golden.json
+++ b/gen/bobgen-mysql/driver/mysql.golden.json
@@ -83,6 +83,34 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "one",
+					"columns": [
+						"one",
+						"two"
+					]
+				},
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "something",
+					"columns": [
+						"something",
+						"another"
+					]
+				},
+				{
+					"name": "sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "PRIMARY",
@@ -138,6 +166,14 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "PRIMARY",
@@ -164,6 +200,14 @@
 					"autoincr": true,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -1536,6 +1580,21 @@
 					"type": "string"
 				}
 			],
+			"indexes": [
+				{
+					"name": "int_one",
+					"columns": [
+						"int_one",
+						"int_two"
+					]
+				},
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "PRIMARY",
@@ -1586,6 +1645,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": null,
 				"foreign": null,
@@ -1607,6 +1667,14 @@
 					"autoincr": true,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -1646,6 +1714,21 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
+				},
+				{
+					"name": "tag_id",
+					"columns": [
+						"tag_id"
+					]
 				}
 			],
 			"constraints": {
@@ -1718,6 +1801,26 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				},
+				{
+					"name": "user_id",
+					"columns": [
+						"user_id"
+					]
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-prisma/driver/prisma.mysql_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.mysql_golden.json
@@ -17,6 +17,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -45,6 +46,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1503,6 +1505,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1553,6 +1556,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1599,6 +1603,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1671,6 +1676,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-prisma/driver/prisma.psql_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.psql_golden.json
@@ -17,6 +17,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -45,6 +46,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1503,6 +1505,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1553,6 +1556,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1599,6 +1603,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1671,6 +1676,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-prisma/driver/prisma.sqlite_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.sqlite_golden.json
@@ -17,6 +17,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -45,6 +46,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1503,6 +1505,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1553,6 +1556,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1599,6 +1603,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1671,6 +1676,7 @@
 					"type": "int"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -17,6 +17,14 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sponsors_pkey",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "sponsors_pkey",
@@ -43,6 +51,14 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "tags_pkey",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -1833,6 +1849,14 @@
 					"type": "string"
 				}
 			],
+			"indexes": [
+				{
+					"name": "type_monsters_pkey",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "type_monsters_pkey",
@@ -1849,6 +1873,7 @@
 			"schema": "",
 			"name": "type_monsters_mv",
 			"columns": null,
+			"indexes": null,
 			"constraints": {
 				"primary": null,
 				"foreign": null,
@@ -3632,6 +3657,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": null,
 				"foreign": null,
@@ -3677,6 +3703,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": null,
 			"constraints": {
 				"primary": null,
 				"foreign": null,
@@ -3753,6 +3780,26 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "users_party_id_key",
+					"columns": [
+						"party_id"
+					]
+				},
+				{
+					"name": "users_pkey",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "users_primary_email_key",
+					"columns": [
+						"primary_email"
+					]
 				}
 			],
 			"constraints": {
@@ -3838,6 +3885,15 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "video_tags_pkey",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "video_tags_pkey",
@@ -3908,6 +3964,20 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "videos_pkey",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "videos_sponsor_id_key",
+					"columns": [
+						"sponsor_id"
+					]
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-sqlite/driver/sqlite.golden.json
+++ b/gen/bobgen-sqlite/driver/sqlite.golden.json
@@ -61,6 +61,21 @@
 					"type": "string"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_autoinckeywordtest_1",
+					"columns": [
+						"sponsor_id"
+					]
+				},
+				{
+					"name": "sqlite_autoindex_autoinckeywordtest_2",
+					"columns": [
+						"something",
+						"another"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_main_autoinckeywordtest",
@@ -116,6 +131,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": {
 					"name": "pk_main_autoinctest",
@@ -199,6 +215,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": {
 					"name": "pk_main_has_generated_columns",
@@ -271,6 +288,7 @@
 					"type": "string"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": {
 					"name": "pk_one_as_generated_columns",
@@ -310,6 +328,21 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_autoinckeywordtest_1",
+					"columns": [
+						"sponsor_id"
+					]
+				},
+				{
+					"name": "sqlite_autoindex_autoinckeywordtest_2",
+					"columns": [
+						"something",
+						"another"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_one_autoinckeywordtest",
@@ -338,6 +371,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": {
 					"name": "pk_one_autoinctest",
@@ -366,6 +400,14 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_sponsors_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_one_sponsors",
@@ -392,6 +434,14 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_tags_1",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -444,6 +494,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": null,
 				"foreign": [],
@@ -465,6 +516,14 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_users_1",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -504,6 +563,15 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_video_tags_1",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
 				}
 			],
 			"constraints": {
@@ -578,6 +646,20 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_videos_1",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "sqlite_autoindex_videos_2",
+					"columns": [
+						"sponsor_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_one_videos",
@@ -634,6 +716,14 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_sponsors_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_main_sponsors",
@@ -660,6 +750,14 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_tags_1",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -1922,6 +2020,14 @@
 					"type": "string"
 				}
 			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_type_monsters_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_main_type_monsters",
@@ -1972,6 +2078,7 @@
 					"type": "int32"
 				}
 			],
+			"indexes": [],
 			"constraints": {
 				"primary": null,
 				"foreign": [],
@@ -1993,6 +2100,14 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_users_1",
+					"columns": [
+						"id"
+					]
 				}
 			],
 			"constraints": {
@@ -2032,6 +2147,15 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_video_tags_1",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
 				}
 			],
 			"constraints": {
@@ -2104,6 +2228,20 @@
 					"autoincr": false,
 					"domain_name": "",
 					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_videos_1",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "sqlite_autoindex_videos_2",
+					"columns": [
+						"sponsor_id"
+					]
 				}
 			],
 			"constraints": {

--- a/gen/drivers/constraints.go
+++ b/gen/drivers/constraints.go
@@ -9,8 +9,10 @@ type DBConstraints struct {
 // PrimaryKey represents a primary key constraint in a database
 type PrimaryKey = Constraint
 
-// Constraint represents a primary key constraint in a database
-type Constraint struct {
+// Constraint represents a constraint in a database
+type Constraint NamedColumnList
+
+type NamedColumnList struct {
 	Name    string   `yaml:"name" json:"name"`
 	Columns []string `yaml:"columns" json:"columns"`
 }

--- a/gen/drivers/indexes.go
+++ b/gen/drivers/indexes.go
@@ -1,0 +1,7 @@
+package drivers
+
+// DBIndexes lists all indexes in the database schema keyed by table name
+type DBIndexes map[string][]Index
+
+// Index represents an index in a table
+type Index NamedColumnList

--- a/gen/drivers/interface.go
+++ b/gen/drivers/interface.go
@@ -87,6 +87,9 @@ type Constructor interface {
 	// Load all constraints in the database, keyed by TableInfo.Key
 	Constraints(context.Context, ColumnFilter) (DBConstraints, error)
 
+	// Load all indexes in the database, keyed by TableInfo.Key
+	Indexes(ctx context.Context) (DBIndexes, error)
+
 	// Load basic info about all tables
 	TablesInfo(context.Context, Filter) (TablesInfo, error)
 	// Load details about a single table
@@ -125,6 +128,14 @@ func BuildDBInfo(ctx context.Context, c Constructor, concurrency int, only, exce
 		ret[i].Constraints.Primary = constraints.PKs[t.Key]
 		ret[i].Constraints.Foreign = constraints.FKs[t.Key]
 		ret[i].Constraints.Uniques = constraints.Uniques[t.Key]
+	}
+
+	indexes, err := c.Indexes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load indexes: %w", err)
+	}
+	for i, t := range ret {
+		ret[i].Indexes = indexes[t.Key]
 	}
 
 	return ret, nil

--- a/gen/drivers/table.go
+++ b/gen/drivers/table.go
@@ -12,6 +12,7 @@ type Table struct {
 	Schema  string   `yaml:"schema" json:"schema"`
 	Name    string   `yaml:"name" json:"name"`
 	Columns []Column `yaml:"columns" json:"columns"`
+	Indexes []Index  `yaml:"indexes" json:"indexes"`
 
 	Constraints Constraints `yaml:"constraints" json:"constraints"`
 }


### PR DESCRIPTION
Hi, I am opening this in relation to https://github.com/stephenafamo/bob/issues/120.

This will allow users like @majiaxin110 to range over `.Table.Indexes` in their custom `*.tpl` enabling the use of `$index.Name` variables in a similar fashion:

```
{{$table := .Table}}
{{$tAlias := .Aliases.Table $table.Key -}}
{{range $index := .Table.Indexes}}
func print_index_{{$tAlias.DownSingular}}_{{$index.Name}}() {
    fmt.Println("{{$index.Name}}")
}
{{end}}
```

Sample output:

```go
func print_index_jet_idx_jets_names() {
	fmt.Println("idx_jets_names")
}

func print_index_jet_idx_jets_pilots() {
	fmt.Println("idx_jets_pilots")
}

func print_index_jet_PRIMARY() {
	fmt.Println("PRIMARY")
}
```

I only added MySQL support to keep the PR focused and get some early feedback on the implementation. If you approve of it, I'd happily add support for PostgreSQL and SQLite as well.