### PR TITLE
Add note for disabling SSL mode in PSQL DSN if needed.

### DIFF
--- a/website/docs/code-generation/psql.md
+++ b/website/docs/code-generation/psql.md
@@ -37,6 +37,12 @@ When you use an environment variable it must also be prefixed by the driver name
 PSQL_DSN="postgres://user:pass@host:port/dbname"
 ```
 
+Additionally if ssl mode is to be disabled (you will get connection failed error - `unable to fetch table data: unable to load enums: pq: SSL is not enabled on the server`), you can add `sslmode` to the dsn:
+
+```sh
+PSQL_DSN="postgres://user:pass@host:port/dbname?sslmode=disable"
+``` 
+
 The values that exist for the drivers:
 
 | Name          | Description                           | Default                  |


### PR DESCRIPTION
wrt SSL connections, you will get an error 
`⁠ unable to fetch table data: unable to load enums: pq: SSL is not enabled on the server ⁠`

so I’m adding notes to docs - that you can let pq know SSL is disabled.