### PR TITLE
Use parentheses for combined queries

### DIFF
--- a/clause/combine.go
+++ b/clause/combine.go
@@ -47,10 +47,14 @@ func (s Combine) WriteSQL(ctx context.Context, w io.Writer, d bob.Dialect, start
 		w.Write([]byte(" "))
 	}
 
+	w.Write([]byte("("))
+
 	args, err := s.Query.WriteQuery(ctx, w, start)
 	if err != nil {
 		return nil, err
 	}
+
+	w.Write([]byte(")"))
 
 	return args, nil
 }

--- a/dialect/mysql/select_test.go
+++ b/dialect/mysql/select_test.go
@@ -115,6 +115,24 @@ func TestSelect(t *testing.T) {
 			),
 			ExpectedSQL: "SELECT id, name FROM users ORDER BY name COLLATE `utf8mb4_bg_0900_as_cs` ASC",
 		},
+		"union with combined args": {
+			Query: mysql.Select(
+				sm.Columns("id", "name"),
+				sm.From("users"),
+				sm.Limit(100),
+				sm.OrderBy("id"),
+				sm.Union(mysql.Select(
+					sm.Columns("id", "name"),
+					sm.From("admins"),
+					sm.Limit(10),
+					sm.OrderBy("id"),
+				)),
+				sm.OrderCombined("id"),
+				sm.LimitCombined(1000),
+			),
+			ExpectedSQL: `(SELECT id, name FROM users ORDER BY id LIMIT 100) UNION (SELECT id, name FROM admins ORDER BY id LIMIT 10)
+ORDER BY id LIMIT 1000`,
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -217,6 +217,12 @@ func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
 	})
 }
 
+type OrderCombined OrderBy[*SelectQuery]
+
+func (o OrderCombined) Apply(q *SelectQuery) {
+	q.CombinedOrder.AppendOrder(o())
+}
+
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef
 
 func (s OrderBy[Q]) Apply(q Q) {

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -252,6 +252,39 @@ WINDOW w AS (PARTITION BY depname ORDER BY salary)`,
 			),
 			ExpectedSQL: `SELECT id, name FROM users UNION select id, name FROM admins UNION select id, name FROM mods`,
 		},
+		"Union with combined args": {
+			Query: psql.Select(
+				sm.Columns("id", "name"),
+				sm.From("users"),
+				sm.Limit(100),
+				sm.OrderBy("id"),
+				sm.Union(psql.Select(
+					sm.Columns("id", "name"),
+					sm.From("admins"),
+					sm.Limit(10),
+					sm.OrderBy("id"),
+				)),
+				sm.OrderCombined("id"),
+				sm.LimitCombined(1000),
+			),
+			ExpectedSQL: `(SELECT id, name FROM users ORDER BY id LIMIT 100) UNION (SELECT id, name FROM admins ORDER BY id LIMIT 10)
+ORDER BY id LIMIT 1000`,
+		},
+		"Union with uncombined args": {
+			Query: psql.Select(
+				sm.Columns("id", "name"),
+				sm.From("users"),
+				sm.Limit(1),
+				sm.OrderBy("id"),
+				sm.Union(psql.Select(
+					sm.Columns("id", "name"),
+					sm.From("admins"),
+					sm.Limit(1),
+					sm.OrderBy("id"),
+				)),
+			),
+			ExpectedSQL: `(SELECT id, name FROM users ORDER BY id LIMIT 1) UNION (SELECT id, name FROM admins ORDER BY id LIMIT 1)`,
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -207,3 +207,33 @@ func ForKeyShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 		}
 	})
 }
+
+// To apply order to the result of a UNION, INTERSECT, or EXCEPT query
+func OrderCombined(e any) dialect.OrderCombined {
+	return dialect.OrderCombined(func() clause.OrderDef {
+		return clause.OrderDef{
+			Expression: e,
+		}
+	})
+}
+
+// To apply limit to the result of a UNION, INTERSECT, or EXCEPT query
+func LimitCombined(count int64) bob.Mod[*dialect.SelectQuery] {
+	return bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
+		q.CombinedLimit.SetLimit(count)
+	})
+}
+
+// To apply offset to the result of a UNION, INTERSECT, or EXCEPT query
+func OffsetCombined(count int64) bob.Mod[*dialect.SelectQuery] {
+	return bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
+		q.CombinedOffset.SetOffset(count)
+	})
+}
+
+// To apply fetch to the result of a UNION, INTERSECT, or EXCEPT query
+func FetchCombined(fetch clause.Fetch) bob.Mod[*dialect.SelectQuery] {
+	return bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
+		q.CombinedFetch.SetFetch(fetch)
+	})
+}


### PR DESCRIPTION
- Always use parens for a combined query.
- Added support for psql combined args for combined queries. 
- Use parens for psql selects that use combined args.