### PR TITLE
Load index information from Atlas schema files

### DIFF
--- a/gen/bobgen-atlas/driver/atlas.go
+++ b/gen/bobgen-atlas/driver/atlas.go
@@ -174,6 +174,7 @@ func (d *driver) tables(realm *schema.Realm) []drivers.Table {
 					Foreign: fks,
 				},
 				Columns: d.tableColumns(atlasTable, colFilter),
+				Indexes: d.indexes(atlasTable, colFilter),
 			}
 			tables = append(tables, table)
 		}
@@ -539,4 +540,76 @@ func (p *driver) getEnums() []drivers.Enum {
 	})
 
 	return enums
+}
+
+func (d *driver) indexes(table *schema.Table, colFilter drivers.ColumnFilter) []drivers.Index {
+	var indexes []drivers.Index //nolint:prealloc
+
+	filter := colFilter[d.key(table.Schema.Name, table.Name)]
+	only := filter.Only
+	except := filter.Except
+
+	if table.PrimaryKey != nil && len(table.PrimaryKey.Parts) > 0 {
+		var pkName string
+		var shouldSkip bool
+
+		cols := make([]string, len(table.PrimaryKey.Parts))
+		for i, part := range table.PrimaryKey.Parts {
+			if part.X != nil || drivers.Skip(part.C.Name, only, except) {
+				shouldSkip = true
+			}
+			cols[i] = part.C.Name
+		}
+		pkName = d.makePkName(table)
+
+		if !shouldSkip && pkName != "" {
+			indexes = append(indexes, drivers.Index{
+				Name:    pkName,
+				Columns: cols,
+			})
+		}
+	}
+
+	for _, index := range table.Indexes {
+		shouldSkip := false
+		cols := make([]string, len(index.Parts))
+		for i, part := range index.Parts {
+			if part.X != nil || drivers.Skip(part.C.Name, only, except) {
+				shouldSkip = true
+			}
+			cols[i] = part.C.Name
+		}
+		if shouldSkip {
+			continue
+		}
+		indexes = append(indexes, drivers.Index{
+			Name:    index.Name,
+			Columns: cols,
+		})
+	}
+
+	return indexes
+}
+
+func (d *driver) makePkName(table *schema.Table) string {
+	if table.PrimaryKey.Name != "" {
+		return table.PrimaryKey.Name
+	}
+	switch d.Dialect() {
+	case "psql":
+		return table.Name + "_pkey"
+	case "mysql":
+		return "PRIMARY"
+	case "sqlite":
+		isCompositePrimaryKey := len(table.PrimaryKey.Parts) > 1
+		isIntegerColumnType := false
+		typ, ok := table.PrimaryKey.Parts[0].C.Type.Type.(*schema.IntegerType)
+		if ok {
+			isIntegerColumnType = typ.T == "integer"
+		}
+		if isCompositePrimaryKey || !isIntegerColumnType {
+			return "sqlite_autoindex_" + table.Name + "_1"
+		}
+	}
+	return ""
 }

