### PR TITLE
Employ specific error type when generating error constants to make error matching easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated error constant generation to employ specific error types for making error matching easier. (thanks @mbezhanov)
+
 ## [v0.29.0] - 2024-11-20
 
 ### Added

--- a/gen/bobgen-mysql/templates/models/singleton/bob_mysql_blocks.go.tpl
+++ b/gen/bobgen-mysql/templates/models/singleton/bob_mysql_blocks.go.tpl
@@ -10,7 +10,7 @@ var (
 {{define "unique_constraint_error_detection_method" -}}
 {{$.Importer.Import "strings"}}
 {{$.Importer.Import "mysqlDriver" "github.com/go-sql-driver/mysql"}}
-func (e *errUniqueConstraint) Is(target error) bool {
+func (e *UniqueConstraintError) Is(target error) bool {
   err, ok := target.(*mysqlDriver.MySQLError)
   if !ok {
     return false

--- a/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
+++ b/gen/bobgen-psql/templates/models/singleton/bob_psql_blocks.go.tpl
@@ -1,5 +1,5 @@
 {{- define "unique_constraint_error_detection_method"}}
-func (e *errUniqueConstraint) Is(target error) bool {
+func (e *UniqueConstraintError) Is(target error) bool {
 	{{$supportedDrivers := list "github.com/lib/pq" "github.com/jackc/pgx" "github.com/jackc/pgx/v4" "github.com/jackc/pgx/v5"}}
 	{{if not (has $.DriverName $supportedDrivers)}}
 	return false

--- a/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/singleton/bob_sqlite_blocks.go.tpl
@@ -35,7 +35,7 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
 {{- end}}
 
 {{define "unique_constraint_error_detection_method" -}}
-func (e *errUniqueConstraint) Is(target error) bool {
+func (e *UniqueConstraintError) Is(target error) bool {
 	{{if not (eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3")}}
 	return false
 	{{else}}

--- a/gen/templates/models/01_types.go.tpl
+++ b/gen/templates/models/01_types.go.tpl
@@ -138,13 +138,13 @@ var {{$tAlias.UpSingular}}Errors = &{{$tAlias.DownSingular}}Errors{
 	{{ if eq "sqlite" $.Dialect }}
 	{{ $s = printf "%s.%s" $table.Name (join (printf ", %s." $table.Name) $constraint.Columns) }}
 	{{ end }}
-	ErrUnique{{join "_and_" $constraint.Columns | camelcase}}: &errUniqueConstraint{s: "{{$s}}"},
+	ErrUnique{{join "_and_" $constraint.Columns | camelcase}}: &UniqueConstraintError{s: "{{$s}}"},
 	{{end}}
 }
 
 type {{$tAlias.DownSingular}}Errors struct {
 	{{range $constraint := $table.Constraints.Uniques}}
-	ErrUnique{{join "_and_" $constraint.Columns | camelcase}} error
+	ErrUnique{{join "_and_" $constraint.Columns | camelcase}} *UniqueConstraintError
 	{{ end }}
 }
 {{ end }}

--- a/gen/templates/models/01_types_test.go.tpl
+++ b/gen/templates/models/01_types_test.go.tpl
@@ -50,7 +50,7 @@ func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
 	}
 	tests := []struct{
 		name        string
-		expectedErr error
+		expectedErr *models.UniqueConstraintError
 		applyFn     func(tpl *factory.{{$tAlias.UpSingular}}Template, obj *models.{{$tAlias.UpSingular}})
 	}{
 	{{range $constraint := $table.Constraints.Uniques}}
@@ -91,6 +91,12 @@ func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
 				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
 			}
 			if !errors.Is(tt.expectedErr, err) {
+				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
+			}
+			if !models.ErrUniqueConstraint.Is(err) {
+				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
+			}
+			if !tt.expectedErr.Is(err) {
 				t.Fatalf("Expected: %s, Got: %v", tt.name, err)
 			}
 			if err = tx.Rollback(); err != nil {

--- a/gen/templates/models/singleton/bob_main.go.tpl
+++ b/gen/templates/models/singleton/bob_main.go.tpl
@@ -132,19 +132,19 @@ func randInt() int64 {
 }
 
 // ErrUniqueConstraint captures all unique constraint errors by explicitly leaving `s` empty.
-var ErrUniqueConstraint = &errUniqueConstraint{s: ""}
+var ErrUniqueConstraint = &UniqueConstraintError{s: ""}
 
-type errUniqueConstraint struct {
+type UniqueConstraintError struct {
 	// s is a string uniquely identifying the constraint in the raw error message returned from the database.
 	s string
 }
 
-func (e *errUniqueConstraint) Error() string {
+func (e *UniqueConstraintError) Error() string {
   return e.s
 }
 
 {{block "unique_constraint_error_detection_method" . -}}
-func (e *errUniqueConstraint) Is(target error) bool {
+func (e *UniqueConstraintError) Is(target error) bool {
   return false
 }
 {{end}}

--- a/website/docs/code-generation/usage.md
+++ b/website/docs/code-generation/usage.md
@@ -188,15 +188,25 @@ Bob will define the following `struct` inside the generated `pilots.go` file:
 
 ```go
 type pilotErrors struct {
-    ErrUniqueFirstNameAndLastName error
+    ErrUniqueFirstNameAndLastName *UniqueConstraintError
 }
 ```
 
-The `struct` is initialized and exported through a `PilotErrors` variable, which can be used for error matching in the following way:
+The `struct` is initialized and exported through a `PilotErrors` variable, which can be used for error matching in one of the following ways:
+
 
 ```go
 pilot, err := models.Pilots.Insert(ctx, db, setter)
 if errors.Is(models.PilotErrors.ErrUniqueFirstNameAndLastName, err) {
+    // handle the error
+}
+```
+
+or
+
+```go
+pilot, err := models.Pilots.Insert(ctx, db, setter)
+if models.PilotErrors.ErrUniqueFirstNameAndLastName.Is(err) {
     // handle the error
 }
 ```
@@ -209,6 +219,17 @@ if errors.Is(models.ErrUniqueConstraint, err) {
     // handle the error
 }
 ```
+
+or
+
+```go
+pilot, err := models.Pilots.Insert(ctx, db, setter)
+if models.ErrUniqueConstraint.Is(err) {
+    // handle the error
+}
+```
+
+When using the `errors.Is()` variant, be mindful that the order of arguments matters due to Go's internal implementation. The first argument should be the error constant, while the second argument should be the actual error returned from the database. If you flip the arguments, the function won't work as intended and won't catch the unique constraint error.
 
 ## Query Building
 


### PR DESCRIPTION
Resolves #306

**Main highlights:**
- The custom error type `errUniqueConstraint` is renamed to `UniqueConstraintError` (so we can use it more easily in generated tests).
- The documentation is updated to explain both the old usage scenario (with `errors.Is()`) and the new usage scenario (with the direct use of the `Is()` method).
- There are now two additional test cases that validate the new usage scenario.
