### PR TITLE
Fix random value generation for pq.Float64Array factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated error constant generation to employ specific error types for making error matching easier. (thanks @mbezhanov)
+- Fix random value generation for pq.Float64Array factory (thanks @felipeparaujo)
 
 ## [v0.29.0] - 2024-11-20
 

--- a/gen/bobgen-helpers/helpers.go
+++ b/gen/bobgen-helpers/helpers.go
@@ -338,7 +338,7 @@ func Types() drivers.Types {
 			Imports: importers.List{`"github.com/lib/pq"`},
 			RandomExpr: `arr := make(pq.Float64Array, f.IntBetween(1, 5))
                 for i := range arr {
-                    arr[i] = f.Float64()
+                    arr[i] = f.Float64(10, -1_000_000, 1_000_000)
                 }
                 return arr`,
 			CompareExpr:        `slices.Equal(AAA, BBB)`,


### PR DESCRIPTION
The call to [faker's `f.Float64`](https://pkg.go.dev/github.com/jaswdr/faker#Faker.Float64) method was missing parameters. I copied the ones set in this same file for non-array float64s.

To reproduce, create the following table and run `bobgen-psql`:

```
CREATE TABLE test (
  dbl_precision DOUBLE PRECISION [] NOT NULL
);
```

I couldn't find any tests for this behaviour, let me know if there are any that need updating.