### PR TITLE
Add FromExisting<Rel> and WithExisting<Rel> to factory

### DIFF
--- a/gen/templates/factory/bobfactory_main.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_main.bob.go.tpl
@@ -1,4 +1,5 @@
 {{$.Importer.Import "context"}}
+{{$.Importer.Import "models" (index $.OutputPackages "models") }}
 
 type Factory struct {
     {{range $table := .Tables}}
@@ -23,6 +24,19 @@ func (f *Factory) New{{$tAlias.UpSingular}}(ctx context.Context, mods ...{{$tAli
   {{$tAlias.UpSingular}}ModSlice(mods).Apply(ctx, o)
 
 	return o
+}
+
+func (f *Factory) FromExisting{{$tAlias.UpSingular}}(m models.{{$tAlias.UpSingular}}) *{{$tAlias.UpSingular}}Template {
+	o := &{{$tAlias.UpSingular}}Template{}
+
+  {{range $column := $table.Columns -}}
+  {{$colAlias := $tAlias.Column $column.Name -}}
+  {{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+        o.{{$colAlias}} = func() {{$colTyp}} { return m.{{$colAlias}} }
+  {{end}}
+  o.alreadyPersisted = true
+
+  return o
 }
 
 {{end}}

--- a/gen/templates/factory/table/01_types.go.tpl
+++ b/gen/templates/factory/table/01_types.go.tpl
@@ -36,6 +36,8 @@ type {{$tAlias.UpSingular}}Template struct {
         r {{$tAlias.DownSingular}}R
     {{- end}}
     f *Factory
+
+    alreadyPersisted bool
 }
 
 {{if $.Relationships.Get $table.Key -}}

--- a/gen/templates/factory/table/03_create.go.tpl
+++ b/gen/templates/factory/table/03_create.go.tpl
@@ -110,10 +110,17 @@ func (o *{{$tAlias.UpSingular}}Template) Create(ctx context.Context, exec bob.Ex
       {{$tAlias.UpSingular}}Mods.WithNew{{$relAlias}}().Apply(ctx, o)
 		}
 
-    rel{{$index}}, err := o.r.{{$relAlias}}.o.Create(ctx, exec)
-    if err != nil {
-      return nil, err
-    }
+		var rel{{$index}} *models.{{$ftable.UpSingular}}
+
+		if o.r.{{$relAlias}}.o.alreadyPersisted {
+			rel{{$index}} = o.r.{{$relAlias}}.o.Build()
+		} else {
+			rel{{$index}}, err = o.r.{{$relAlias}}.o.Create(ctx, exec)
+			if err != nil {
+				return nil, err
+			}
+		}
+	
 
 		{{range $rel.ValuedSides -}}
 			{{- if ne .TableName $table.Key}}{{continue}}{{end -}}

--- a/gen/templates/factory/table/12_rel_to_one_mods.go.tpl
+++ b/gen/templates/factory/table/12_rel_to_one_mods.go.tpl
@@ -28,6 +28,15 @@ func (m {{$tAlias.DownSingular}}Mods) WithParentsCascading() {{$tAlias.UpSingula
 {{- $ftable := $.Aliases.Table .Foreign -}}
 {{- $relAlias := $tAlias.Relationship .Name -}}
 
+func (m {{$tAlias.DownSingular}}Mods) WithExisting{{$relAlias}}(em models.{{$ftable.UpSingular}}) {{$tAlias.UpSingular}}Mod {
+	return {{$tAlias.UpSingular}}ModFunc(func (ctx context.Context, o *{{$tAlias.UpSingular}}Template) {
+		o.r.{{$relAlias}} = &{{$tAlias.DownSingular}}R{{$relAlias}}R{
+			o: o.f.FromExisting{{$ftable.UpSingular}}(em),
+			{{$.Tables.RelDependenciesTypSet $.Aliases .}}
+		}
+	})
+}
+
 func (m {{$tAlias.DownSingular}}Mods) With{{$relAlias}}({{$.Tables.RelDependencies $.Aliases . "" "Template"}} rel *{{$ftable.UpSingular}}Template) {{$tAlias.UpSingular}}Mod {
 	return {{$tAlias.UpSingular}}ModFunc(func (ctx context.Context, o *{{$tAlias.UpSingular}}Template) {
 		o.r.{{$relAlias}} = &{{$tAlias.DownSingular}}R{{$relAlias}}R{


### PR DESCRIPTION
### Use case

I'm trying to setup a more complex sample/test database using factories. I already have persisted records for some of the schemas (using earlier calls to factories), and now I'm trying to create new records that refer to the existing entries instead of creating new records.

For example think about a forum: it has users and threads. There are already users in the database, and now we want to create threads with the creator set to a random existing user.

Something like this works if the relation is not required:

```
findRandomUser := func() int32 {
		res, _ := models.Users.Query(sm.Columns("id"), sm.OrderBy("random()")).One(ctx, bobdb)
		return res.ID
	}
	threadTemplate := factoryCtx.NewThread(ctx, factory.ThreadMods.CreatorUserIDFunc(findRandomUser))

```

But it doesn't work with required relations, because in that case the factory always creates a new relation.

This PR basically unifies the behavior for the two cases.

### Alternative idea

I was also thinking about proposing a new method for relations, `WithExisting<RelationName>`. But the problem with this is:
* it needs a way to properly select which record(s) to use (always using random doesn't seem right)
* it would leave the inconsistency I mentioned above

So instead I'm proposing this patch to unify the behavior.




What do you think?

(`m.R.relation` won't be set in this case - but that's already the case for optional relations when done this way)


