### PR TITLE
Fix enum types match by "db_type" when using bobgen-psql

### DIFF
--- a/gen/bobgen-psql/driver/exclude-tables.golden.json
+++ b/gen/bobgen-psql/driver/exclude-tables.golden.json
@@ -486,7 +486,7 @@
 				},
 				{
 					"name": "enum_use",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "",
 					"comment": "",
 					"nullable": false,
@@ -497,7 +497,7 @@
 				},
 				{
 					"name": "enum_nullable",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,
@@ -2325,7 +2325,7 @@
 				},
 				{
 					"name": "enum_use",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,
@@ -2336,7 +2336,7 @@
 				},
 				{
 					"name": "enum_nullable",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -651,7 +651,7 @@
 				},
 				{
 					"name": "enum_use",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "",
 					"comment": "",
 					"nullable": false,
@@ -662,7 +662,7 @@
 				},
 				{
 					"name": "enum_nullable",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,
@@ -2490,7 +2490,7 @@
 				},
 				{
 					"name": "enum_use",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,
@@ -2501,7 +2501,7 @@
 				},
 				{
 					"name": "enum_nullable",
-					"db_type": "ENUM",
+					"db_type": "public.unicode_enum",
 					"default": "NULL",
 					"comment": "",
 					"nullable": true,

--- a/gen/bobgen-psql/driver/translate.go
+++ b/gen/bobgen-psql/driver/translate.go
@@ -90,6 +90,7 @@ func (d *driver) translateColumnType(c drivers.Column, info colInfo) drivers.Col
 		c.Type = "pgtypes.TxIDSnapshot"
 	case "ENUM":
 		c.Type = "string"
+		c.DBType = info.UDTSchema + "." + info.UDTName
 		for _, e := range d.enums {
 			if e.Schema == info.UDTSchema && e.Name == info.UDTName {
 				d.mu.Lock()


### PR DESCRIPTION
When using enum types, the `Column.DBType` now correctly includes the schema name and replacement works well.

Examples:

// migrations.up.sql
```sql
CREATE SCHEMA IF NOT EXISTS preferences;
CREATE TYPE preferences.test AS ENUM ('foo', 'bar');
CREATE TABLE IF NOT EXISTS preferences.users
(
    id SERIAL PRIMARY KEY,
    name VARCHAR(255) NOT NULL,
    test preferences.test NOT NULL
);
```
// bobgen.yaml
```yaml
...
types:
  mtype.Type:
    no_randomization_test: true
    imports:
      - '"test-bob/mtype"'

replacements:
  - tables: []
    match:
      db_type: "preferences.test"
    replace: "mtype.Type"
```

Note: If the PostgreSQL type is created without an explicit schema (e.g., `CREATE TYPE test AS ENUM ('foo', 'bar');`), it defaults to the public schema. In this case, the replacement config should explicitly specify `public`:
```yaml
match:
  db_type: "public.test"
```