### PR TITLE
fix(gen): Fix MySQL setter template invalid expression with pointer-based type systems

### DIFF
--- a/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
+++ b/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
@@ -32,10 +32,11 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     bob.ExpressionFunc(func(ctx context.Context, w io.Writer, d bob.Dialect, start int) ([]any, error){
         {{$colAlias := $tAlias.Column $column.Name -}}
         {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-        if !{{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
+        if {{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
+          return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
+        } else {
           return {{$.Dialect}}.Raw("DEFAULT").WriteSQL(ctx, w, d, start)
         }
-        return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
     }),
   {{- end}})
 }

--- a/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
+++ b/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
@@ -32,11 +32,10 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     bob.ExpressionFunc(func(ctx context.Context, w io.Writer, d bob.Dialect, start int) ([]any, error){
         {{$colAlias := $tAlias.Column $column.Name -}}
         {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-        if {{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
-          return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
-        } else {
+        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
           return {{$.Dialect}}.Raw("DEFAULT").WriteSQL(ctx, w, d, start)
         }
+        return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
     }),
   {{- end}})
 }


### PR DESCRIPTION
Fixes https://github.com/stephenafamo/bob/issues/519

This PR fixes a compilation error in MySQL setter generation when using `github.com/aarondl/opt/null` or `database/sql` type systems.

The previous pattern generated invalid expressions with pointer-based type systems:
- `github.com/aarondl/opt`: `if !s.ID.IsValue()` ✓ (works)
- `github.com/aarondl/opt/null`: `if !s.ID != nil` ✗ (compile error) 
- `database/sql`: `if !s.ID != nil` ✗ (compile error)

The `!s.ID != nil` pattern was interpreted as `(!s.ID) != nil` causing compilation errors.

This change wraps the ValidExpr with parentheses to fix the operator precedence issue while maintaining the existing template structure.