### PR TITLE
fix(gen): Fix issue due to duplicate titlecasing column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed issue with redundant title casing column names in query templates. (thanks @luiscleto)
+
 ## [v0.39.0] - 2025-07-28
 
 ### Added

--- a/gen/templates/queries/query/01_query.go.tpl
+++ b/gen/templates/queries/query/01_query.go.tpl
@@ -98,7 +98,7 @@ func {{$upperName}} ({{join ", " $args}}) *{{$upperName}}Query {
             return func(row *scan.Row) (any, error) {
                 var t {{$queryResultTypeOne}}
                 {{range $colIndex, $col := $query.Columns.WithNames -}}
-                  row.ScheduleScanByIndex({{$colIndex}}, &t.{{titleCase $col.Name}})
+                  row.ScheduleScanByIndex({{$colIndex}}, &t.{{$col.Name}})
                 {{end -}}
                 return &t, nil
               }, func(v any) ({{$queryResultTypeOne}}, error) {


### PR DESCRIPTION
Should fix https://github.com/stephenafamo/bob/issues/517 (tested locally on my problematic queries, having issues running mysql gen suite + not sure the best way to add a testcase here).

This makes the $col.Name consistent in the struct declaration and scanner function. Title case is already applied once so applying it a second time can break some column names (eg: is_ex -> IsEx -> ISEX)