### PR TITLE
fix: Use Decimal Equal method for comparisons

### DIFF
--- a/gen/bobgen-helpers/helpers.go
+++ b/gen/bobgen-helpers/helpers.go
@@ -328,8 +328,9 @@ func Types() drivers.Types {
 			CompareExprImports: importers.List{`"slices"`},
 		},
 		"decimal.Decimal": {
-			Imports:    importers.List{`"github.com/shopspring/decimal"`},
-			RandomExpr: `return decimal.New(f.Int64Between(0, 1000), 0)`,
+			Imports:     importers.List{`"github.com/shopspring/decimal"`},
+			RandomExpr:  `return decimal.New(f.Int64Between(0, 1000), 0)`,
+			CompareExpr: `AAA.Equal(BBB)`,
 		},
 		"pgtypes.LSN": {
 			Imports:    importers.List{`"github.com/stephenafamo/bob/types/pgtypes"`},


### PR DESCRIPTION
It is not safe to compare the decimal.Decimal type using standard equality, the [Equal](https://pkg.go.dev/github.com/shopspring/decimal#Decimal.Equal) method should be used instead.