### PR TITLE
Allow changing alias of TableRef with As method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the `As` method to `clause.TableRef`, which sets the alias and return a copy of the struct.
+
 ### Changed
 
 - `Mod` is now a separate field in `orm.ModQuery` and `orm.ModExecQuery`.

--- a/clause/from.go
+++ b/clause/from.go
@@ -87,6 +87,13 @@ func (f *TableRef) AppendIndexHint(i IndexHint) {
 	f.IndexHints = append(f.IndexHints, i)
 }
 
+func (f TableRef) As(alias string, columns ...string) TableRef {
+	f.Alias = alias
+	f.Columns = append(f.Columns, columns...)
+
+	return f
+}
+
 func (f TableRef) WriteSQL(ctx context.Context, w io.Writer, d bob.Dialect, start int) ([]any, error) {
 	if f.Only {
 		w.Write([]byte("ONLY "))


### PR DESCRIPTION
Having method `As()` as it previously existed for type `clause.From` allows creating a `clause.TableRef` struct and reusing it within a query with different aliases.

Currently, what we have to do is make a copy of `clause.TableRef` variable, modify alias and only then we can reference it within a query.