### PR TITLE
fix(gen-mysql): handle table names with backticks

### DIFF
--- a/gen/bobgen-mysql/driver/mysql.golden.json
+++ b/gen/bobgen-mysql/driver/mysql.golden.json
@@ -2940,7 +2940,57 @@
 			"comment": ""
 		}
 	],
-	"query_folders": [],
+	"query_folders": [
+		{
+			"path": "./queries",
+			"files": [
+				{
+					"path": "queries/users.sql",
+					"queries": [
+						{
+							"type": 1,
+							"name": "SelectUsers",
+							"raw": "SELECT `users`.`id` FROM `users` WHERE `id` IN (?)",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "id",
+									"db_name": "id",
+									"nullable": false,
+									"type": "int32",
+									"type_limits": []
+								}
+							],
+							"args": [
+								{
+									"col": {
+										"name": "id",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": []
+									},
+									"children": null,
+									"positions": [
+										[
+											48,
+											49
+										]
+									],
+									"can_be_multiple": true
+								}
+							],
+							"mods": "q.AppendSelect(EXPR.subExpr(7, 19))\nq.SetTable(EXPR.subExpr(25, 32))\nq.AppendWhere(EXPR.subExpr(39, 50))\n"
+						}
+					]
+				}
+			]
+		}
+	],
 	"enums": [
 		{
 			"Type": "TypeMonstersEnumNullable",

--- a/gen/bobgen-mysql/driver/mysql_test.go
+++ b/gen/bobgen-mysql/driver/mysql_test.go
@@ -138,9 +138,10 @@ func TestDriver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testConfig := Config{
 				Config: helpers.Config{
-					Dsn:    dsn,
-					Only:   tt.only,
-					Except: tt.except,
+					Dsn:     dsn,
+					Only:    tt.only,
+					Except:  tt.except,
+					Queries: []string{"./queries"},
 				},
 			}
 

--- a/gen/bobgen-mysql/driver/parser/types.go
+++ b/gen/bobgen-mysql/driver/parser/types.go
@@ -111,5 +111,10 @@ func getSimpleIDName(ctx mysqlparser.ISimpleIdContext) string {
 		return ""
 	}
 
+	// certain types of simpleId can include REVERSE_QUOTE_IDs so trimming may still be necessary
+	if ctx.GetStart().GetTokenType() == mysqlparser.MySqlParserREVERSE_QUOTE_ID {
+		return ctx.GetText()[1 : len(ctx.GetText())-1]
+	}
+
 	return ctx.GetText()
 }

--- a/gen/bobgen-mysql/driver/queries/users.sql
+++ b/gen/bobgen-mysql/driver/queries/users.sql
@@ -1,0 +1,3 @@
+-- SelectUsers
+SELECT * FROM `users` WHERE id IN (?)
+;


### PR DESCRIPTION
Currently escaping table names with backticks is broken for mysql due to SimpleIDs being able to include backticks through the engineName rule.

This commit updates getSimpleIDName to trim backticks when the start token is a backtick and adds queries tests to bobgen-mysql.

This is a quick fix for the secondary issue identified in https://github.com/stephenafamo/bob/issues/491 without a proper grammar update.