### PR TITLE
Update changelog with previous fix and fix mysql tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix transformer for single result queries.
 - Properly handle indexes where the sorting order can be null.
 - Check for nullability when loading relationships.
-- Handle table names quoted with backticks in mysql query parser.
+- Handle table names quoted with backticks in mysql query parser. (thanks @luiscleto)
 
 ## [v0.38.0] - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix transformer for single result queries.
 - Properly handle indexes where the sorting order can be null.
 - Check for nullability when loading relationships.
+- Handle table names quoted with backticks in mysql query parser.
 
 ## [v0.38.0] - 2025-06-04
 

--- a/gen/bobgen-mysql/driver/mysql.golden.json
+++ b/gen/bobgen-mysql/driver/mysql.golden.json
@@ -2985,6 +2985,45 @@
 								}
 							],
 							"mods": "q.AppendSelect(EXPR.subExpr(7, 19))\nq.SetTable(EXPR.subExpr(25, 32))\nq.AppendWhere(EXPR.subExpr(39, 50))\n"
+						},
+						{
+							"type": 1,
+							"name": "SelectUsersCount",
+							"raw": "SELECT COUNT(`id`)  AS `users_count`\nFROM `users`\nWHERE `id` IN (?)",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "users_count",
+									"db_name": "users_count",
+									"nullable": false,
+									"type": "int",
+									"type_limits": null
+								}
+							],
+							"args": [
+								{
+									"col": {
+										"name": "id",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": []
+									},
+									"children": null,
+									"positions": [
+										[
+											65,
+											66
+										]
+									],
+									"can_be_multiple": true
+								}
+							],
+							"mods": "q.AppendSelect(EXPR.subExpr(7, 36))\nq.SetTable(EXPR.subExpr(42, 49))\nq.AppendWhere(EXPR.subExpr(56, 67))\n"
 						}
 					]
 				}

--- a/gen/bobgen-mysql/driver/mysql_test.go
+++ b/gen/bobgen-mysql/driver/mysql_test.go
@@ -71,10 +71,12 @@ func TestDriver(t *testing.T) {
 		name       string
 		only       map[string][]string
 		except     map[string][]string
+		queries    []string
 		goldenJson string
 	}{
 		{
 			name:       "default",
+			queries:    []string{"./queries"},
 			goldenJson: "mysql.golden.json",
 		},
 		{
@@ -141,7 +143,7 @@ func TestDriver(t *testing.T) {
 					Dsn:     dsn,
 					Only:    tt.only,
 					Except:  tt.except,
-					Queries: []string{"./queries"},
+					Queries: tt.queries,
 				},
 			}
 

--- a/gen/bobgen-mysql/driver/queries/users.sql
+++ b/gen/bobgen-mysql/driver/queries/users.sql
@@ -1,3 +1,9 @@
 -- SelectUsers
 SELECT * FROM `users` WHERE id IN (?)
 ;
+
+-- SelectUsersCount
+SELECT count(id) /*:int*/ as users_count
+FROM `users`
+WHERE id IN (?)
+;


### PR DESCRIPTION
Previous contribution broke tests with include/exclude tables.
This PR adds a `queries` params to tests and includes it only in the base test with all tables.
This also adds another test with a type annotation in a query to be updated if/when behavior changes in case this is not the intended behavior

Also updates changelog with previous fix for backticks around table names in mysql queries