### PR TITLE
Handle `null` column names in expression indexes

### DIFF
--- a/gen/bobgen-atlas/driver/atlas.mysql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.mysql_golden.json
@@ -88,27 +88,31 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "one",
 					"columns": [
 						"one",
 						"two"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "something",
 					"columns": [
 						"something",
 						"another"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -171,7 +175,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -207,7 +212,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1585,14 +1591,16 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "int_one",
 					"columns": [
 						"int_one",
 						"int_two"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1674,7 +1682,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1722,13 +1731,15 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "tag_id",
 					"columns": [
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1808,19 +1819,22 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "user_id",
 					"columns": [
 						"user_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-atlas/driver/atlas.psql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.psql_golden.json
@@ -22,7 +22,8 @@
 					"name": "sponsors_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -58,7 +59,8 @@
 					"name": "tags_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1854,7 +1856,8 @@
 					"name": "type_monsters_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1912,13 +1915,15 @@
 					"name": "users_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "users_primary_email_key",
 					"columns": [
 						"primary_email"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1973,7 +1978,8 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -2053,13 +2059,15 @@
 					"name": "videos_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "videos_sponsor_id_key",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
@@ -66,14 +66,16 @@
 					"name": "autoinckeywordtest_sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "autoinckeywordtest_something_another",
 					"columns": [
 						"something",
 						"another"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -238,7 +240,8 @@
 					"name": "sqlite_autoindex_sponsors_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -274,7 +277,8 @@
 					"name": "sqlite_autoindex_tags_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1542,7 +1546,8 @@
 					"name": "sqlite_autoindex_type_monsters_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1578,7 +1583,8 @@
 					"name": "sqlite_autoindex_users_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1626,7 +1632,8 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1706,13 +1713,15 @@
 					"name": "sqlite_autoindex_videos_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "videos_sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-mysql/driver/mysql.golden.json
+++ b/gen/bobgen-mysql/driver/mysql.golden.json
@@ -89,26 +89,30 @@
 					"columns": [
 						"one",
 						"two"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "something",
 					"columns": [
 						"something",
 						"another"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -171,7 +175,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -207,7 +212,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -217,6 +223,100 @@
 						"id"
 					]
 				},
+				"foreign": null,
+				"uniques": null
+			}
+		},
+		{
+			"key": "test_index_expressions",
+			"schema": "",
+			"name": "test_index_expressions",
+			"columns": [
+				{
+					"name": "col1",
+					"db_type": "int",
+					"default": "",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col2",
+					"db_type": "int",
+					"default": "",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col3",
+					"db_type": "int",
+					"default": "",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "idx1",
+					"columns": null,
+					"expressions": [
+						"(`col1` + `col2`)"
+					]
+				},
+				{
+					"name": "idx2",
+					"columns": [
+						"col3"
+					],
+					"expressions": [
+						"(`col1` + `col2`)"
+					]
+				},
+				{
+					"name": "idx3",
+					"columns": [
+						"col1"
+					],
+					"expressions": [
+						"(`col2` + `col3`)"
+					]
+				},
+				{
+					"name": "idx4",
+					"columns": [
+						"col3"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx5",
+					"columns": [
+						"col1",
+						"col2"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx6",
+					"columns": null,
+					"expressions": [
+						"pow(`col3`,2)"
+					]
+				}
+			],
+			"constraints": {
+				"primary": null,
 				"foreign": null,
 				"uniques": null
 			}
@@ -1586,13 +1686,15 @@
 					"columns": [
 						"int_one",
 						"int_two"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1674,7 +1776,8 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1722,13 +1825,15 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "tag_id",
 					"columns": [
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -1808,19 +1913,22 @@
 					"name": "PRIMARY",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sponsor_id",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "user_id",
 					"columns": [
 						"user_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -22,7 +22,8 @@
 					"name": "sponsors_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -58,7 +59,8 @@
 					"name": "tags_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -68,6 +70,100 @@
 						"id"
 					]
 				},
+				"foreign": null,
+				"uniques": null
+			}
+		},
+		{
+			"key": "test_index_expressions",
+			"schema": "",
+			"name": "test_index_expressions",
+			"columns": [
+				{
+					"name": "col1",
+					"db_type": "integer",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col2",
+					"db_type": "integer",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col3",
+					"db_type": "integer",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "idx1",
+					"columns": null,
+					"expressions": [
+						"(col1 + col2)"
+					]
+				},
+				{
+					"name": "idx2",
+					"columns": [
+						"col3"
+					],
+					"expressions": [
+						"(col1 + col2)"
+					]
+				},
+				{
+					"name": "idx3",
+					"columns": [
+						"col1"
+					],
+					"expressions": [
+						"(col2 + col3)"
+					]
+				},
+				{
+					"name": "idx4",
+					"columns": [
+						"col3"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx5",
+					"columns": [
+						"col1",
+						"col2"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx6",
+					"columns": null,
+					"expressions": [
+						"pow(col3::double precision, 2::double precision)"
+					]
+				}
+			],
+			"constraints": {
+				"primary": null,
 				"foreign": null,
 				"uniques": null
 			}
@@ -1854,7 +1950,8 @@
 					"name": "type_monsters_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -3787,19 +3884,22 @@
 					"name": "users_party_id_key",
 					"columns": [
 						"party_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "users_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "users_primary_email_key",
 					"columns": [
 						"primary_email"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -3891,7 +3991,8 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -3971,13 +4072,15 @@
 					"name": "videos_pkey",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "videos_sponsor_id_key",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/bobgen-sqlite/driver/sqlite.go
+++ b/gen/bobgen-sqlite/driver/sqlite.go
@@ -594,7 +594,7 @@ func (d *driver) indexes(ctx context.Context, schema, tableName string) ([]drive
 
 	indexes := make([]drivers.Index, len(indexNames))
 	for i, indexName := range indexNames {
-		indexes[i], err = d.getIndexWithColumns(ctx, schema, indexName)
+		indexes[i], err = d.getIndexInformation(ctx, schema, tableName, indexName)
 		if err != nil {
 			return nil, err
 		}
@@ -603,8 +603,9 @@ func (d *driver) indexes(ctx context.Context, schema, tableName string) ([]drive
 	return indexes, nil
 }
 
-func (d *driver) getIndexWithColumns(ctx context.Context, schema, indexName string) (drivers.Index, error) {
-	index := drivers.Index{Name: indexName}
+func (d *driver) getIndexInformation(ctx context.Context, schema, tableName, indexName string) (drivers.Index, error) {
+	var index drivers.Index
+	index.Name = indexName
 
 	//nolint:gosec
 	query := fmt.Sprintf("SELECT name FROM '%s'.pragma_index_info('%s') ORDER BY seqno ASC", schema, indexName)
@@ -614,13 +615,25 @@ func (d *driver) getIndexWithColumns(ctx context.Context, schema, indexName stri
 	}
 	defer rows.Close()
 
-	for rows.Next() {
-		var name string
+	exprCols := make(map[int]struct{})
+	for seqno := 0; rows.Next(); seqno++ {
+		var name null.Val[string]
 		err = rows.Scan(&name)
 		if err != nil {
 			return index, err
 		}
-		index.Columns = append(index.Columns, name)
+		if name.IsSet() {
+			index.Columns = append(index.Columns, name.GetOrZero())
+		} else {
+			exprCols[seqno] = struct{}{}
+		}
+	}
+
+	if len(exprCols) > 0 {
+		index.Expressions, err = d.extractIndexExpressions(ctx, schema, tableName, indexName, exprCols)
+		if err != nil {
+			return index, err
+		}
 	}
 
 	if err = rows.Err(); err != nil {
@@ -628,4 +641,75 @@ func (d *driver) getIndexWithColumns(ctx context.Context, schema, indexName stri
 	}
 
 	return index, nil
+}
+
+func (d driver) extractIndexExpressions(ctx context.Context, schema, tableName, indexName string, exprCols map[int]struct{}) ([]string, error) {
+	var ddl string
+	var expressions []string //nolint:prealloc
+	//nolint:gosec
+	query := fmt.Sprintf("SELECT sql FROM '%s'.sqlite_master WHERE type = 'index' AND name = ? AND tbl_name = ?", schema)
+	result := d.conn.QueryRowContext(ctx, query, indexName, tableName)
+	err := result.Scan(&ddl)
+	if err != nil {
+		return expressions, fmt.Errorf("failed retrieving index DDL statement: %w", err)
+	}
+	// We're following the parsing logic from the `intckParseCreateIndex` function in the SQLite source code.
+	// 1. https://github.com/sqlite/sqlite/blob/1d8cde9d56d153767e98595c4b015221864ef0e7/ext/intck/sqlite3intck.c#L363
+	// 2. https://www.sqlite.org/lang_createindex.html
+
+	// skip forward until the first "(" token
+	i := strings.Index(ddl, "(")
+	if i == -1 {
+		return expressions, fmt.Errorf("failed locating first column: %w", err)
+	}
+	ddl = ddl[i+1:]
+	// discard the WHERE clause fragment (if one exists)
+	i = strings.LastIndex(ddl, ")")
+	if i == -1 {
+		return expressions, fmt.Errorf("failed locating last column: %w", err)
+	}
+	ddl = ddl[:i]
+	// organize column definitions into a list
+	colDefs := d.splitColumnDefinitions(ddl)
+
+	for seqno, expression := range colDefs {
+		if _, ok := exprCols[seqno]; !ok {
+			// this index column references a regular column rather than an expression, so we skip the extraction.
+			continue
+		}
+		expressions = append(expressions, strings.TrimSpace(expression))
+	}
+
+	return expressions, nil
+}
+
+// splitColumnDefinitions performs an intelligent split of the DDL part defining the index columns.
+//
+// We cannot perform a simple `strings.Split(ddl, ",")` as `ddl` could contain functional expressions, i.e.:
+//
+//	sql  := CREATE INDEX idx ON test (col1, (col2 + col3), (POW(col3, 2)));
+//	ddl  := "col1, (col2 + col3), (POW(col3, 2))"
+//	defs := []string{"col1", "(col2 + col3)", "(POW(col3, 2))"}
+func (d driver) splitColumnDefinitions(ddl string) []string {
+	var defs []string
+	var i, pOpen int
+
+	for j := 0; j < len(ddl); j++ {
+		if ddl[j] == '(' {
+			pOpen++
+		}
+		if ddl[j] == ')' {
+			pOpen--
+		}
+		if pOpen == 0 && ddl[j] == ',' {
+			defs = append(defs, ddl[i:j])
+			i = j + 1
+		}
+	}
+
+	if i < len(ddl) {
+		defs = append(defs, ddl[i:])
+	}
+
+	return defs
 }

--- a/gen/bobgen-sqlite/driver/sqlite.golden.json
+++ b/gen/bobgen-sqlite/driver/sqlite.golden.json
@@ -66,14 +66,16 @@
 					"name": "sqlite_autoindex_autoinckeywordtest_1",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sqlite_autoindex_autoinckeywordtest_2",
 					"columns": [
 						"something",
 						"another"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -333,14 +335,16 @@
 					"name": "sqlite_autoindex_autoinckeywordtest_1",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sqlite_autoindex_autoinckeywordtest_2",
 					"columns": [
 						"something",
 						"another"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -405,7 +409,8 @@
 					"name": "sqlite_autoindex_sponsors_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -441,7 +446,8 @@
 					"name": "sqlite_autoindex_tags_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -523,7 +529,8 @@
 					"name": "sqlite_autoindex_users_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -571,7 +578,8 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -651,13 +659,15 @@
 					"name": "sqlite_autoindex_videos_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sqlite_autoindex_videos_2",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -721,7 +731,8 @@
 					"name": "sqlite_autoindex_sponsors_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -757,7 +768,8 @@
 					"name": "sqlite_autoindex_tags_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -767,6 +779,100 @@
 						"id"
 					]
 				},
+				"foreign": [],
+				"uniques": []
+			}
+		},
+		{
+			"key": "test_index_expressions",
+			"schema": "",
+			"name": "test_index_expressions",
+			"columns": [
+				{
+					"name": "col1",
+					"db_type": "INT",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col2",
+					"db_type": "INT",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				},
+				{
+					"name": "col3",
+					"db_type": "INT",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"generated": false,
+					"autoincr": false,
+					"domain_name": "",
+					"type": "int32"
+				}
+			],
+			"indexes": [
+				{
+					"name": "idx1",
+					"columns": null,
+					"expressions": [
+						"(col1 + col2)"
+					]
+				},
+				{
+					"name": "idx2",
+					"columns": [
+						"col3"
+					],
+					"expressions": [
+						"(col1 + col2)"
+					]
+				},
+				{
+					"name": "idx3",
+					"columns": [
+						"col1"
+					],
+					"expressions": [
+						"(col2 + col3)"
+					]
+				},
+				{
+					"name": "idx4",
+					"columns": [
+						"col3"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx5",
+					"columns": [
+						"col1",
+						"col2"
+					],
+					"expressions": null
+				},
+				{
+					"name": "idx6",
+					"columns": null,
+					"expressions": [
+						"POW(col3, 2)"
+					]
+				}
+			],
+			"constraints": {
+				"primary": null,
 				"foreign": [],
 				"uniques": []
 			}
@@ -2025,7 +2131,8 @@
 					"name": "sqlite_autoindex_type_monsters_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -2107,7 +2214,8 @@
 					"name": "sqlite_autoindex_users_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -2155,7 +2263,8 @@
 					"columns": [
 						"video_id",
 						"tag_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {
@@ -2235,13 +2344,15 @@
 					"name": "sqlite_autoindex_videos_1",
 					"columns": [
 						"id"
-					]
+					],
+					"expressions": null
 				},
 				{
 					"name": "sqlite_autoindex_videos_2",
 					"columns": [
 						"sponsor_id"
-					]
+					],
+					"expressions": null
 				}
 			],
 			"constraints": {

--- a/gen/drivers/indexes.go
+++ b/gen/drivers/indexes.go
@@ -4,4 +4,8 @@ package drivers
 type DBIndexes map[string][]Index
 
 // Index represents an index in a table
-type Index NamedColumnList
+type Index struct {
+	Name        string   `yaml:"name" json:"name"`
+	Columns     []string `yaml:"columns" json:"columns"`
+	Expressions []string `yaml:"expressions" json:"expressions"`
+}

--- a/test/files/mysql/schema.sql
+++ b/test/files/mysql/schema.sql
@@ -205,3 +205,15 @@ CREATE TABLE multi_keys (
     UNIQUE(something, another),
     FOREIGN KEY (one, two) REFERENCES type_monsters(int_one, int_two)
 );
+
+CREATE TABLE test_index_expressions (
+    col1 int,
+    col2 int,
+    col3 int
+);
+CREATE INDEX idx1 ON test_index_expressions ((col1 + col2));
+CREATE INDEX idx2 ON test_index_expressions ((col1 + col2), col3);
+CREATE INDEX idx3 ON test_index_expressions (col1, (col2 + col3));
+CREATE INDEX idx4 ON test_index_expressions (col3);
+CREATE INDEX idx5 ON test_index_expressions (col1 DESC, col2 DESC);
+CREATE INDEX idx6 ON test_index_expressions ((POW(col3, 2)));

--- a/test/files/psql/schema.sql
+++ b/test/files/psql/schema.sql
@@ -273,3 +273,15 @@ inner join videos v on v.user_id = u.id;
 
 create view type_monsters_v as select * from type_monsters; 
 create materialized view type_monsters_mv as select * from type_monsters_v;
+
+CREATE TABLE test_index_expressions (
+    col1 int,
+    col2 int,
+    col3 int
+);
+CREATE INDEX idx1 ON test_index_expressions ((col1 + col2));
+CREATE INDEX idx2 ON test_index_expressions ((col1 + col2), col3);
+CREATE INDEX idx3 ON test_index_expressions (col1, (col2 + col3));
+CREATE INDEX idx4 ON test_index_expressions (col3);
+CREATE INDEX idx5 ON test_index_expressions (col1 DESC, col2 DESC);
+CREATE INDEX idx6 ON test_index_expressions (POW(col3, 2));

--- a/test/files/sqlite/schema.sql
+++ b/test/files/sqlite/schema.sql
@@ -252,3 +252,14 @@ create table one.as_generated_columns (
    e TEXT GENERATED ALWAYS AS (substr(c,b,b+1)) STORED
 );
 
+CREATE TABLE test_index_expressions (
+    col1 int,
+    col2 int,
+    col3 int
+);
+CREATE INDEX idx1 ON test_index_expressions ((col1 + col2));
+CREATE INDEX idx2 ON test_index_expressions ((col1 + col2), col3);
+CREATE INDEX idx3 ON test_index_expressions (col1, (col2 + col3));
+CREATE INDEX idx4 ON test_index_expressions (col3);
+CREATE INDEX idx5 ON test_index_expressions (col1 DESC, col2 DESC);
+CREATE INDEX idx6 ON test_index_expressions (POW(col3, 2));


### PR DESCRIPTION
This provides a fix to #244.

DDL for testing:

```sql
CREATE TABLE t1 (
  col1 int,
  col2 int,
  col3 int
);

CREATE INDEX idx1 ON t1 ((col1 + col2));
CREATE INDEX idx2 ON t1 ((col1 + col2), col3);
CREATE INDEX idx3 ON t1 (col3);
```

Before the patch, generation failed with the following error:

1. MySQL:

    > 2024/06/27 11:49:12 unable to fetch table data: unable to load indexes: sql: Scan error on column index 2, name "column_name": converting NULL to string is unsupported

2. SQLite:
    > 2024/06/27 11:51:14 unable to fetch table data: sql: Scan error on column index 0, name "name": converting NULL to string is unsupported


After the patch, generation completes successfully with the following information being collected:

![image](https://github.com/stephenafamo/bob/assets/785542/fd2e66c6-dff6-4ec2-9644-8584a9346252)

---

Please note that PostgreSQL was not affected by this issue, as it uses the expression as a `column_name` rather than omitting it:

![image](https://github.com/stephenafamo/bob/assets/785542/ea3f306c-e74d-43ae-8fd8-c564c87f91da)

---

@stephenafamo would you prefer to use the expression contents as a `column_name` for SQLite and MySQL as well, rather than omitting them? I checked two different database GUIs. The first one used the expression contents as a `column_name`, and the others one omitted the expression from the column listing.