### PR TITLE
Export custom unique constraint error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added custom error types to generated models for checking unique constraint errors.
+
 ### Fixed
 
 - Remove unnecessary import of `strings` in `bobfactory_random.go`.
+- Prevent data races in unit tests.
 
 ## [v0.28.1] - 2024-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added custom error types to generated models for checking unique constraint errors.
+- Added error constants for matching against both specific and generic unique constraint errors raised by the underlying database driver.
 
 ### Fixed
 
-- Remove unnecessary import of `strings` in `bobfactory_random.go`.
-- Prevent data races in unit tests.
+- Removed unnecessary import of `strings` in `bobfactory_random.go`.
+- Fixed data races in unit tests.
 
 ## [v0.28.1] - 2024-06-28
 

--- a/gen/bobgen-atlas/driver/atlas.mysql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.mysql_golden.json
@@ -1899,5 +1899,6 @@
 			]
 		}
 	],
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": ""
 }

--- a/gen/bobgen-atlas/driver/atlas.psql_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.psql_golden.json
@@ -2122,5 +2122,6 @@
 			]
 		}
 	],
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": ""
 }

--- a/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
+++ b/gen/bobgen-atlas/driver/atlas.sqlite_golden.json
@@ -1765,5 +1765,6 @@
 		}
 	],
 	"enums": [],
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": ""
 }

--- a/gen/bobgen-mysql/driver/mysql.go
+++ b/gen/bobgen-mysql/driver/mysql.go
@@ -98,7 +98,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 	}
 	defer d.conn.Close()
 
-	dbinfo = &DBInfo{}
+	dbinfo = &DBInfo{DriverName: "github.com/go-sql-driver/mysql"}
 
 	dbinfo.Tables, err = drivers.BuildDBInfo(ctx, d, d.config.Concurrency, d.config.Only, d.config.Except)
 	if err != nil {

--- a/gen/bobgen-mysql/driver/mysql.golden.json
+++ b/gen/bobgen-mysql/driver/mysql.golden.json
@@ -1993,5 +1993,6 @@
 			]
 		}
 	],
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": "github.com/go-sql-driver/mysql"
 }

--- a/gen/bobgen-mysql/templates/models/singleton/bob_mysql_blocks.go.tpl
+++ b/gen/bobgen-mysql/templates/models/singleton/bob_mysql_blocks.go.tpl
@@ -6,3 +6,15 @@ var (
 	DeleteWhere = Where[*dialect.DeleteQuery]()
 )
 {{- end -}}
+
+{{define "unique_constraint_error_detection_method"}}
+{{$.Importer.Import "strings"}}
+{{$.Importer.Import "mysqlDriver" "github.com/go-sql-driver/mysql"}}
+func (e *errUniqueConstraint) Is(target error) bool {
+  err, ok := target.(*mysqlDriver.MySQLError)
+  if !ok {
+    return false
+  }
+  return err.Number == 1062 && strings.Contains(err.Message, e.s)
+}
+{{end}}

--- a/gen/bobgen-prisma/driver/prisma.mysql_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.mysql_golden.json
@@ -1736,5 +1736,6 @@
 			"DriverSource": "",
 			"DriverENVSource": ""
 		}
-	}
+	},
+	"driver_name": ""
 }

--- a/gen/bobgen-prisma/driver/prisma.psql_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.psql_golden.json
@@ -1736,5 +1736,6 @@
 			"DriverSource": "",
 			"DriverENVSource": ""
 		}
-	}
+	},
+	"driver_name": ""
 }

--- a/gen/bobgen-prisma/driver/prisma.sqlite_golden.json
+++ b/gen/bobgen-prisma/driver/prisma.sqlite_golden.json
@@ -1736,5 +1736,6 @@
 			"DriverSource": "",
 			"DriverENVSource": ""
 		}
-	}
+	},
+	"driver_name": ""
 }

