### PR TITLE
Add support for custom types in models directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for libSQL. (thanks @mbezhanov)
+- Added support for declaring types inside the models package.
 
 ### Changed
 

--- a/gen/drivers/interface.go
+++ b/gen/drivers/interface.go
@@ -48,7 +48,7 @@ type Type struct {
 	CompareExpr string `yaml:"compare_expr"`
 	// Imports needed for the compare expression
 	CompareExprImports importers.List `yaml:"compare_expr_imports"`
-	// If factory generation should have "pkgname." prefix
+	// If factory generation should have "models." prefix
 	InGeneratedPackage bool `yaml:"in_generated_package"`
 }
 

--- a/gen/drivers/interface.go
+++ b/gen/drivers/interface.go
@@ -48,6 +48,8 @@ type Type struct {
 	CompareExpr string `yaml:"compare_expr"`
 	// Imports needed for the compare expression
 	CompareExprImports importers.List `yaml:"compare_expr_imports"`
+	// If factory generation should have "pkgname." prefix
+	InGeneratedPackage bool `yaml:"in_generated_package"`
 }
 
 type Types map[string]Type

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -189,6 +189,7 @@ var templateFunctions = template.FuncMap{
 	},
 	"isPrimitiveType":    isPrimitiveType,
 	"relQueryMethodName": relQueryMethodName,
+	"getType":            getType,
 }
 
 func relQueryMethodName(tAlias drivers.TableAlias, relAlias string) string {
@@ -204,4 +205,20 @@ func relQueryMethodName(tAlias drivers.TableAlias, relAlias string) string {
 
 func NormalizeType(val string) string {
 	return typesReplacer.Replace(val)
+}
+
+// Gets the type for a db column. Used if you have types defined inside the
+// models dir, which needs the models prefix in the factory files.
+func getType(columnType string, typedef drivers.Type) string {
+
+	prefix := ""
+	if typedef.InGeneratedPackage {
+		prefix = "models."
+	}
+
+	if typedef.AliasOf != "" {
+		return prefix + typedef.AliasOf
+	}
+
+	return prefix + columnType
 }

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -210,7 +210,6 @@ func NormalizeType(val string) string {
 // Gets the type for a db column. Used if you have types defined inside the
 // models dir, which needs the models prefix in the factory files.
 func getType(columnType string, typedef drivers.Type) string {
-
 	prefix := ""
 	if typedef.InGeneratedPackage {
 		prefix = "models."

--- a/gen/templates/factory/bobfactory_random.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_random.bob.go.tpl
@@ -1,5 +1,6 @@
 {{$.Importer.Import "github.com/jaswdr/faker/v2"}}
 
+
 var defaultFaker = faker.New()
 
 {{$doneTypes := dict }}
@@ -25,7 +26,10 @@ var defaultFaker = faker.New()
     */}}{{- end -}}
     {{- $.Importer.ImportList $typDef.Imports -}}
     {{- $.Importer.ImportList $typDef.RandomExprImports -}}
-    func random_{{normalizeType $colTyp}}(f *faker.Faker) {{or $typDef.AliasOf $colTyp}} {
+    {{- if $typDef.InGeneratedPackage -}}
+      {{$.Importer.Import "models" $.ModelsPackage}}
+    {{- end -}}
+    func random_{{normalizeType $colTyp}}(f *faker.Faker) {{getType $colTyp $typDef}} {
       if f == nil {
         f = &defaultFaker
       }

--- a/gen/templates/factory/bobfactory_random_test.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_random_test.bob.go.tpl
@@ -5,7 +5,8 @@
 {{- range $table := .Tables}}
 {{- $tAlias := $.Aliases.Table $table.Key}}
   {{range $column := $table.Columns -}}
-    {{- $colTyp := $column.Type -}}
+    {{- $typDef :=  index $.Types $column.Type -}}
+    {{- $colTyp := getType $column.Type $typDef -}}
     {{- if hasKey $doneTypes $colTyp}}{{continue}}{{end -}}
     {{- $_ :=  set $doneTypes $colTyp nil -}}
     {{- $typInfo :=  index $.Types $column.Type -}}

--- a/gen/templates/factory/table/01_types.go.tpl
+++ b/gen/templates/factory/table/01_types.go.tpl
@@ -25,7 +25,7 @@ func (mods {{$tAlias.UpSingular}}ModSlice) Apply(n *{{$tAlias.UpSingular}}Templa
 type {{$tAlias.UpSingular}}Template struct {
     {{- range $column := $table.Columns -}}
         {{- $typDef :=  index $.Types $column.Type -}}
-        {{- $colTyp := or $typDef.AliasOf $column.Type -}}
+        {{- $colTyp := getType $column.Type $typDef -}}
         {{- $.Importer.ImportList $typDef.Imports -}}
         {{- $colAlias := $tAlias.Column $column.Name -}}
         {{- if $column.Nullable -}}

--- a/gen/templates/factory/table/11_column_mods.go.tpl
+++ b/gen/templates/factory/table/11_column_mods.go.tpl
@@ -18,7 +18,7 @@ func (m {{$tAlias.DownSingular}}Mods) RandomizeAllColumns(f *faker.Faker) {{$tAl
 {{range $column := .Table.Columns}}
 {{$colAlias := $tAlias.Column $column.Name -}}
 {{- $typDef :=  index $.Types $column.Type -}}
-{{- $colTyp := or $typDef.AliasOf $column.Type -}}
+{{- $colTyp := getType $column.Type $typDef -}}
 {{- if $column.Nullable -}}
 	{{- $.Importer.Import "github.com/aarondl/opt/null" -}}
 	{{- $colTyp = printf "null.Val[%s]" $colTyp -}}
@@ -56,7 +56,7 @@ func (m {{$tAlias.DownSingular}}Mods) Random{{$colAlias}}(f *faker.Faker) {{$tAl
         }
 
         if f.Bool() {
-          return null.FromPtr[{{or $typDef.AliasOf $column.Type}}](nil)
+          return null.FromPtr[{{getType $column.Type $typDef}}](nil)
         }
 
         return null.From(random_{{normalizeType $column.Type}}(f))

--- a/website/docs/code-generation/configuration.md
+++ b/website/docs/code-generation/configuration.md
@@ -142,6 +142,14 @@ types:
     random_expr: |-
       tag := f.Lorem().Word()
       return fmt.Sprintf("<%s>%s</%s>", tag, f.Lorem().Word(), tag)
+  LocalType:
+    # Set this to true if your custom type is declared in the generated package (i.e. "models").
+    # If this is not the case, "models." will not be prefixed in the generated factory.
+    in_generated_package: true
+    no_randomization_test: true
+    random_expr: |
+      localType := models.LocalType{}
+      return localType
   type.JSON[json.RawMessage]:
     # If true, a test for the random expression will not be generated
     no_randomization_test: false


### PR DESCRIPTION
This adds support for declaring custom types within the "models" directory (or what it is specified as). 

It will make sure the correct imports are used in the corresponding factory files