### PR TITLE
Respect character_maximum_length when generating random values for string columns

### DIFF
--- a/gen/drivers/column.go
+++ b/gen/drivers/column.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"strings"
 
+	"github.com/aarondl/opt/null"
 	"github.com/volatiletech/strmangle"
 )
 
@@ -20,6 +21,8 @@ type Column struct {
 	// DomainName is the domain type name associated to the column. See here:
 	// https://www.postgresql.org/docs/16/extend-type-system.html
 	DomainName string `json:"domain_name" yaml:"domain_name" toml:"domain_name"`
+
+	CharMaxLen null.Val[int] `json:"char_max_len" yaml:"char_max_len" toml:"char_max_len"`
 
 	Type string `json:"type" yaml:"type" toml:"type"`
 }

--- a/gen/templates/factory/03_create.go.tpl
+++ b/gen/templates/factory/03_create.go.tpl
@@ -8,14 +8,20 @@
 
 func ensureCreatable{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingular}}Setter) {
 	{{range $column := $table.Columns -}}
-  {{- if $column.Default}}{{continue}}{{end -}}
-  {{- if $column.Nullable}}{{continue}}{{end -}}
+	{{- if $column.Default}}{{continue}}{{end -}}
+	{{- if $column.Nullable}}{{continue}}{{end -}}
 	{{- if $column.Generated}}{{continue}}{{end -}}
 	{{- $colAlias := $tAlias.Column $column.Name -}}
-  {{- $typDef :=  index $.Types $column.Type -}}
-  {{- $colTyp := or $typDef.AliasOf $column.Type -}}
-		if m.{{$colAlias}}.IsUnset() {
-        m.{{$colAlias}} = omit.From(random_{{normalizeType $column.Type}}(nil))
+	{{- $typDef :=  index $.Types $column.Type -}}
+	{{- $colTyp := or $typDef.AliasOf $column.Type -}}
+	{{- $wrapStart := "" -}}
+	{{- $wrapEnd := "" -}}
+	{{- if $column.CharMaxLen.IsSet -}}
+		{{- $wrapStart = "truncateString(" -}}
+		{{- $wrapEnd = printf `,%d )` $column.CharMaxLen.GetOrZero -}}
+	{{- end -}}
+	if m.{{$colAlias}}.IsUnset() {
+		m.{{$colAlias}} = omit.From({{$wrapStart}}random_{{normalizeType $column.Type}}(nil){{$wrapEnd}})
     }
 	{{end -}}
 }

--- a/gen/templates/factory/11_column_mods.go.tpl
+++ b/gen/templates/factory/11_column_mods.go.tpl
@@ -24,6 +24,13 @@ func (m {{$tAlias.DownSingular}}Mods) RandomizeAllColumns(f *faker.Faker) {{$tAl
 	{{- $colTyp = printf "null.Val[%s]" $colTyp -}}
 {{- end -}}
 
+{{- $wrapStart := "" -}}
+{{- $wrapEnd := "" -}}
+{{- if $column.CharMaxLen.IsSet -}}
+	{{- $wrapStart = "truncateString(" -}}
+	{{- $wrapEnd = printf `,%d )` $column.CharMaxLen.GetOrZero -}}
+{{- end -}}
+
 // Set the model columns to this value
 func (m {{$tAlias.DownSingular}}Mods) {{$colAlias}}(val {{$colTyp}}) {{$tAlias.UpSingular}}Mod {
 	return {{$tAlias.UpSingular}}ModFunc(func(o *{{$tAlias.UpSingular}}Template) {
@@ -59,9 +66,9 @@ func (m {{$tAlias.DownSingular}}Mods) Random{{$colAlias}}(f *faker.Faker) {{$tAl
           return null.FromPtr[{{or $typDef.AliasOf $column.Type}}](nil)
         }
 
-        return null.From(random_{{normalizeType $column.Type}}(f))
+        return null.From({{$wrapStart}}random_{{normalizeType $column.Type}}(f){{$wrapEnd}})
 			{{- else -}}
-				return random_{{normalizeType $column.Type}}(f)
+				return {{$wrapStart}}random_{{normalizeType $column.Type}}(f){{$wrapEnd}}
 			{{- end}}
 		}
 	})

--- a/gen/templates/factory/singleton/bobfactory_random.go.tpl
+++ b/gen/templates/factory/singleton/bobfactory_random.go.tpl
@@ -3,10 +3,12 @@
 
 var defaultFaker = faker.New()
 
+{{$hasCharMaxLen := false}}
 {{$doneTypes := dict }}
 {{- range $table := .Tables}}
 {{- $tAlias := $.Aliases.Table $table.Key}}
   {{range $column := $table.Columns -}}
+      {{- if $column.CharMaxLen -}}{{- $hasCharMaxLen = true -}}{{- end -}}
       {{- $colTyp := $column.Type -}}
       {{- if hasKey $doneTypes $column.Type}}{{continue}}{{end -}}
       {{- $_ :=  set $doneTypes $column.Type nil -}}
@@ -34,3 +36,12 @@ var defaultFaker = faker.New()
       {{$typDef.RandomExpr}}
     }
 {{end -}}
+
+{{- if $hasCharMaxLen -}}
+func truncateString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+{{- end -}}


### PR DESCRIPTION
Hi, I'm opening this PR to propose a new feature that addresses an issue I ran into while trying out the ORM generators.

Consider the following PostgreSQL schema:

```sql
CREATE TABLE pilots (
    id serial PRIMARY KEY,
    name varchar(5) NOT NULL
);

CREATE TABLE jets (
  id serial PRIMARY KEY,
  pilot_id int NOT NULL,
  first_name varchar(7) NOT NULL,
  last_name varchar(8) NOT NULL,
  FOREIGN KEY (pilot_id) REFERENCES pilots(id)
);

CREATE INDEX idx_jets_pilots ON jets (pilot_id);
CREATE INDEX idx_jets_names ON jets (first_name, last_name);
```

Or, alternatively, the following MySQL schema:

```sql
CREATE TABLE pilots (
    id int unsigned NOT NULL,
    name varchar(5) NOT NULL,
    primary key (id)
);

CREATE TABLE jets (
  id int unsigned NOT NULL,
  pilot_id int unsigned NOT NULL,
  first_name varchar(7) NOT NULL,
  last_name varchar(8) NOT NULL,
  primary key (id)
);

CREATE INDEX idx_jets_pilots ON jets (pilot_id);
CREATE INDEX idx_jets_names ON jets (first_name, last_name);
ALTER TABLE jets ADD CONSTRAINT fkey_pilots_1 FOREIGN KEY(pilot_id) REFERENCES pilots(id);
```

Then try using the following code against either the MySQL or the PostgreSQL schema:

```go
func main() {
	f := factory.New()
	f.AddBasePilotMod(
		factory.PilotMods.RandomID(nil),
		factory.PilotMods.RandomName(nil)
	)
	p := f.NewJet()

	ctx := context.Background()
	//ex, err := bob.Open("mysql", "test:test@/test?parseTime=true")
	ex, err := bob.Open("postgres", "postgres://postgres:test@localhost/postgres?sslmode=disable")
	if err != nil {
		log.Fatal(err)
	}
	_, err = p.CreateMany(ctx, ex, 5)
	if err != nil {
		log.Fatal(err)
	}
}
```

Bob fails with similar errors:

PostgreSQL:
> 2024/06/24 17:12:02 pq: value too long for type character varying(5)

MySQL:
> 2024/06/24 17:14:14 Error 1406 (22001): Data too long for column 'name' at row 1

That's because the random generator doesn't respect the specified `character_maximum_length` for the string columns. This PR changes this, and the random generators start producing strings truncated to the maximum possible length for each specified column. I hope that other Bob users will find this feature convenient too.

If you require any changes, just let me know :slightly_smiling_face: 