### PR TITLE
Add `net/netip` to random expr imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix random value generation for pq.Float64Array factory (thanks @felipeparaujo)
 - Using the `UpdateMod()` and `DeleteMod()` methods on an empty model slice now appends `WHERE primary_key IN NULL` which will return no results. Instead of `WHERE primary_key IN ()` which is a syntax error.
+- Ensure `net/netip` is imported for the `pgtypes.Inet` random expression (thanks @plunkettscott)
 
 ## [v0.29.0] - 2024-11-20
 

--- a/gen/bobgen-helpers/helpers.go
+++ b/gen/bobgen-helpers/helpers.go
@@ -281,7 +281,7 @@ func Types() drivers.Types {
                 ipAddr := netip.AddrFrom4(addr)
                 ipPrefix := netip.PrefixFrom(ipAddr, f.IntBetween(0, ipAddr.BitLen()))
                 return pgtypes.Inet{Prefix: ipPrefix}`,
-			RandomExprImports: importers.List{`"crypto/rand"`},
+			RandomExprImports: importers.List{`"crypto/rand"`, `"net/netip"`},
 		},
 		"pgtypes.Macaddr": {
 			Imports: importers.List{`"github.com/stephenafamo/bob/types/pgtypes"`},


### PR DESCRIPTION
The `pgtypes.Inet` type uses `net/netip` in its `RandomExpr`, but does not add it to the import list for the `RandomExprImports`. This results in a compilation error for the factory package if no other type exists which also imports the netip package.

I've worked around this in my projects by re-defining the type with the proper import until this can be merged.