--- a/gen/bobgen-atlas/driver/atlas.mysql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.mysql_golden.json
@@ -83,7 +83,34 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "one",
+					"columns": [
+						"one",
+						"two"
+					]
+				},
+				{
+					"name": "something",
+					"columns": [
+						"something",
+						"another"
+					]
+				},
+				{
+					"name": "sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_multi_keys",
@@ -139,7 +166,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -168,7 +202,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1539,7 +1580,21 @@
 					"type": "string"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "int_one",
+					"columns": [
+						"int_one",
+						"int_two"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1614,7 +1669,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1654,7 +1716,21 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
+				},
+				{
+					"name": "tag_id",
+					"columns": [
+						"tag_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1727,7 +1803,26 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "PRIMARY",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				},
+				{
+					"name": "user_id",
+					"columns": [
+						"user_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-atlas/driver/atlas.psql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.psql_golden.json
@@ -17,7 +17,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sponsors_pkey",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -46,7 +53,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "tags_pkey",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1835,7 +1849,14 @@
 					"type": "string"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "type_monsters_pkey",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1886,7 +1907,20 @@
 					"type": "string"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "users_pkey",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "users_primary_email_key",
+					"columns": [
+						"primary_email"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1933,7 +1967,15 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "video_tags_pkey",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -2006,7 +2048,20 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "videos_pkey",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "videos_sponsor_id_key",
+					"columns": [
+						"sponsor_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",

--- a/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
@@ -61,7 +61,21 @@
 					"type": "string"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "autoinckeywordtest_sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				},
+				{
+					"name": "autoinckeywordtest_something_another",
+					"columns": [
+						"something",
+						"another"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_autoinckeywordtest",
@@ -85,13 +99,13 @@
 				],
 				"uniques": [
 					{
-						"name": "sqlite_autoindex_autoinckeywordtest_1",
+						"name": "autoinckeywordtest_sponsor_id",
 						"columns": [
 							"sponsor_id"
 						]
 					},
 					{
-						"name": "sqlite_autoindex_autoinckeywordtest_2",
+						"name": "autoinckeywordtest_something_another",
 						"columns": [
 							"something",
 							"another"
@@ -219,7 +233,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_sponsors_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_sponsors",
@@ -248,7 +269,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_tags_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_tags",
@@ -1509,7 +1537,14 @@
 					"type": "string"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_type_monsters_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_type_monsters",
@@ -1538,7 +1573,14 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_users_1",
+					"columns": [
+						"id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_users",
@@ -1578,7 +1620,15 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_video_tags_1",
+					"columns": [
+						"video_id",
+						"tag_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_video_tags",
@@ -1651,7 +1701,20 @@
 					"type": "int32"
 				}
 			],
-			"indexes": null,
+			"indexes": [
+				{
+					"name": "sqlite_autoindex_videos_1",
+					"columns": [
+						"id"
+					]
+				},
+				{
+					"name": "videos_sponsor_id",
+					"columns": [
+						"sponsor_id"
+					]
+				}
+			],
 			"constraints": {
 				"primary": {
 					"name": "pk_videos",
@@ -1683,7 +1746,7 @@
 				],
 				"uniques": [
 					{
-						"name": "sqlite_autoindex_videos_2",
+						"name": "videos_sponsor_id",
 						"columns": [
 							"sponsor_id"
 						]

--- a/gen/bobgen-atlas/driver/test_schema/mysql/schema.hcl
+++ b/gen/bobgen-atlas/driver/test_schema/mysql/schema.hcl
@@ -353,12 +353,12 @@ table "type_monsters" {
   column "bytea_seven" {
     null    = false
     type    = binary(1)
-    default = "0x"
+    default = sql("0x0")
   }
   column "bytea_eight" {
     null    = false
     type    = binary(1)
-    default = "0x"
+    default = sql("0x0")
   }
   column "time_zero" {
     null = true

--- a/gen/bobgen-atlas/driver/test_schema/psql/schema.hcl
+++ b/gen/bobgen-atlas/driver/test_schema/psql/schema.hcl
@@ -820,5 +820,17 @@ enum "workday" {
   schema = schema.public
   values = ["monday", "tuesday", "wednesday", "thursday", "friday"]
 }
+domain "uint3" {
+  schema = schema.public
+  type   = smallint
+  check "uint3_check" {
+    expr = "(VALUE >= 0 AND VALUE <= 7)"
+  }
+}
+
+domain "my_int_array" {
+  schema = schema.public
+  type   = sql("integer[]")
+}
 schema "public" {
 }

--- a/gen/bobgen-atlas/driver/test_schema/sqlite/schema.hcl
+++ b/gen/bobgen-atlas/driver/test_schema/sqlite/schema.hcl
@@ -47,7 +47,7 @@ table "videos" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  index "sqlite_autoindex_videos_2" {
+  index "videos_sponsor_id" {
     unique  = true
     columns = [column.sponsor_id]
   }
@@ -298,44 +298,44 @@ table "type_monsters" {
   }
   column "bytea_zero" {
     null = true
-    type = sql("binary")
+    type = clob
   }
   column "bytea_one" {
     null = true
-    type = sql("binary")
+    type = clob
   }
   column "bytea_two" {
     null = false
-    type = sql("binary")
+    type = clob
   }
   column "bytea_three" {
     null    = false
-    type    = sql("binary")
+    type    = clob
     default = "a"
   }
   column "bytea_four" {
     null    = true
-    type    = sql("binary")
+    type    = clob
     default = "b"
   }
   column "bytea_five" {
     null    = false
-    type    = sql("binary")
+    type    = clob
     default = "abcdefghabcdefghabcdefgh"
   }
   column "bytea_six" {
     null    = true
-    type    = sql("binary")
+    type    = clob
     default = "hgfedcbahgfedcbahgfedcba"
   }
   column "bytea_seven" {
     null    = false
-    type    = sql("binary")
+    type    = clob
     default = ""
   }
   column "bytea_eight" {
     null    = false
-    type    = sql("binary")
+    type    = clob
     default = ""
   }
   column "time_zero" {
@@ -506,27 +506,27 @@ table "type_monsters" {
   }
   column "binary_null" {
     null = true
-    type = sql("binary")
+    type = clob
   }
   column "binary_nnull" {
     null = false
-    type = sql("binary")
+    type = clob
   }
   column "varbinary_null" {
     null = true
-    type = sql("varbinary")
+    type = clob
   }
   column "varbinary_nnull" {
     null = false
-    type = sql("varbinary")
+    type = clob
   }
   column "tinyblob_null" {
     null = true
-    type = sql("tinyblob")
+    type = clob
   }
   column "tinyblob_nnull" {
     null = false
-    type = sql("tinyblob")
+    type = clob
   }
   column "blob_null" {
     null = true
@@ -538,19 +538,19 @@ table "type_monsters" {
   }
   column "mediumblob_null" {
     null = true
-    type = sql("mediumblob")
+    type = clob
   }
   column "mediumblob_nnull" {
     null = false
-    type = sql("mediumblob")
+    type = clob
   }
   column "longblob_null" {
     null = true
-    type = sql("longblob")
+    type = clob
   }
   column "longblob_nnull" {
     null = false
-    type = sql("longblob")
+    type = clob
   }
   column "varchar_null" {
     null = true
@@ -620,11 +620,11 @@ table "autoinckeywordtest" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  index "sqlite_autoindex_autoinckeywordtest_1" {
+  index "autoinckeywordtest_sponsor_id" {
     unique  = true
     columns = [column.sponsor_id]
   }
-  index "sqlite_autoindex_autoinckeywordtest_2" {
+  index "autoinckeywordtest_something_another" {
     unique  = true
     columns = [column.something, column.another]
   }


### PR DESCRIPTION
Continuing what I started in #237, this PR adds proper support for loading index information from Atlas schema files.

I wanted to do the Atlas and Prisma driver modifications together, but the Atlas implementation took a bit longer than I anticipated.

I had to update the original `schema.hcl` files, as they had some small issues preventing the `atlas` CLI from executing them against real MySQL, PostgreSQL, and SQLite databases (now it works).

All questions and comments are welcome.