### PR TITLE
Ability to use 'In' and 'NotIn' where mods with empty value slices

### DIFF
--- a/dialect/mysql/where.go
+++ b/dialect/mysql/where.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/expr"
 	"github.com/stephenafamo/bob/mods"
 )
 
@@ -66,6 +67,9 @@ func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=0)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
@@ -74,6 +78,9 @@ func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=1)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)

--- a/dialect/psql/where.go
+++ b/dialect/psql/where.go
@@ -67,6 +67,9 @@ func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=0)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
@@ -75,6 +78,9 @@ func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=1)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)

--- a/dialect/sqlite/where.go
+++ b/dialect/sqlite/where.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/expr"
 	"github.com/stephenafamo/bob/mods"
 )
 
@@ -66,6 +67,9 @@ func (w WhereMod[Q, C]) GTE(val C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=0)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
@@ -74,6 +78,9 @@ func (w WhereMod[Q, C]) In(slice ...C) mods.Where[Q] {
 }
 
 func (w WhereMod[Q, C]) NotIn(slice ...C) mods.Where[Q] {
+	if len(slice) == 0 {
+		return mods.Where[Q]{E: expr.Raw("(1=1)")}
+	}
 	values := make([]any, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)


### PR DESCRIPTION
Added the ability to use `In` and `NotIn` where modifiers with empty value slices.

- Follows the same pattern as [sqlboiler's handling of empty IN clauses](https://github.com/volatiletech/sqlboiler/commit/569dd00c27fa61c96c708db179f87bab794d8b7c#diff-1903c797de1900cb84322838dabf94209eea5277d3b7f12c03d9895d6d8b4484R395-R399)
- Empty `In` clauses will resolve to FALSE (no results)
- Empty `NotIn` clauses will resolve to TRUE (all results)

Thanks to @Rubanik-Alexei for suggesting this approach.