### PR TITLE
Add ncruces/go-sqlite3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the `drivers/pgx` package which contains types and functions to use a `pgx/v5` connection as a `bob.Executor`.
+- Added support for `github.com/ncruces/go-sqlite3`. (thanks @ncruces)
 
 ### Changed
 

--- a/gen/bobgen-sqlite/driver/sqlite.go
+++ b/gen/bobgen-sqlite/driver/sqlite.go
@@ -46,6 +46,7 @@ func New(config Config) Interface {
 	// These are the only supported drivers
 	case "modernc.org/sqlite":
 	case "github.com/mattn/go-sqlite3":
+	case "github.com/ncruces/go-sqlite3":
 	case "github.com/tursodatabase/libsql-client-go/libsql":
 	default:
 		panic(fmt.Sprintf(

--- a/gen/bobgen-sqlite/driver/sqlite_test.go
+++ b/gen/bobgen-sqlite/driver/sqlite_test.go
@@ -136,7 +136,7 @@ func TestAssembleSQLite(t *testing.T) {
 
 	config := Config{
 		Config: helpers.Config{
-			Dsn: mainDB.Name() + "?_pragma=foreign_keys(1)&_pragma=busy_timeout(10000)",
+			Dsn: "file:" + mainDB.Name() + "?_pragma=foreign_keys(1)&_pragma=busy_timeout(10000)",
 		},
 		Attach: map[string]string{"one": oneDB.Name()},
 	}
@@ -172,6 +172,10 @@ func testSQLiteDriver(t *testing.T, config Config) {
 		{
 			name:       "modernc",
 			driverName: "modernc.org/sqlite",
+		},
+		{
+			name:       "ncruces",
+			driverName: "github.com/ncruces/go-sqlite3",
 		},
 	}
 

--- a/gen/bobgen-sqlite/templates/models/bob_sqlite_blocks.bob.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/bob_sqlite_blocks.bob.go.tpl
@@ -18,7 +18,7 @@ func (e *UniqueConstraintError) Is(target error) bool {
       target.Error(),
       fmt.Sprintf("SQLite error: UNIQUE constraint failed: %s", strings.Join(fullCols, ", ")),
     )
-	{{else if eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3"}}
+	{{else if eq $.DriverName "modernc.org/sqlite" "github.com/mattn/go-sqlite3" "github.com/ncruces/go-sqlite3"}}
 		{{$errType := ""}}
 		{{$codeGetter := ""}}
 		{{$.Importer.Import "strings"}}
@@ -30,11 +30,15 @@ func (e *UniqueConstraintError) Is(target error) bool {
 			{{$.Importer.Import $.DriverName}}
 			{{$errType = "sqlite3.Error"}}
 			{{$codeGetter = "ExtendedCode"}}
+		{{else if eq $.DriverName "github.com/ncruces/go-sqlite3"}}
+			{{$.Importer.Import $.DriverName}}
+			{{$errType = "*sqlite3.Error"}}
+			{{$codeGetter = "ExtendedCode()"}}
 		{{else}}
 			panic("Unsupported driver {{$.DriverName}} for UniqueConstraintError detection")
 		{{end}}
-    err, ok := target.({{$errType}})
-    if !ok {
+    var err {{$errType}}
+    if !errors.As(target, &err) {
       return false
     }
 

--- a/test/gen/templates/database.bob_test.go.tpl
+++ b/test/gen/templates/database.bob_test.go.tpl
@@ -25,6 +25,12 @@
   {{$.Importer.Import "strings"}}
 	{{$sqlDriverName = "sqlite3_extended"}}
 	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
+{{ else if eq $.DriverName "github.com/ncruces/go-sqlite3" }}
+	{{$.Importer.Import $.DriverName }}
+  {{$.Importer.Import "_" "github.com/ncruces/go-sqlite3/driver" }}
+  {{$.Importer.Import "_" "github.com/ncruces/go-sqlite3/embed" }}
+	{{$sqlDriverName = "sqlite3"}}
+	{{$dsnEnvVarName = "SQLITE_TEST_DSN"}}
 {{ else if eq $.DriverName  "github.com/tursodatabase/libsql-client-go/libsql" }}
 	{{$.Importer.Import "_" $.DriverName }}
 	{{$sqlDriverName = "libsql"}}
@@ -69,6 +75,11 @@ func TestMain(m *testing.M) {
         }
         return nil
       },
+    })
+  {{ else if eq $.DriverName  "github.com/ncruces/go-sqlite3" }}
+    sqlite3.AutoExtension(func(c *sqlite3.Conn) error {
+      queries := os.Getenv("BOB_SQLITE_ATTACH_QUERIES")
+      return c.Exec(queries)
     })
   {{end}}
 


### PR DESCRIPTION
As discussed on Reddit, and as a first approximation, this is what should be required to support my driver.

What's the simplest, but still realistic, way to test this? I ask because my driver has a few peculiarities, and I'd like to be sure I'm not messing anything up.

The one that matters the most here, is that the driver is split into 3 packages:
- [`github.com/ncruces/go-sqlite3`](https://pkg.go.dev/github.com/ncruces/go-sqlite3) wraps the [C SQLite API](https://sqlite.org/cintro.html) - this is needed for the `sqlite3.Error` type
- [`github.com/ncruces/go-sqlite3/driver`](https://pkg.go.dev/github.com/ncruces/go-sqlite3/driver) registers the `database/sql` driver
- [`github.com/ncruces/go-sqlite3/embed`](https://pkg.go.dev/github.com/ncruces/go-sqlite3/embed) embeds/links SQLite into your application

You don't need to import `driver` or `embed` everywhere in your project, and in fact I'd argue if you're creating (or in this case generating) a library you _shouldn't_ import them at all.

The reason is that, e.g., for the `embed` package in particular, you may decide to embed/link a modified SQLite build. I have an [alternative package](https://github.com/ncruces/go-sqlite3/tree/main/embed/bcw2#embeddable-wasm-build-of-sqlite) that includes "experimental" SQLite features, Alex [publishes](https://alexgarcia.xyz/sqlite-vec/go.html#ncruces) another one that supports vector search, etc.

It's up to the final end user which build of SQLite they want to link with, and they can decide by importing the correct package in the `main.go` of their application (or some other place where it makes sense).

I'm sorry if this over complicates things.