### PR TITLE
chore: update go to 1.24 and the modfile package with it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stephenafamo/bob
 
-go 1.23
+go 1.24
 
 require (
 	github.com/DATA-DOG/go-txdb v0.1.6
@@ -25,7 +25,7 @@ require (
 	github.com/urfave/cli/v2 v2.23.7
 	github.com/volatiletech/strmangle v0.0.6
 	github.com/wasilibs/go-pgquery v0.0.0-20240319230125-b9b2e95c69a7
-	golang.org/x/mod v0.17.0
+	golang.org/x/mod v0.24.0
 	golang.org/x/text v0.14.0
 	golang.org/x/tools v0.21.0
 	modernc.org/sqlite v1.20.3

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJ
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
This works locally. 

Closes https://github.com/stephenafamo/bob/issues/377

It now:
```bash
❯ PSQL_DSN="postgresql://user:123password@localhost:5438/db?sslmode=disable" bobgen-psql                                                                                                            12:02:37 PM
    795 bytes        models/bob_main_test.bob.go
== SKIPPED ==        models/bob_psql_blocks.bob.go
== SKIPPED ==        models/bob_enums.bob.go
   3208 bytes        models/bob_main.bob.go
  19277 bytes        models/firehose_lane_config.bob.go
== SKIPPED ==        models/firehose_lane_config.bob_test.go
  11663 bytes        models/schema_migrations.bob.go
== SKIPPED ==        models/schema_migrations.bob_test.go
   1417 bytes        models/factory/bobfactory_random_test.bob.go
    690 bytes        models/factory/bobfactory_context.bob.go
== SKIPPED ==        models/factory/bobfactory_enums.bob.go
   1195 bytes        models/factory/bobfactory_main.bob.go
   1479 bytes        models/factory/bobfactory_random.bob.go
  22352 bytes        models/factory/lane_config.bob.go
   9578 bytes        models/factory/schema_migrations.bob.go
```