### PR TITLE
Document `driver_name` configuration option

### DIFF
--- a/website/docs/code-generation/psql.md
+++ b/website/docs/code-generation/psql.md
@@ -45,17 +45,31 @@ PSQL_DSN="postgres://user:pass@host:port/dbname?sslmode=disable"
 
 The values that exist for the drivers:
 
-| Name          | Description                           | Default                  |
-|---------------|---------------------------------------|--------------------------|
-| dsn           | URL to connect to                     |                          |
-| schemas       | Schemas find tables in                | ["public"]               |
-| shared_schema | Schema to not include prefix in model | first value in "schemas" |
-| output        | Folder for generated files            | "models"                 |
-| pkgname       | Package name for generated code       | "models"                 |
-| uuid_pkg      | UUID package to use (gofrs or google) | "gofrs"                  |
-| concurrency   | How many tables to fetch in parallel  | 10                       |
-| only          | Only generate these                   |                          |
-| except        | Skip generation for these             |                          |
+| Name          | Description                                       | Default                  |
+|---------------|---------------------------------------------------|--------------------------|
+| dsn           | URL to connect to                                 |                          |
+| driver_name   | Driver to use for generating driver-specific code | `github.com/lib/pq`      |
+| schemas       | Schemas find tables in                            | ["public"]               |
+| shared_schema | Schema to not include prefix in model             | first value in "schemas" |
+| output        | Folder for generated files                        | "models"                 |
+| pkgname       | Package name for generated code                   | "models"                 |
+| uuid_pkg      | UUID package to use (gofrs or google)             | "gofrs"                  |
+| concurrency   | How many tables to fetch in parallel              | 10                       |
+| only          | Only generate these                               |                          |
+| except        | Skip generation for these                         |                          |
+
+## Driver-specific code
+
+The `driver_name` configuration option enables Bob to generate code that is tailored to the specifics of the selected `database/sql` driver.
+
+For Postgres, the supported drivers are:
+
+- [github.com/lib/pq](https://pkg.go.dev/github.com/lib/pq) (default)
+- [github.com/jackc/pgx](https://pkg.go.dev/github.com/jackc/pgx)
+- [github.com/jackc/pgx/v4](https://pkg.go.dev/github.com/jackc/pgx/v4)
+- [github.com/jackc/pgx/v5](https://pkg.go.dev/github.com/jackc/pgx/v5)
+
+Bob leverages driver-specific code to perform precise error matching for [generated error constants](./usage#generated-error-constants).
 
 ## Only/Except:
 

--- a/website/docs/code-generation/sqlite.md
+++ b/website/docs/code-generation/sqlite.md
@@ -39,15 +39,27 @@ SQLITE_DSN="file.db"
 
 The values that exist for the drivers:
 
-| Name          | Description                              | Default             |
-|---------------|------------------------------------------|---------------------|
-| dsn           | Path to database                         |                     |
-| attach        | Schemas to attach and the path to the db | map[string]string{} |
-| shared_schema | Schema to not include prefix in model    | "main"              |
-| output        | Folder for generated files               | "models"            |
-| pkgname       | Package name for generated code          | "models"            |
-| only          | Only generate these                      |                     |
-| except        | Skip generation for these                |                     |
+| Name          | Description                                       | Default               |
+|---------------|---------------------------------------------------|-----------------------|
+| dsn           | Path to database                                  |                       |
+| driver_name   | Driver to use for generating driver-specific code | `modernc.org/sqlite`  |
+| attach        | Schemas to attach and the path to the db          | map[string]string{}   |
+| shared_schema | Schema to not include prefix in model             | "main"                |
+| output        | Folder for generated files                        | "models"              |
+| pkgname       | Package name for generated code                   | "models"              |
+| only          | Only generate these                               |                       |
+| except        | Skip generation for these                         |                       |
+
+## Driver-specific code
+
+The `driver_name` configuration option enables Bob to generate code that is tailored to the specifics of the selected `database/sql` driver.
+
+For SQLite, the supported drivers are:
+
+- [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite) (default)
+- [github.com/mattn/go-sqlite3](https://pkg.go.dev/github.com/mattn/go-sqlite3)
+
+Bob leverages driver-specific code to perform precise error matching for [generated error constants](./usage#generated-error-constants).
 
 ## Only/Except:
 


### PR DESCRIPTION
The PR adds a bit of documentation about the `driver_name` configuration option as requested in https://github.com/stephenafamo/bob/pull/248#issuecomment-2593848804.