--- a/gen/bobgen-psql/driver/psql.go
+++ b/gen/bobgen-psql/driver/psql.go
@@ -47,6 +47,8 @@ type Config struct {
 	Concurrency int
 	// Which UUID package to use (gofrs or google)
 	UUIDPkg string `yaml:"uuid_pkg"`
+	// Which `database/sql` driver to use (the full module name)
+	DriverName string `yaml:"driver_name"`
 
 	//-------
 
@@ -69,6 +71,10 @@ func New(config Config) Interface {
 
 	if config.UUIDPkg == "" {
 		config.UUIDPkg = "gofrs"
+	}
+
+	if config.DriverName == "" {
+		config.DriverName = "github.com/lib/pq"
 	}
 
 	if config.Concurrency < 1 {
@@ -132,7 +138,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 	}
 	defer d.conn.Close()
 
-	dbinfo = &DBInfo{}
+	dbinfo = &DBInfo{DriverName: d.config.DriverName}
 
 	// drivers.Tables call translateColumnType which uses Enums
 	if err := d.loadEnums(ctx); err != nil {

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -4135,5 +4135,6 @@
 			]
 		}
 	],
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": "github.com/lib/pq"
 }

--- a/gen/bobgen-psql/main.go
+++ b/gen/bobgen-psql/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io/fs"
 	"log"
 	"os"
 	"os/signal"
@@ -49,7 +50,10 @@ func run(c *cli.Context) error {
 	}
 
 	d := driver.New(driverConfig)
-	outputs := helpers.DefaultOutputs(driverConfig.Output, driverConfig.Pkgname, config.NoFactory, nil)
+	outputs := helpers.DefaultOutputs(
+		driverConfig.Output, driverConfig.Pkgname, config.NoFactory,
+		&helpers.Templates{Models: []fs.FS{gen.PSQLModelTemplates}},
+	)
 
 	state := &gen.State{
 		Config:  config,

--- a/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
+++ b/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
@@ -25,7 +25,7 @@ func (e *errUniqueConstraint) Is(target error) bool {
 	if !ok {
 		return false
 	}
-	return err.Code == "23505" && err.{{$constraintNameField}} == e.s
+	return err.Code == "23505" && (e.s == "" || err.{{$constraintNameField}} == e.s)
 	{{end}}
 }
 {{end}}

--- a/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
+++ b/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
@@ -1,0 +1,31 @@
+{{define "unique_constraint_error_detection_method"}}
+func (e *errUniqueConstraint) Is(target error) bool {
+	{{$supportedDrivers := list "github.com/lib/pq" "github.com/jackc/pgx" "github.com/jackc/pgx/v4" "github.com/jackc/pgx/v5"}}
+	{{if not (has $.DriverName $supportedDrivers)}}
+	return false
+	{{else}}
+		{{$errType := ""}}
+		{{$constraintNameField := "ConstraintName"}}
+		{{if eq $.DriverName "github.com/jackc/pgx/v4" "github.com/jackc/pgx/v5"}}
+			{{$errType = "*pgconn.PgError"}}
+			{{if eq $.DriverName "github.com/jackc/pgx/v4" }}
+				{{$.Importer.Import "github.com/jackc/pgconn"}}
+			{{else}}
+				{{$.Importer.Import "github.com/jackc/pgx/v5/pgconn"}}
+			{{end}}
+		{{else}}
+			{{$.Importer.Import $.DriverName}}
+			{{$errType = "pgx.PgError"}}
+			{{if eq $.DriverName "github.com/lib/pq" }}
+				{{$errType = "*pq.Error"}}
+				{{$constraintNameField = "Constraint"}}
+			{{end}}
+		{{end}}
+	err, ok := target.({{$errType}})
+	if !ok {
+		return false
+	}
+	return err.Code == "23505" && err.{{$constraintNameField}} == e.s
+	{{end}}
+}
+{{end}}

--- a/gen/bobgen-sqlite/driver/sqlite.golden.json
+++ b/gen/bobgen-sqlite/driver/sqlite.golden.json
@@ -2396,5 +2396,6 @@
 		}
 	],
 	"enums": null,
-	"extra_info": null
+	"extra_info": null,
+	"driver_name": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
@@ -23,3 +23,28 @@ func (s {{$tAlias.UpSingular}}Setter) InsertMod() bob.Mod[*dialect.InsertQuery] 
 }
 {{- end}}
 
