### PR TITLE
Add LibSQL support to SQLite generator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,28 @@ jobs:
           && mysql --execute 'CREATE DATABASE dialect_droppable;'
           && mysql --execute 'CREATE DATABASE driver_droppable;'
 
+      - name: LibSQL Setup
+        run: |
+          mkdir -p ./regexp \
+          && wget https://github.com/nalgeon/sqlean/releases/download/0.27.1/sqlean-linux-x86.zip \
+          && unzip sqlean-linux-x86.zip regexp.so \
+          && rm sqlean-linux-x86.zip \
+          && sha256sum regexp.so > ./regexp/trusted.lst \
+          && mv regexp.so ./regexp \
+          && docker run -d -p 8080:8080 -p 8000:8000 --rm -v ${{ github.workspace }}/regexp:/var/lib/sqld/regexp \
+               ghcr.io/tursodatabase/libsql-server:c6e4e09 sqld \
+               --http-listen-addr=0.0.0.0:8080 \
+               --admin-listen-addr=0.0.0.0:8000 \
+               --enable-namespaces \
+               --extensions-path /var/lib/sqld/regexp \
+          && sleep 1 \
+          && curl -X POST http://localhost:8000/v1/namespaces/one/create \
+               -H "Content-Type: application/json" \
+               --data '{}' \
+          && curl -X POST http://localhost:8000/v1/namespaces/one/config \
+               -H "Content-Type: application/json" \
+               --data '{"block_reads": false, "block_writes": false, "block_reason": null, "max_db_size": "1000.0 PB", "heartbeat_url": null, "jwt_key": null, "allow_attach": true, "txn_timeout_s": null, "durability_mode": "relaxed"}'
+
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -66,12 +88,12 @@ jobs:
 
   test-windows-sqlite:
     # Run generation test on windows to catch filepath issues
-    # Testing Postgres and MySQL are not possible since the windows runner
+    # Testing Postgres, MySQL, and LibSQL are not possible since the windows runner
     # does not support containers
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['stable' ]
+        go: ['stable']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -85,4 +107,4 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -race ./gen/bobgen-sqlite/driver
+        run: go test -race -run '^(TestAssembleSQLite)$' ./gen/bobgen-sqlite/driver

--- a/gen/bobgen-sqlite/templates/models/bob_sqlite_blocks.bob.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/bob_sqlite_blocks.bob.go.tpl
@@ -7,9 +7,11 @@ var (
 
 {{define "unique_constraint_error_detection_method" -}}
 func (e *UniqueConstraintError) Is(target error) bool {
-	{{if not (eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3")}}
-	return false
-	{{else}}
+	{{if eq $.DriverName "github.com/tursodatabase/libsql-client-go/libsql"}}
+		{{$.Importer.Import "strings"}}
+		{{$.Importer.Import "fmt"}}
+	return strings.Contains(target.Error(), fmt.Sprintf("SQLite error: UNIQUE constraint failed: %s", e.s))
+	{{else if eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3"}}
 		{{$errType := ""}}
 		{{$codeGetter := ""}}
 		{{$.Importer.Import "strings"}}
@@ -27,6 +29,8 @@ func (e *UniqueConstraintError) Is(target error) bool {
 		return false
 	}
 	return err.{{$codeGetter}} == 2067 && strings.Contains(err.Error(), e.s)
+	{{else}}
+	return false
 	{{end}}
 }
 {{end -}}

--- a/gen/templates/models/table/01_types_test.go.tpl
+++ b/gen/templates/models/table/01_types_test.go.tpl
@@ -41,6 +41,10 @@
 	{{$.Importer.Import "_" $.DriverName }}
 	{{$sqlDriverName = "sqlite3"}}
 	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/tursodatabase/libsql-client-go/libsql" }}
+	{{$.Importer.Import "_" $.DriverName }}
+	{{$sqlDriverName = "libsql"}}
+	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
 {{ end }}
 
 func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
@@ -80,7 +84,7 @@ func Test{{$tAlias.UpSingular}}UniqueConstraintErrors(t *testing.T) {
 			}
 			exec := bob.New(tx)
 			f := factory.New()
-			tpl := f.New{{$tAlias.UpSingular}}()
+			tpl := f.New{{$tAlias.UpSingular}}(factory.{{$tAlias.UpSingular}}Mods.RandomizeAllColumns(nil))
 			obj, err := tpl.Create(ctx, exec)
 			if err != nil {
 				t.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
 	github.com/stephenafamo/scan v0.6.1
 	github.com/stephenafamo/sqlparser v0.0.0-20241111104950-b04fa8a26c9c
+	github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d
 	github.com/urfave/cli/v2 v2.23.7
 	github.com/volatiletech/strmangle v0.0.6
 	github.com/wasilibs/go-pgquery v0.0.0-20240319230125-b9b2e95c69a7
@@ -36,6 +37,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/aarondl/json v0.0.0-20221020222930-8b0db17ef1bf // indirect
+	github.com/coder/websocket v1.8.12 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aarondl/opt v0.0.0-20230114172057-b91f370c41f0 h1:vLrhbOWVPxtHao/QthU
 github.com/aarondl/opt v0.0.0-20230114172057-b91f370c41f0/go.mod h1:l4/5NZtYd/SIohsFhaJQQe+sPOTG22furpZ5FvcYOzk=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -109,8 +111,6 @@ github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97 h1:XItoZNmhOih06TC02jK7l3wlpZ0XT/sPQYutDcGOQjg=
 github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97/go.mod h1:bM3Vmw1IakoaXocHmMIGgJFYob0vuK+CFWiJHQvz0jQ=
-github.com/stephenafamo/scan v0.6.0 h1:N0joyP/wriC9VvP6w9SDxHIuQGatW4c2YW7Z5L4m45s=
-github.com/stephenafamo/scan v0.6.0/go.mod h1:FhIUJ8pLNyex36xGFiazDJJ5Xry0UkAi+RkWRrEcRMg=
 github.com/stephenafamo/scan v0.6.1 h1:nXokGCQwYazMuyvdNAoK0T8Z76FWcpMvDdtengpz6PU=
 github.com/stephenafamo/scan v0.6.1/go.mod h1:FhIUJ8pLNyex36xGFiazDJJ5Xry0UkAi+RkWRrEcRMg=
 github.com/stephenafamo/sqlparser v0.0.0-20241111104950-b04fa8a26c9c h1:JFga++XBnZG2xlnvQyHJkeBWZ9G9mGdtgvLeSRbp/BA=
@@ -129,6 +129,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
 github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d h1:dOMI4+zEbDI37KGb0TI44GUAwxHF9cMsIoDTJ7UmgfU=
+github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d/go.mod h1:l8xTsYB90uaVdMHXMCxKKLSgw5wLYBwBKKefNIUnm9s=
 github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
 github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=

--- a/test/files/files.go
+++ b/test/files/files.go
@@ -10,3 +10,9 @@ var MySQLSchema embed.FS
 
 //go:embed sqlite
 var SQLiteSchema embed.FS
+
+//go:embed libsql/default
+var LibSQLDefaultSchema embed.FS
+
+//go:embed libsql/one
+var LibSQLOneSchema embed.FS

--- a/test/files/libsql/default/schema.sql
+++ b/test/files/libsql/default/schema.sql
@@ -1,0 +1,227 @@
+create table users (
+	id int primary key not null
+);
+
+create table sponsors (
+	id int primary key not null
+);
+
+create table videos (
+	id int primary key not null,
+
+	user_id int not null,
+	sponsor_id int unique,
+
+	foreign key (user_id) references users (id),
+	foreign key (sponsor_id) references sponsors (id)
+);
+
+create table tags (
+	id int primary key not null
+);
+
+create table video_tags (
+	video_id int not null,
+	tag_id   int not null,
+
+	primary key (video_id, tag_id),
+	foreign key (video_id) references videos, -- Implicitly references videos(id)
+	foreign key (tag_id) references tags (id)
+);
+
+create table type_monsters (
+	id int primary key not null,
+
+	id_two     int not null,
+	id_three   int,
+	bool_zero  bool,
+	bool_one   bool null,
+	bool_two   bool not null,
+	bool_three bool null default false,
+	bool_four  bool null default true,
+	bool_five  bool not null default false,
+	bool_six   bool not null default true,
+
+	string_zero   varchar(1),
+	string_one    varchar(1) null,
+	string_two    varchar(1) not null,
+	string_three  varchar(1) null default 'a',
+	string_four   varchar(1) not null default 'b',
+	string_five   varchar(1000),
+	string_six    varchar(1000) null,
+	string_seven  varchar(1000) not null,
+	string_eight  varchar(1000) null default 'abcdefgh',
+	string_nine   varchar(1000) not null default 'abcdefgh',
+	string_ten    varchar(1000) null default '',
+	string_eleven varchar(1000) not null default '',
+
+	big_int_zero  bigint,
+	big_int_one   bigint NULL,
+	big_int_two   bigint NOT NULL,
+	big_int_three bigint NULL DEFAULT 111111,
+	big_int_four  bigint NOT NULL DEFAULT 222222,
+	big_int_five  bigint NULL DEFAULT 0,
+	big_int_six   bigint NOT NULL DEFAULT 0,
+
+	int_zero  int,
+	int_one   int NULL,
+	int_two   int NOT NULL,
+	int_three int NULL DEFAULT 333333,
+	int_four  int NOT NULL DEFAULT 444444,
+	int_five  int NULL DEFAULT 0,
+	int_six   int NOT NULL DEFAULT 0,
+
+	float_zero  float,
+	float_one   float,
+	float_two   float(2,1),
+	float_three float(2,1),
+	float_four  float(2,1) null,
+	float_five  float(2,1) not null,
+	float_six   float(2,1) null default 1.1,
+	float_seven float(2,1) not null default 1.1,
+	float_eight float(2,1) null default 0.0,
+	float_nine  float(2,1) null default 0.0,
+	bytea_zero  binary,
+	bytea_one   binary null,
+	bytea_two   binary not null,
+	bytea_three binary not null default 'a',
+	bytea_four  binary null default 'b',
+	bytea_five  binary(100) not null default 'abcdefghabcdefghabcdefgh',
+	bytea_six   binary(100) null default 'hgfedcbahgfedcbahgfedcba',
+	bytea_seven binary not null default '',
+	bytea_eight binary not null default '',
+	time_zero   timestamp,
+	time_one    date,
+	time_two    timestamp null default null,
+	time_three  timestamp null,
+	time_five   timestamp null default current_timestamp,
+	time_nine   timestamp not null default current_timestamp,
+	time_eleven date null,
+	time_twelve date not null,
+	time_fifteen date null default '19990108',
+	time_sixteen date not null default '1999-01-08',
+
+	json_null  json null,
+	json_nnull json not null,
+
+	tinyint_null    tinyint null,
+	tinyint_nnull   tinyint not null,
+	tinyint1_null   tinyint(1) null,
+	tinyint1_nnull  tinyint(1) not null,
+	tinyint2_null   tinyint(2) null,
+	tinyint2_nnull  tinyint(2) not null,
+	smallint_null   smallint null,
+	smallint_nnull  smallint not null,
+	mediumint_null  mediumint null,
+	mediumint_nnull mediumint not null,
+	bigint_null     bigint null,
+	bigint_nnull    bigint not null,
+
+	float_null       float null,
+	float_nnull      float not null,
+	double_null      double null,
+	double_nnull     double not null,
+	doubleprec_null  double precision null,
+	doubleprec_nnull double precision not null,
+
+	real_null  real null,
+	real_nnull real not null,
+
+	boolean_null  boolean null,
+	boolean_nnull boolean not null,
+
+	date_null  date null,
+	date_nnull date not null,
+
+	datetime_null  datetime null,
+	datetime_nnull datetime not null,
+
+	timestamp_null  timestamp null,
+	timestamp_nnull timestamp not null default current_timestamp,
+
+	binary_null      binary null,
+	binary_nnull     binary not null,
+	varbinary_null   varbinary(100) null,
+	varbinary_nnull  varbinary(100) not null,
+	tinyblob_null    tinyblob null,
+	tinyblob_nnull   tinyblob not null,
+	blob_null        blob null,
+	blob_nnull       blob not null,
+	mediumblob_null  mediumblob null,
+	mediumblob_nnull mediumblob not null,
+	longblob_null    longblob null,
+	longblob_nnull   longblob not null,
+
+	varchar_null  varchar(100) null,
+	varchar_nnull varchar(100) not null,
+	char_null     char null,
+	char_nnull    char not null,
+	text_null     text null,
+	text_nnull    text not null
+);
+
+-- all table defintions will not cause sqlite autoincrement primary key without rowid tables to be generated
+create table autoinctest (
+    id INTEGER PRIMARY KEY NOT NULL,
+    FOREIGN KEY (id) REFERENCES tags (id) -- causes make sure id is included in getter
+);
+
+-- additional fields should not be marked as auto generated, when the AUTOINCREMENT keyword is present
+create table autoinckeywordtest (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+
+	user_id int not null,
+	sponsor_id int unique,
+
+    something TEXT,
+    another TEXT,
+    UNIQUE(something, another),
+
+    FOREIGN KEY(user_id, sponsor_id) REFERENCES videos(user_id, sponsor_id)
+);
+
+create view user_videos as
+select u.id user_id, v.id video_id, v.sponsor_id sponsor_id
+from users u
+inner join videos v on v.user_id = u.id;
+
+CREATE TABLE has_generated_columns (
+   a INTEGER PRIMARY KEY NOT NULL,
+   b INT,
+   c TEXT,
+   d INT GENERATED ALWAYS AS (a*abs(b)) VIRTUAL,
+   e TEXT GENERATED ALWAYS AS (substr(c,b,b+1)) STORED
+);
+
+CREATE TABLE test_index_expressions (
+    col1 int,
+    col2 int,
+    col3 int
+);
+CREATE INDEX idx1 ON test_index_expressions ((col1 + col2));
+CREATE INDEX idx2 ON test_index_expressions ((col1 + col2), col3);
+CREATE INDEX idx3 ON test_index_expressions (col1, (col2 + col3));
+CREATE INDEX idx4 ON test_index_expressions (col3);
+CREATE INDEX idx5 ON test_index_expressions (col1 DESC, col2 DESC);
+CREATE INDEX idx6 ON test_index_expressions (POW(col3, 2));
+
+CREATE TABLE foo_bar (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE foo_baz (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE foo_qux (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE bar_baz (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE bar_qux (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);

--- a/test/files/libsql/one/schema.sql
+++ b/test/files/libsql/one/schema.sql
@@ -1,0 +1,77 @@
+-- For the attached database
+create table users (
+	id int primary key not null
+);
+
+create table sponsors (
+	id int primary key not null
+);
+
+create table videos (
+	id int primary key not null,
+
+	user_id int not null,
+	sponsor_id int unique,
+
+	foreign key (user_id) references users (id),
+	foreign key (sponsor_id) references sponsors (id)
+);
+
+create table tags (
+	id int primary key not null
+);
+
+create table video_tags (
+	video_id int not null,
+	tag_id   int not null,
+
+	primary key (video_id, tag_id),
+	foreign key (video_id) references videos (id),
+	foreign key (tag_id) references tags (id)
+);
+
+
+-- all table defintions will not cause sqlite autoincrement primary key without rowid tables to be generated
+create table autoinctest (
+	id INTEGER PRIMARY KEY NOT NULL
+);
+
+-- additional fields should not be marked as auto generated, when the AUTOINCREMENT keyword is present
+create table autoinckeywordtest (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	b INTEGER
+);
+
+create view user_videos as
+select u.id user_id, v.id video_id, v.sponsor_id sponsor_id
+from users u
+inner join videos v on v.user_id = u.id;
+
+create table as_generated_columns (
+   a INTEGER PRIMARY KEY NOT NULL,
+   b INT,
+   c TEXT,
+   d INT GENERATED ALWAYS AS (a*abs(b)) VIRTUAL,
+   e TEXT GENERATED ALWAYS AS (substr(c,b,b+1)) STORED
+);
+
+CREATE TABLE foo_bar (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE foo_baz (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE foo_qux (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE bar_baz (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);
+CREATE TABLE bar_qux (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    secret_col TEXT NOT NULL
+);


### PR DESCRIPTION
Closes [#304](https://github.com/stephenafamo/bob/issues/304).

Let me know if you require any adjustments or further details about the implementation.

Some of the more notable changes:

1. Switched from index placeholders to regular placeholders during table filter processing to work around the following issue with the LibSQL driver:

    > Arguments do not match SQL parameters: value for parameter $1 not found

2. Adjusted `ATTACH` statements to make sure they use an unquoted DSN string to avoid the following LibSQL error:

   > unable to execute attach database 'one' as one: SQL string could not be parsed: unsupported statement: attach database 'one' as one

3. Added runtime modification of golden files for LibSQL tests (the idea is to reuse the original SQLite golden files, only tweaking the recorded `DriverName`, as they are otherwise identical).