+{{define "unique_constraint_error_detection_method"}}
+func (e *errUniqueConstraint) Is(target error) bool {
+	{{if not (eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3")}}
+	return false
+	{{else}}
+		{{$errType := ""}}
+		{{$codeGetter := ""}}
+		{{$.Importer.Import "strings"}}
+		{{if eq $.DriverName "modernc.org/sqlite"}}
+			{{$.Importer.Import "sqliteDriver" $.DriverName}}
+			{{$errType = "*sqliteDriver.Error"}}
+			{{$codeGetter = "Code()"}}
+		{{else}}
+			{{$.Importer.Import $.DriverName}}
+			{{$errType = "sqlite3.Error"}}
+			{{$codeGetter = "ExtendedCode"}}
+		{{end}}
+	err, ok := target.({{$errType}})
+	if !ok {
+		return false
+	}
+	return err.{{$codeGetter}} == 2067 && strings.Contains(err.Error(), e.s)
+	{{end}}
+}
+{{end}}

--- a/gen/drivers/interface.go
+++ b/gen/drivers/interface.go
@@ -61,6 +61,8 @@ type DBInfo[T any] struct {
 	Tables    []Table `json:"tables"`
 	Enums     []Enum  `json:"enums"`
 	ExtraInfo T       `json:"extra_info"`
+	// DriverName is the module name of the underlying `database/sql` driver
+	DriverName string `json:"driver_name"`
 }
 
 type Enum struct {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -158,6 +158,8 @@ func Run[T any](ctx context.Context, s *State, driver drivers.Interface[T], plug
 
 func generate[T any](s *State, data *TemplateData[T], goVersion string) error {
 	knownKeys := make(map[string]struct{})
+	templateByteBuffer := &bytes.Buffer{}
+	templateHeaderByteBuffer := &bytes.Buffer{}
 
 	for _, o := range s.Outputs {
 		if len(o.Templates) == 0 {
@@ -192,6 +194,10 @@ func generate[T any](s *State, data *TemplateData[T], goVersion string) error {
 		if err != nil {
 			return fmt.Errorf("unable to initialize the output folders: %w", err)
 		}
+
+		// assign reusable scratch buffers to provided Output
+		o.templateByteBuffer = templateByteBuffer
+		o.templateHeaderByteBuffer = templateHeaderByteBuffer
 
 		if err := generateSingletonOutput(o, data, goVersion); err != nil {
 			return fmt.Errorf("singleton template output: %w", err)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -125,6 +125,7 @@ func Run[T any](ctx context.Context, s *State, driver drivers.Interface[T], plug
 		Aliases:           s.Config.Aliases,
 		Types:             types,
 		Relationships:     relationships,
+		NoFactory:         s.Config.NoFactory,
 		NoTests:           s.Config.NoTests,
 		NoBackReferencing: s.Config.NoBackReferencing,
 		StructTagCasing:   s.Config.StructTagCasing,
@@ -132,6 +133,7 @@ func Run[T any](ctx context.Context, s *State, driver drivers.Interface[T], plug
 		Tags:              s.Config.Tags,
 		RelationTag:       s.Config.RelationTag,
 		ModelsPackage:     modPkg,
+		DriverName:        dbInfo.DriverName,
 	}
 
 	for _, v := range s.Config.TagIgnore {

--- a/gen/output.go
+++ b/gen/output.go
@@ -275,6 +275,9 @@ func executeTemplates[T any](e executeTemplateData[T], goVersion string) error {
 				if len(dir) != 0 {
 					pkgName = filepath.Base(dir)
 				}
+				if e.isTest {
+					pkgName = fmt.Sprintf("%s_test", pkgName)
+				}
 				version = goVersion
 				writeFileDisclaimer(headerOut)
 				writePackageName(headerOut, pkgName)

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -23,19 +23,23 @@ var templates embed.FS
 //go:embed bobgen-mysql/templates
 var mysqlTemplates embed.FS
 
-//go:embed bobgen-sqlite/templates
-var sqliteTemplates embed.FS
-
 //go:embed bobgen-prisma/templates
 var prismaTemplates embed.FS
+
+//go:embed bobgen-psql/templates
+var psqlTemplates embed.FS
+
+//go:embed bobgen-sqlite/templates
+var sqliteTemplates embed.FS
 
 //nolint:gochecknoglobals
 var (
 	ModelTemplates, _       = fs.Sub(templates, "templates/models")
 	FactoryTemplates, _     = fs.Sub(templates, "templates/factory")
 	MySQLModelTemplates, _  = fs.Sub(mysqlTemplates, "bobgen-mysql/templates/models")
-	SQLiteModelTemplates, _ = fs.Sub(sqliteTemplates, "bobgen-sqlite/templates/models")
 	PrismaModelTemplates, _ = fs.Sub(prismaTemplates, "bobgen-prisma/templates/models")
+	PSQLModelTemplates, _   = fs.Sub(psqlTemplates, "bobgen-psql/templates/models")
+	SQLiteModelTemplates, _ = fs.Sub(sqliteTemplates, "bobgen-sqlite/templates/models")
 	typesReplacer           = strings.NewReplacer(
 		" ", "_",
 		".", "_",
@@ -97,6 +101,7 @@ type TemplateData[T any] struct {
 	AddSoftDeletes    bool
 	AddEnumTypes      bool
 	EnumNullPrefix    string
+	NoFactory         bool
 	NoTests           bool
 	NoBackReferencing bool
 
@@ -112,6 +117,9 @@ type TemplateData[T any] struct {
 	// Supplied by the driver
 	ExtraInfo     T
 	ModelsPackage string
+
+	// DriverName is the module name of the underlying `database/sql` driver
+	DriverName string
 }
 
 func (t *TemplateData[T]) ResetImports() {

--- a/gen/templates/models/01_types.go.tpl
+++ b/gen/templates/models/01_types.go.tpl
@@ -270,3 +270,21 @@ func build{{$tAlias.UpSingular}}Joins[Q dialect.Joinable](cols {{$tAlias.DownSin
 	}
 }
 {{- end}}
+
+{{ if $table.Constraints.Uniques }}
+var {{$tAlias.UpSingular}}Errors = &{{$tAlias.DownSingular}}Errors{
+	{{range $constraint := $table.Constraints.Uniques}}
+	{{ $s := $constraint.Name }}
+	{{ if eq "sqlite" $.Dialect }}
+	{{ $s = printf "%s.%s" $table.Name (join (printf ", %s." $table.Name) $constraint.Columns) }}
+	{{ end }}
+	ErrUnique{{join "_and_" $constraint.Columns | camelcase}}: &errUniqueConstraint{s: "{{$s}}"},
+	{{end}}
+}
+
+type {{$tAlias.DownSingular}}Errors struct {
+	{{range $constraint := $table.Constraints.Uniques}}
+	ErrUnique{{join "_and_" $constraint.Columns | camelcase}} error
+	{{ end }}
+}
+{{ end }}

--- a/gen/templates/models/01_types_test.go.tpl
+++ b/gen/templates/models/01_types_test.go.tpl
@@ -1,0 +1,99 @@
+{{$table := .Table}}
+{{if and $table.Constraints.Uniques (not $.NoFactory)}}
+{{$tAlias := .Aliases.Table $table.Key}}
+{{$factoryPackage := printf "%s/factory" $.ModelsPackage }}
+{{$.Importer.Import "factory" $factoryPackage }}
+{{$.Importer.Import "models" $.ModelsPackage}}
+{{$.Importer.Import "context"}}
+{{$.Importer.Import "database/sql"}}
+{{$.Importer.Import "errors"}}
+{{$.Importer.Import "os"}}
+{{$.Importer.Import "testing"}}
+{{$.Importer.Import "github.com/stephenafamo/bob"}}
+
+{{ $sqlDriverName := "" }}
+{{ $dsnEnvVarName := "" }}
+{{ if eq $.DriverName "github.com/go-sql-driver/mysql" }}
+	{{$.Importer.Import "_" $.DriverName }}
+	{{$sqlDriverName = "mysql"}}
+	{{$dsnEnvVarName = "MYSQL_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/lib/pq" }}
+	{{$.Importer.Import "_" $.DriverName }}
+	{{$sqlDriverName = "postgres"}}
+	{{$dsnEnvVarName = "PSQL_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/jackc/pgx" }}
+	{{$.Importer.Import "_" (printf "%s/stdlib" $.DriverName) }}
+	{{$sqlDriverName = "pgx"}}
+	{{$dsnEnvVarName = "PSQL_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/jackc/pgx/v4" }}
+	{{$.Importer.Import "_" (printf "%s/stdlib" $.DriverName) }}
+	{{$sqlDriverName = "pgx"}}
+	{{$dsnEnvVarName = "PSQL_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/jackc/pgx/v5" }}
+	{{$.Importer.Import "_" (printf "%s/stdlib" $.DriverName) }}
+	{{$sqlDriverName = "pgx"}}
+	{{$dsnEnvVarName = "PSQL_TEST_DSN"}}
+{{ else if eq $.DriverName "modernc.org/sqlite" }}
+	{{$.Importer.Import "_" $.DriverName }}
+	{{$sqlDriverName = "sqlite"}}
+	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
+{{ else if eq $.DriverName  "github.com/mattn/go-sqlite3" }}
+	{{$.Importer.Import "_" $.DriverName }}
+	{{$sqlDriverName = "sqlite3"}}
+	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
+{{ end }}
+
+func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
+	db, err := sql.Open("{{$sqlDriverName}}", os.Getenv("{{$dsnEnvVarName}}"))
+	if err != nil {
+		t.Fatal("Error connecting to database")
+	}
+	tests := []struct{
+		name        string
+		expectedErr error
+		applyFn     func(tpl *factory.{{$tAlias.UpSingular}}Template, obj *models.{{$tAlias.UpSingular}})
+	}{
+	{{range $constraint := $table.Constraints.Uniques}}
+		{{- $errName := printf "ErrUnique%s" (join "_and_" $constraint.Columns | camelcase) -}}
+		{
+			name: "{{$errName}}",
+			expectedErr: models.{{$tAlias.UpSingular}}Errors.{{$errName}},
+			applyFn: func(tpl *factory.{{$tAlias.UpSingular}}Template, obj *models.{{$tAlias.UpSingular}}) {
+				tpl.Apply(
+					factory.{{$tAlias.UpSingular}}Mods.RandomizeAllColumns(nil),
+					{{range $columnName := $constraint.Columns}}
+					{{- $colAlias := $tAlias.Column $columnName -}}
+					factory.{{$tAlias.UpSingular}}Mods.{{$colAlias}}(obj.{{$colAlias}}),
+					{{end}}
+				)
+			},
+		},
+	{{end}}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tx, err := db.Begin()
+			if err != nil {
+				t.Fatal("Couldn't start database transaction")
+			}
+			exec := bob.New(tx)
+			f := factory.New()
+			tpl := f.New{{$tAlias.UpSingular}}()
+			obj, err := tpl.Create(ctx, exec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.applyFn(tpl, obj)
+			_, err = models.{{$tAlias.UpPlural}}.Insert(ctx, exec, tpl.BuildSetter())
+			if !errors.Is(tt.expectedErr, err) {
+				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
+			}
+			if err = tx.Rollback(); err != nil {
+				t.Fatal("Couldn't rollback database transaction")
+			}
+		})
+	}
+}
+{{end}}

--- a/gen/templates/models/01_types_test.go.tpl
+++ b/gen/templates/models/01_types_test.go.tpl
@@ -87,6 +87,9 @@ func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
 			}
 			tt.applyFn(tpl, obj)
 			_, err = models.{{$tAlias.UpPlural}}.Insert(ctx, exec, tpl.BuildSetter())
+			if !errors.Is(models.ErrUniqueConstraint, err) {
+				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
+			}
 			if !errors.Is(tt.expectedErr, err) {
 				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
 			}

--- a/gen/templates/models/singleton/bob_main.go.tpl
+++ b/gen/templates/models/singleton/bob_main.go.tpl
@@ -130,3 +130,18 @@ func randInt() int64 {
 
 	return out % 10000
 }
+
+type errUniqueConstraint struct {
+	// s is a string uniquely identifying the constraint in the raw error message returned from the database.
+	s string
+}
+
+func (e *errUniqueConstraint) Error() string {
+  return e.s
+}
+
+{{block "unique_constraint_error_detection_method" . -}}
+func (e *errUniqueConstraint) Is(target error) bool {
+  return false
+}
+{{end}}

--- a/gen/templates/models/singleton/bob_main.go.tpl
+++ b/gen/templates/models/singleton/bob_main.go.tpl
@@ -131,6 +131,9 @@ func randInt() int64 {
 	return out % 10000
 }
 
+// ErrUniqueConstraint captures all unique constraint errors by explicitly leaving `s` empty.
+var ErrUniqueConstraint = &errUniqueConstraint{s: ""}
+
 type errUniqueConstraint struct {
 	// s is a string uniquely identifying the constraint in the raw error message returned from the database.
 	s string

--- a/website/docs/code-generation/usage.md
+++ b/website/docs/code-generation/usage.md
@@ -184,7 +184,7 @@ CREATE TABLE pilots (
 );
 ```
 
-Bob will define the following `struct`:
+Bob will define the following `struct` inside the generated `pilots.go` file:
 
 ```go
 type pilotErrors struct {
@@ -192,12 +192,21 @@ type pilotErrors struct {
 }
 ```
 
-After that, the `struct` is initialized and exported through a `PilotErrors` variable, which can be used for error matching in the following way:
+The `struct` is initialized and exported through a `PilotErrors` variable, which can be used for error matching in the following way:
 
 ```go
 pilot, err := models.Pilots.Insert(ctx, db, setter)
 if errors.Is(models.PilotErrors.ErrUniqueFirstNameAndLastName, err) {
-    log.Fatal(err)
+    // handle the error
+}
+```
+
+Bob furthermore defines a generic `ErrUniqueConstraint` constant, which can be used for matching and handling all unique constraint errors:
+
+```go
+pilot, err := models.Pilots.Insert(ctx, db, setter)
+if errors.Is(models.ErrUniqueConstraint, err) {
+    // handle the error
 }
 ```
 

--- a/website/docs/code-generation/usage.md
+++ b/website/docs/code-generation/usage.md
@@ -70,7 +70,7 @@ var JetsTable = psql.NewTablex[*Jet, JetSlice, *JetSetter]("", "jets")
 
 :::tip
 
-**JetsTable** gives the full range of capabilites of a Bob model, including
+**JetsTable** gives the full range of capabilities of a Bob model, including
 
 - Flexible queries: One, All, Cursor, Count, Exists
 - Expressions for names and column lists
@@ -167,6 +167,38 @@ Use exists to quickly check if a model with a given PK exists.
 
 ```go
 hasJet, err := models.JetExists(ctx, db, 10).All()
+```
+
+## Generated Error Constants
+
+Generated error constants allow for matching against specific errors raised by the underlying database driver.
+
+Take the following database table, for example:
+
+```sql
+CREATE TABLE pilots (
+    id serial PRIMARY KEY NOT NULL,
+    first_name text NOT NULL,
+    last_name text NOT NULL,
+    UNIQUE (first_name, last_name)
+);
+```
+
+Bob will define the following `struct`:
+
+```go
+type pilotErrors struct {
+    ErrUniqueFirstNameAndLastName error
+}
+```
+
+After that, the `struct` is initialized and exported through a `PilotErrors` variable, which can be used for error matching in the following way:
+
+```go
+pilot, err := models.Pilots.Insert(ctx, db, setter)
+if errors.Is(models.PilotErrors.ErrUniqueFirstNameAndLastName, err) {
+    log.Fatal(err)
+}
 ```
 
 ## Query Building


### PR DESCRIPTION
Opening this PR to materialize our discussion from #242.

In its current form, it adds support for the following drivers via `bobgen.yaml`:

```yaml
psql:
  driver_name: "pq" # default
#  driver_name: "pgx"
#  driver_name: "pgx/v4"
#  driver_name: "pgx/v5"

sqlite:
  driver_name: "sqlite" # default
#  driver_name: "go-sqlite3"
```

The MySQL driver is non-configurable and just defaults to `github.com/go-sql-driver/mysql`.

There's one bigger design decision that's worth discussing before finalizing this PR.

Right now, I'm generalizing the main `errUniqueConstraint` structure in `bob_main.go` as follows:
```go
type errUniqueConstraint struct {
	// s is a string uniquely identifying the constraint in 
        // the raw error message returned from the database.
	s string
}
```

Here, `s` is a substring to look for in the raw error message that the specified database system has returned. The reason why I'm using this generalization is because Postgres and MySQL report the constraint name, but SQLite reports the names of the columns included in the constraint (omitting the name).

This is also why in `01_types.go.tpl`, I'm doing this to build the respective substring:

```go
{{ $s := $constraint.Name }}
{{ if eq "sqlite" $.Dialect }}
{{ $s = printf "%s.%s" $table.Name (join (printf ", %s." $table.Name) $constraint.Columns) }}
{{ end }}
```

A possible alternative would be to keep the `errUniqueConstraint` type more verbose, e.g.:

```go
type errUniqueConstraint struct {
	name string
	table  string
	cols[] string
}
```

And then just use the `table` and `cols` information to augment the `unique_constraint_error_detection_method` block for SQLite to produce something like:

```go
func (e *errUniqueConstraint) Is(target error) bool {
	err, ok := target.(*sqliteDriver.Error)
	if !ok {
		return false
	}
	var sb strings.Builder
	for i := 0; i < len(e.cols); i++ {
		if i > 0 {
			sb.WriteString(", ")
		}
		sb.WriteString(e.table + "." + e.cols[i])
	}
	return err.Code() == 2067 && strings.Contains(err.Error(), sb.String())
}
```

Once we come to an agreement on that decision (and address any other comments that may arise), I'll finalize this PR with additional tests.