### PR TITLE
SQLite INTEGER PRIMARY KEY as int64

### DIFF
--- a/gen/bobgen-sqlite/driver/exclude-tables.golden.json
+++ b/gen/bobgen-sqlite/driver/exclude-tables.golden.json
@@ -1,3281 +1,3179 @@
 {
-	"tables": [
-		{
-			"key": "autoinckeywordtest",
-			"schema": "",
-			"name": "autoinckeywordtest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "something",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "another",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_2",
-					"columns": [
-						{
-							"name": "something",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "another",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_1",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinckeywordtest_0",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_2",
-						"columns": [
-							"something",
-							"another"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_1",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "autoinctest",
-			"schema": "",
-			"name": "autoinctest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinctest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinctest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinctest_0",
-						"columns": [
-							"id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_baz",
-			"schema": "",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_qux",
-			"schema": "",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_qux",
-			"schema": "",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "has_generated_columns",
-			"schema": "",
-			"name": "has_generated_columns",
-			"columns": [
-				{
-					"name": "a",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "c",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "d",
-					"db_type": "INT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "e",
-					"db_type": "TEXT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						{
-							"name": "a",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						"a"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.as_generated_columns",
-			"schema": "one",
-			"name": "as_generated_columns",
-			"columns": [
-				{
-					"name": "a",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "c",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "d",
-					"db_type": "INT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "e",
-					"db_type": "TEXT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_as_generated_columns",
-					"columns": [
-						{
-							"name": "a",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_as_generated_columns",
-					"columns": [
-						"a"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.autoinckeywordtest",
-			"schema": "one",
-			"name": "autoinckeywordtest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INTEGER",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_autoinckeywordtest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_autoinckeywordtest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.autoinctest",
-			"schema": "one",
-			"name": "autoinctest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_autoinctest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_autoinctest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_baz",
-			"schema": "one",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_qux",
-			"schema": "one",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_qux",
-			"schema": "one",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.sponsors",
-			"schema": "one",
-			"name": "sponsors",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_sponsors_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_sponsors",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.tags",
-			"schema": "one",
-			"name": "tags",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_tags_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_tags",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.user_videos",
-			"schema": "one",
-			"name": "user_videos",
-			"columns": [
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.users",
-			"schema": "one",
-			"name": "users",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_users_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_users",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.video_tags",
-			"schema": "one",
-			"name": "video_tags",
-			"columns": [
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "tag_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_video_tags_1",
-					"columns": [
-						{
-							"name": "video_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "tag_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_video_tags",
-					"columns": [
-						"video_id",
-						"tag_id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_video_tags_0",
-						"columns": [
-							"tag_id"
-						],
-						"foreign_table": "one.tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_video_tags_1",
-						"columns": [
-							"video_id"
-						],
-						"foreign_table": "one.videos",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.videos",
-			"schema": "one",
-			"name": "videos",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_2",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_videos_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_videos",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_videos_0",
-						"columns": [
-							"sponsor_id"
-						],
-						"foreign_table": "one.sponsors",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_videos_1",
-						"columns": [
-							"user_id"
-						],
-						"foreign_table": "one.users",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_videos_2",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "sponsors",
-			"schema": "",
-			"name": "sponsors",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_sponsors_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_sponsors",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "tags",
-			"schema": "",
-			"name": "tags",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_tags_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_tags",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "test_index_expressions",
-			"schema": "",
-			"name": "test_index_expressions",
-			"columns": [
-				{
-					"name": "col1",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col2",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col3",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "c",
-					"name": "idx6",
-					"columns": [
-						{
-							"name": "POW(col3, 2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx5",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": true,
-							"is_expression": false
-						},
-						{
-							"name": "col2",
-							"desc": true,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx4",
-					"columns": [
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx3",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "(col2 + col3)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx2",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						},
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx1",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "type_monsters",
-			"schema": "",
-			"name": "type_monsters",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_three",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bool_zero",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_one",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_two",
-					"db_type": "BOOL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_three",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_four",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_five",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_six",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_zero",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_one",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_two",
-					"db_type": "VARCHAR(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_three",
-					"db_type": "VARCHAR(1)",
-					"default": "'a'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_four",
-					"db_type": "VARCHAR(1)",
-					"default": "'b'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_five",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_six",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_seven",
-					"db_type": "VARCHAR(1000)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eight",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_nine",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_ten",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eleven",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_zero",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_one",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_two",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_three",
-					"db_type": "BIGINT",
-					"default": "111111",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_four",
-					"db_type": "BIGINT",
-					"default": "222222",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_five",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_six",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "int_zero",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_one",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_three",
-					"db_type": "INT",
-					"default": "333333",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_four",
-					"db_type": "INT",
-					"default": "444444",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_five",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_six",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "float_zero",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_one",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_two",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_three",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_four",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_five",
-					"db_type": "FLOAT(2,1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_six",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_seven",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_eight",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_nine",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_zero",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_one",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_two",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_three",
-					"db_type": "BINARY",
-					"default": "'a'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_four",
-					"db_type": "BINARY",
-					"default": "'b'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_five",
-					"db_type": "BINARY(100)",
-					"default": "'abcdefghabcdefghabcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_six",
-					"db_type": "BINARY(100)",
-					"default": "'hgfedcbahgfedcbahgfedcba'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_seven",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_eight",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "time_zero",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_one",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_two",
-					"db_type": "TIMESTAMP",
-					"default": "null",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_three",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_five",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_nine",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_eleven",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_twelve",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_fifteen",
-					"db_type": "DATE",
-					"default": "'1999-01-08'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "json_null",
-					"db_type": "JSON",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "json_nnull",
-					"db_type": "JSON",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_null",
-					"db_type": "TINYINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_nnull",
-					"db_type": "TINYINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_null",
-					"db_type": "TINYINT(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_nnull",
-					"db_type": "TINYINT(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_null",
-					"db_type": "TINYINT(2)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_nnull",
-					"db_type": "TINYINT(2)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_null",
-					"db_type": "SMALLINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_nnull",
-					"db_type": "SMALLINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_null",
-					"db_type": "MEDIUMINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_nnull",
-					"db_type": "MEDIUMINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_null",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_nnull",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "float_null",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_nnull",
-					"db_type": "FLOAT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "double_null",
-					"db_type": "DOUBLE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "double_nnull",
-					"db_type": "DOUBLE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_null",
-					"db_type": "DOUBLE PRECISION",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_nnull",
-					"db_type": "DOUBLE PRECISION",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "real_null",
-					"db_type": "REAL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "real_nnull",
-					"db_type": "REAL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_null",
-					"db_type": "BOOLEAN",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_nnull",
-					"db_type": "BOOLEAN",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "date_null",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "date_nnull",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_null",
-					"db_type": "DATETIME",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_nnull",
-					"db_type": "DATETIME",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_null",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_nnull",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "binary_null",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "binary_nnull",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_null",
-					"db_type": "VARBINARY(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_nnull",
-					"db_type": "VARBINARY(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_null",
-					"db_type": "TINYBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_nnull",
-					"db_type": "TINYBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "blob_null",
-					"db_type": "BLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "blob_nnull",
-					"db_type": "BLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_null",
-					"db_type": "MEDIUMBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_nnull",
-					"db_type": "MEDIUMBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_null",
-					"db_type": "LONGBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_nnull",
-					"db_type": "LONGBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_null",
-					"db_type": "VARCHAR(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_nnull",
-					"db_type": "VARCHAR(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_null",
-					"db_type": "CHAR",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_nnull",
-					"db_type": "CHAR",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_null",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_nnull",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_type_monsters_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_type_monsters",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "user_videos",
-			"schema": "",
-			"name": "user_videos",
-			"columns": [
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "users",
-			"schema": "",
-			"name": "users",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_users_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_users",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "video_tags",
-			"schema": "",
-			"name": "video_tags",
-			"columns": [
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "tag_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_video_tags_1",
-					"columns": [
-						{
-							"name": "video_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "tag_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_video_tags",
-					"columns": [
-						"video_id",
-						"tag_id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_video_tags_0",
-						"columns": [
-							"tag_id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_video_tags_1",
-						"columns": [
-							"video_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "videos",
-			"schema": "",
-			"name": "videos",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_3",
-					"columns": [
-						{
-							"name": "user_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_2",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_videos_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_videos",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_videos_0",
-						"columns": [
-							"sponsor_id"
-						],
-						"foreign_table": "sponsors",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_videos_1",
-						"columns": [
-							"user_id"
-						],
-						"foreign_table": "users",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_videos_3",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_videos_2",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "autoinckeywordtest",
+      "schema": "",
+      "name": "autoinckeywordtest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "something",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "another",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinckeywordtest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_2",
+          "columns": [
+            {
+              "name": "something",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "another",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_1",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinckeywordtest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinckeywordtest_0",
+            "columns": ["user_id", "sponsor_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_2",
+            "columns": ["something", "another"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_1",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "autoinctest",
+      "schema": "",
+      "name": "autoinctest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinctest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinctest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinctest_0",
+            "columns": ["id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_baz",
+      "schema": "",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_qux",
+      "schema": "",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_qux",
+      "schema": "",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "has_generated_columns",
+      "schema": "",
+      "name": "has_generated_columns",
+      "columns": [
+        {
+          "name": "a",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "c",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "d",
+          "db_type": "INT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "e",
+          "db_type": "TEXT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_has_generated_columns",
+          "columns": [
+            {
+              "name": "a",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_has_generated_columns",
+          "columns": ["a"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.as_generated_columns",
+      "schema": "one",
+      "name": "as_generated_columns",
+      "columns": [
+        {
+          "name": "a",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "c",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "d",
+          "db_type": "INT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "e",
+          "db_type": "TEXT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_as_generated_columns",
+          "columns": [
+            {
+              "name": "a",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_as_generated_columns",
+          "columns": ["a"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.autoinckeywordtest",
+      "schema": "one",
+      "name": "autoinckeywordtest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INTEGER",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_autoinckeywordtest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_autoinckeywordtest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.autoinctest",
+      "schema": "one",
+      "name": "autoinctest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_autoinctest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_autoinctest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_baz",
+      "schema": "one",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "default": "auto_increment",
+          "db_type": "BIGINT",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_qux",
+      "schema": "one",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_qux",
+      "schema": "one",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.sponsors",
+      "schema": "one",
+      "name": "sponsors",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_sponsors_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_sponsors",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.tags",
+      "schema": "one",
+      "name": "tags",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_tags_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_tags",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.user_videos",
+      "schema": "one",
+      "name": "user_videos",
+      "columns": [
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.users",
+      "schema": "one",
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_users_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_users",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.video_tags",
+      "schema": "one",
+      "name": "video_tags",
+      "columns": [
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "tag_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_video_tags_1",
+          "columns": [
+            {
+              "name": "video_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "tag_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_video_tags",
+          "columns": ["video_id", "tag_id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_video_tags_0",
+            "columns": ["tag_id"],
+            "foreign_table": "one.tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_video_tags_1",
+            "columns": ["video_id"],
+            "foreign_table": "one.videos",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.videos",
+      "schema": "one",
+      "name": "videos",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_2",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_videos_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_videos",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_videos_0",
+            "columns": ["sponsor_id"],
+            "foreign_table": "one.sponsors",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_videos_1",
+            "columns": ["user_id"],
+            "foreign_table": "one.users",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_videos_2",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "sponsors",
+      "schema": "",
+      "name": "sponsors",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_sponsors_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_sponsors",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "tags",
+      "schema": "",
+      "name": "tags",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_tags_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_tags",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "test_index_expressions",
+      "schema": "",
+      "name": "test_index_expressions",
+      "columns": [
+        {
+          "name": "col1",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col2",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col3",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "c",
+          "name": "idx6",
+          "columns": [
+            {
+              "name": "POW(col3, 2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx5",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": true,
+              "is_expression": false
+            },
+            {
+              "name": "col2",
+              "desc": true,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx4",
+          "columns": [
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx3",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "(col2 + col3)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx2",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            },
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx1",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "type_monsters",
+      "schema": "",
+      "name": "type_monsters",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_three",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bool_zero",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_one",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_two",
+          "db_type": "BOOL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_three",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_four",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_five",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_six",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_zero",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_one",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_two",
+          "db_type": "VARCHAR(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_three",
+          "db_type": "VARCHAR(1)",
+          "default": "'a'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_four",
+          "db_type": "VARCHAR(1)",
+          "default": "'b'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_five",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_six",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_seven",
+          "db_type": "VARCHAR(1000)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eight",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_nine",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_ten",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eleven",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_zero",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_one",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_two",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_three",
+          "db_type": "BIGINT",
+          "default": "111111",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_four",
+          "db_type": "BIGINT",
+          "default": "222222",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_five",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_six",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "int_zero",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_one",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_three",
+          "db_type": "INT",
+          "default": "333333",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_four",
+          "db_type": "INT",
+          "default": "444444",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_five",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_six",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "float_zero",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_one",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_two",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_three",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_four",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_five",
+          "db_type": "FLOAT(2,1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_six",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_seven",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_eight",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_nine",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_zero",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_one",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_two",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_three",
+          "db_type": "BINARY",
+          "default": "'a'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_four",
+          "db_type": "BINARY",
+          "default": "'b'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_five",
+          "db_type": "BINARY(100)",
+          "default": "'abcdefghabcdefghabcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_six",
+          "db_type": "BINARY(100)",
+          "default": "'hgfedcbahgfedcbahgfedcba'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_seven",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_eight",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "time_zero",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_one",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_two",
+          "db_type": "TIMESTAMP",
+          "default": "null",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_three",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_five",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_nine",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_eleven",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_twelve",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_fifteen",
+          "db_type": "DATE",
+          "default": "'1999-01-08'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "json_null",
+          "db_type": "JSON",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "json_nnull",
+          "db_type": "JSON",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_null",
+          "db_type": "TINYINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_nnull",
+          "db_type": "TINYINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_null",
+          "db_type": "TINYINT(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_nnull",
+          "db_type": "TINYINT(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_null",
+          "db_type": "TINYINT(2)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_nnull",
+          "db_type": "TINYINT(2)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_null",
+          "db_type": "SMALLINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_nnull",
+          "db_type": "SMALLINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_null",
+          "db_type": "MEDIUMINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_nnull",
+          "db_type": "MEDIUMINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_null",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_nnull",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "float_null",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_nnull",
+          "db_type": "FLOAT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "double_null",
+          "db_type": "DOUBLE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "double_nnull",
+          "db_type": "DOUBLE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_null",
+          "db_type": "DOUBLE PRECISION",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_nnull",
+          "db_type": "DOUBLE PRECISION",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "real_null",
+          "db_type": "REAL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "real_nnull",
+          "db_type": "REAL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_null",
+          "db_type": "BOOLEAN",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_nnull",
+          "db_type": "BOOLEAN",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "date_null",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "date_nnull",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_null",
+          "db_type": "DATETIME",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_nnull",
+          "db_type": "DATETIME",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_null",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_nnull",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "binary_null",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "binary_nnull",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_null",
+          "db_type": "VARBINARY(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_nnull",
+          "db_type": "VARBINARY(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_null",
+          "db_type": "TINYBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_nnull",
+          "db_type": "TINYBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "blob_null",
+          "db_type": "BLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "blob_nnull",
+          "db_type": "BLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_null",
+          "db_type": "MEDIUMBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_nnull",
+          "db_type": "MEDIUMBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_null",
+          "db_type": "LONGBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_nnull",
+          "db_type": "LONGBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_null",
+          "db_type": "VARCHAR(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_nnull",
+          "db_type": "VARCHAR(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_null",
+          "db_type": "CHAR",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_nnull",
+          "db_type": "CHAR",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_null",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_nnull",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_type_monsters_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_type_monsters",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "user_videos",
+      "schema": "",
+      "name": "user_videos",
+      "columns": [
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "users",
+      "schema": "",
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_users_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_users",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "video_tags",
+      "schema": "",
+      "name": "video_tags",
+      "columns": [
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "tag_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_video_tags_1",
+          "columns": [
+            {
+              "name": "video_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "tag_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_video_tags",
+          "columns": ["video_id", "tag_id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_video_tags_0",
+            "columns": ["tag_id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_video_tags_1",
+            "columns": ["video_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "videos",
+      "schema": "",
+      "name": "videos",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_3",
+          "columns": [
+            {
+              "name": "user_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_2",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_videos_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_videos",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_videos_0",
+            "columns": ["sponsor_id"],
+            "foreign_table": "sponsors",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_videos_1",
+            "columns": ["user_id"],
+            "foreign_table": "users",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_videos_3",
+            "columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_videos_2",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/driver/include-exclude-tables-mixed.golden.json
+++ b/gen/bobgen-sqlite/driver/include-exclude-tables-mixed.golden.json
@@ -1,260 +1,252 @@
 {
-	"tables": [
-		{
-			"key": "bar_baz",
-			"schema": "",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_qux",
-			"schema": "",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_baz",
-			"schema": "one",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_qux",
-			"schema": "one",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "bar_baz",
+      "schema": "",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_qux",
+      "schema": "",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_baz",
+      "schema": "one",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_qux",
+      "schema": "one",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/driver/include-exclude-tables-regex.golden.json
+++ b/gen/bobgen-sqlite/driver/include-exclude-tables-regex.golden.json
@@ -1,260 +1,252 @@
 {
-	"tables": [
-		{
-			"key": "bar_qux",
-			"schema": "",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_qux",
-			"schema": "",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_qux",
-			"schema": "one",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_qux",
-			"schema": "one",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "bar_qux",
+      "schema": "",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_qux",
+      "schema": "",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_qux",
+      "schema": "one",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_qux",
+      "schema": "one",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/driver/include-exclude-tables.golden.json
+++ b/gen/bobgen-sqlite/driver/include-exclude-tables.golden.json
@@ -1,134 +1,130 @@
 {
-	"tables": [
-		{
-			"key": "foo_baz",
-			"schema": "",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_baz",
-			"schema": "one",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "foo_baz",
+      "schema": "",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_baz",
+      "schema": "one",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/driver/include-tables.golden.json
+++ b/gen/bobgen-sqlite/driver/include-tables.golden.json
@@ -1,260 +1,252 @@
 {
-	"tables": [
-		{
-			"key": "foo_bar",
-			"schema": "",
-			"name": "foo_bar",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_bar",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_bar",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_baz",
-			"schema": "",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_bar",
-			"schema": "one",
-			"name": "foo_bar",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_bar",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_bar",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_baz",
-			"schema": "one",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "foo_bar",
+      "schema": "",
+      "name": "foo_bar",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_bar",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_bar",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_baz",
+      "schema": "",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_bar",
+      "schema": "one",
+      "name": "foo_bar",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_bar",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_bar",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_baz",
+      "schema": "one",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }

--- a/gen/bobgen-sqlite/driver/libsql.golden.json
+++ b/gen/bobgen-sqlite/driver/libsql.golden.json
@@ -1,2666 +1,2601 @@
 {
-	"tables": [
-		{
-			"key": "autoinckeywordtest",
-			"schema": "",
-			"name": "autoinckeywordtest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "something",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "another",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_2",
-					"columns": [
-						{
-							"name": "something",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "another",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_1",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinckeywordtest_0",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_2",
-						"columns": [
-							"something",
-							"another"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_1",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "autoinctest",
-			"schema": "",
-			"name": "autoinctest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinctest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinctest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinctest_0",
-						"columns": [
-							"id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_baz",
-			"schema": "",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_qux",
-			"schema": "",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_bar",
-			"schema": "",
-			"name": "foo_bar",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_bar",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_bar",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_baz",
-			"schema": "",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_qux",
-			"schema": "",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "has_generated_columns",
-			"schema": "",
-			"name": "has_generated_columns",
-			"columns": [
-				{
-					"name": "a",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "c",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "d",
-					"db_type": "INT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "e",
-					"db_type": "TEXT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						{
-							"name": "a",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						"a"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "sponsors",
-			"schema": "",
-			"name": "sponsors",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_sponsors_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_sponsors",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "tags",
-			"schema": "",
-			"name": "tags",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_tags_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_tags",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "test_index_expressions",
-			"schema": "",
-			"name": "test_index_expressions",
-			"columns": [
-				{
-					"name": "col1",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col2",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col3",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "c",
-					"name": "idx6",
-					"columns": [
-						{
-							"name": "POW(col3, 2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx5",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": true,
-							"is_expression": false
-						},
-						{
-							"name": "col2",
-							"desc": true,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx4",
-					"columns": [
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx3",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "(col2 + col3)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx2",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						},
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx1",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "type_monsters",
-			"schema": "",
-			"name": "type_monsters",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_three",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bool_zero",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_one",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_two",
-					"db_type": "BOOL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_three",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_four",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_five",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_six",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_zero",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_one",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_two",
-					"db_type": "VARCHAR(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_three",
-					"db_type": "VARCHAR(1)",
-					"default": "'a'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_four",
-					"db_type": "VARCHAR(1)",
-					"default": "'b'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_five",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_six",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_seven",
-					"db_type": "VARCHAR(1000)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eight",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_nine",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_ten",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eleven",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_zero",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_one",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_two",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_three",
-					"db_type": "BIGINT",
-					"default": "111111",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_four",
-					"db_type": "BIGINT",
-					"default": "222222",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_five",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_six",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "int_zero",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_one",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_three",
-					"db_type": "INT",
-					"default": "333333",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_four",
-					"db_type": "INT",
-					"default": "444444",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_five",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_six",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "float_zero",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_one",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_two",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_three",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_four",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_five",
-					"db_type": "FLOAT(2,1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_six",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_seven",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_eight",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_nine",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_zero",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_one",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_two",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_three",
-					"db_type": "BINARY",
-					"default": "'a'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_four",
-					"db_type": "BINARY",
-					"default": "'b'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_five",
-					"db_type": "BINARY(100)",
-					"default": "'abcdefghabcdefghabcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_six",
-					"db_type": "BINARY(100)",
-					"default": "'hgfedcbahgfedcbahgfedcba'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_seven",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_eight",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "time_zero",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_one",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_two",
-					"db_type": "TIMESTAMP",
-					"default": "null",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_three",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_five",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_nine",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_eleven",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_twelve",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_fifteen",
-					"db_type": "DATE",
-					"default": "'19990108'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_sixteen",
-					"db_type": "DATE",
-					"default": "'1999-01-08'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "json_null",
-					"db_type": "JSON",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "json_nnull",
-					"db_type": "JSON",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_null",
-					"db_type": "TINYINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_nnull",
-					"db_type": "TINYINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_null",
-					"db_type": "TINYINT(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_nnull",
-					"db_type": "TINYINT(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_null",
-					"db_type": "TINYINT(2)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_nnull",
-					"db_type": "TINYINT(2)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_null",
-					"db_type": "SMALLINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_nnull",
-					"db_type": "SMALLINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_null",
-					"db_type": "MEDIUMINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_nnull",
-					"db_type": "MEDIUMINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_null",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_nnull",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "float_null",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_nnull",
-					"db_type": "FLOAT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "double_null",
-					"db_type": "DOUBLE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "double_nnull",
-					"db_type": "DOUBLE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_null",
-					"db_type": "DOUBLE PRECISION",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_nnull",
-					"db_type": "DOUBLE PRECISION",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "real_null",
-					"db_type": "REAL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "real_nnull",
-					"db_type": "REAL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_null",
-					"db_type": "BOOLEAN",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_nnull",
-					"db_type": "BOOLEAN",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "date_null",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "date_nnull",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_null",
-					"db_type": "DATETIME",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_nnull",
-					"db_type": "DATETIME",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_null",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_nnull",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.Time",
-					"type_limits": null
-				},
-				{
-					"name": "binary_null",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "binary_nnull",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_null",
-					"db_type": "VARBINARY(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_nnull",
-					"db_type": "VARBINARY(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_null",
-					"db_type": "TINYBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_nnull",
-					"db_type": "TINYBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "blob_null",
-					"db_type": "BLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "blob_nnull",
-					"db_type": "BLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_null",
-					"db_type": "MEDIUMBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_nnull",
-					"db_type": "MEDIUMBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_null",
-					"db_type": "LONGBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_nnull",
-					"db_type": "LONGBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_null",
-					"db_type": "VARCHAR(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_nnull",
-					"db_type": "VARCHAR(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_null",
-					"db_type": "CHAR",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_nnull",
-					"db_type": "CHAR",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_null",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_nnull",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_type_monsters_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_type_monsters",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "user_videos",
-			"schema": "",
-			"name": "user_videos",
-			"columns": [
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "users",
-			"schema": "",
-			"name": "users",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_users_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_users",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "video_tags",
-			"schema": "",
-			"name": "video_tags",
-			"columns": [
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "tag_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_video_tags_1",
-					"columns": [
-						{
-							"name": "video_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "tag_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_video_tags",
-					"columns": [
-						"video_id",
-						"tag_id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_video_tags_0",
-						"columns": [
-							"tag_id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_video_tags_1",
-						"columns": [
-							"video_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "videos",
-			"schema": "",
-			"name": "videos",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_3",
-					"columns": [
-						{
-							"name": "user_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_2",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_videos_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_videos",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_videos_0",
-						"columns": [
-							"sponsor_id"
-						],
-						"foreign_table": "sponsors",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_videos_1",
-						"columns": [
-							"user_id"
-						],
-						"foreign_table": "users",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_videos_3",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_videos_2",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "github.com/tursodatabase/libsql-client-go/libsql"
+  "tables": [
+    {
+      "key": "autoinckeywordtest",
+      "schema": "",
+      "name": "autoinckeywordtest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "something",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "another",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinckeywordtest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_2",
+          "columns": [
+            {
+              "name": "something",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "another",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_1",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinckeywordtest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinckeywordtest_0",
+            "columns": ["user_id", "sponsor_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_2",
+            "columns": ["something", "another"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_1",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "autoinctest",
+      "schema": "",
+      "name": "autoinctest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinctest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinctest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinctest_0",
+            "columns": ["id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_baz",
+      "schema": "",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_qux",
+      "schema": "",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_bar",
+      "schema": "",
+      "name": "foo_bar",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_bar",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_bar",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_baz",
+      "schema": "",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_qux",
+      "schema": "",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "has_generated_columns",
+      "schema": "",
+      "name": "has_generated_columns",
+      "columns": [
+        {
+          "name": "a",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "c",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "d",
+          "db_type": "INT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "e",
+          "db_type": "TEXT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_has_generated_columns",
+          "columns": [
+            {
+              "name": "a",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_has_generated_columns",
+          "columns": ["a"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "sponsors",
+      "schema": "",
+      "name": "sponsors",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_sponsors_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_sponsors",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "tags",
+      "schema": "",
+      "name": "tags",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_tags_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_tags",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "test_index_expressions",
+      "schema": "",
+      "name": "test_index_expressions",
+      "columns": [
+        {
+          "name": "col1",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col2",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col3",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "c",
+          "name": "idx6",
+          "columns": [
+            {
+              "name": "POW(col3, 2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx5",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": true,
+              "is_expression": false
+            },
+            {
+              "name": "col2",
+              "desc": true,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx4",
+          "columns": [
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx3",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "(col2 + col3)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx2",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            },
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx1",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "type_monsters",
+      "schema": "",
+      "name": "type_monsters",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_three",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bool_zero",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_one",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_two",
+          "db_type": "BOOL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_three",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_four",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_five",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_six",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_zero",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_one",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_two",
+          "db_type": "VARCHAR(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_three",
+          "db_type": "VARCHAR(1)",
+          "default": "'a'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_four",
+          "db_type": "VARCHAR(1)",
+          "default": "'b'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_five",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_six",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_seven",
+          "db_type": "VARCHAR(1000)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eight",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_nine",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_ten",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eleven",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_zero",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_one",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_two",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_three",
+          "db_type": "BIGINT",
+          "default": "111111",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_four",
+          "db_type": "BIGINT",
+          "default": "222222",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_five",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_six",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "int_zero",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_one",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_three",
+          "db_type": "INT",
+          "default": "333333",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_four",
+          "db_type": "INT",
+          "default": "444444",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_five",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_six",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "float_zero",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_one",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_two",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_three",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_four",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_five",
+          "db_type": "FLOAT(2,1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_six",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_seven",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_eight",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_nine",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_zero",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_one",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_two",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_three",
+          "db_type": "BINARY",
+          "default": "'a'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_four",
+          "db_type": "BINARY",
+          "default": "'b'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_five",
+          "db_type": "BINARY(100)",
+          "default": "'abcdefghabcdefghabcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_six",
+          "db_type": "BINARY(100)",
+          "default": "'hgfedcbahgfedcbahgfedcba'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_seven",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_eight",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "time_zero",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_one",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_two",
+          "db_type": "TIMESTAMP",
+          "default": "null",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_three",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_five",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_nine",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_eleven",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_twelve",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_fifteen",
+          "db_type": "DATE",
+          "default": "'19990108'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_sixteen",
+          "db_type": "DATE",
+          "default": "'1999-01-08'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "json_null",
+          "db_type": "JSON",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "json_nnull",
+          "db_type": "JSON",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_null",
+          "db_type": "TINYINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_nnull",
+          "db_type": "TINYINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_null",
+          "db_type": "TINYINT(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_nnull",
+          "db_type": "TINYINT(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_null",
+          "db_type": "TINYINT(2)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_nnull",
+          "db_type": "TINYINT(2)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_null",
+          "db_type": "SMALLINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_nnull",
+          "db_type": "SMALLINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_null",
+          "db_type": "MEDIUMINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_nnull",
+          "db_type": "MEDIUMINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_null",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_nnull",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "float_null",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_nnull",
+          "db_type": "FLOAT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "double_null",
+          "db_type": "DOUBLE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "double_nnull",
+          "db_type": "DOUBLE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_null",
+          "db_type": "DOUBLE PRECISION",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_nnull",
+          "db_type": "DOUBLE PRECISION",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "real_null",
+          "db_type": "REAL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "real_nnull",
+          "db_type": "REAL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_null",
+          "db_type": "BOOLEAN",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_nnull",
+          "db_type": "BOOLEAN",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "date_null",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "date_nnull",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_null",
+          "db_type": "DATETIME",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_nnull",
+          "db_type": "DATETIME",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_null",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_nnull",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.Time",
+          "type_limits": null
+        },
+        {
+          "name": "binary_null",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "binary_nnull",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_null",
+          "db_type": "VARBINARY(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_nnull",
+          "db_type": "VARBINARY(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_null",
+          "db_type": "TINYBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_nnull",
+          "db_type": "TINYBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "blob_null",
+          "db_type": "BLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "blob_nnull",
+          "db_type": "BLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_null",
+          "db_type": "MEDIUMBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_nnull",
+          "db_type": "MEDIUMBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_null",
+          "db_type": "LONGBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_nnull",
+          "db_type": "LONGBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_null",
+          "db_type": "VARCHAR(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_nnull",
+          "db_type": "VARCHAR(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_null",
+          "db_type": "CHAR",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_nnull",
+          "db_type": "CHAR",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_null",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_nnull",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_type_monsters_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_type_monsters",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "user_videos",
+      "schema": "",
+      "name": "user_videos",
+      "columns": [
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "users",
+      "schema": "",
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_users_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_users",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "video_tags",
+      "schema": "",
+      "name": "video_tags",
+      "columns": [
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "tag_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_video_tags_1",
+          "columns": [
+            {
+              "name": "video_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "tag_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_video_tags",
+          "columns": ["video_id", "tag_id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_video_tags_0",
+            "columns": ["tag_id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_video_tags_1",
+            "columns": ["video_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "videos",
+      "schema": "",
+      "name": "videos",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_3",
+          "columns": [
+            {
+              "name": "user_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_2",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_videos_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_videos",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_videos_0",
+            "columns": ["sponsor_id"],
+            "foreign_table": "sponsors",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_videos_1",
+            "columns": ["user_id"],
+            "foreign_table": "users",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_videos_3",
+            "columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_videos_2",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "github.com/tursodatabase/libsql-client-go/libsql"
 }

--- a/gen/bobgen-sqlite/driver/sqlite.golden.json
+++ b/gen/bobgen-sqlite/driver/sqlite.golden.json
@@ -1,3605 +1,3495 @@
 {
-	"tables": [
-		{
-			"key": "autoinckeywordtest",
-			"schema": "",
-			"name": "autoinckeywordtest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "something",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "another",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_2",
-					"columns": [
-						{
-							"name": "something",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "another",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_autoinckeywordtest_1",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinckeywordtest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinckeywordtest_0",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_2",
-						"columns": [
-							"something",
-							"another"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_autoinckeywordtest_1",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "autoinctest",
-			"schema": "",
-			"name": "autoinctest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_autoinctest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_autoinctest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_autoinctest_0",
-						"columns": [
-							"id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_baz",
-			"schema": "",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "bar_qux",
-			"schema": "",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_bar",
-			"schema": "",
-			"name": "foo_bar",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_bar",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_bar",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_baz",
-			"schema": "",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "foo_qux",
-			"schema": "",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "has_generated_columns",
-			"schema": "",
-			"name": "has_generated_columns",
-			"columns": [
-				{
-					"name": "a",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "c",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "d",
-					"db_type": "INT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "e",
-					"db_type": "TEXT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						{
-							"name": "a",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_has_generated_columns",
-					"columns": [
-						"a"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.as_generated_columns",
-			"schema": "one",
-			"name": "as_generated_columns",
-			"columns": [
-				{
-					"name": "a",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "c",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "d",
-					"db_type": "INT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "e",
-					"db_type": "TEXT",
-					"default": "auto_generated",
-					"comment": "",
-					"nullable": true,
-					"generated": true,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_as_generated_columns",
-					"columns": [
-						{
-							"name": "a",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_as_generated_columns",
-					"columns": [
-						"a"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.autoinckeywordtest",
-			"schema": "one",
-			"name": "autoinckeywordtest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "b",
-					"db_type": "INTEGER",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_autoinckeywordtest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_autoinckeywordtest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.autoinctest",
-			"schema": "one",
-			"name": "autoinctest",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_autoinctest",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_autoinctest",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_baz",
-			"schema": "one",
-			"name": "bar_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.bar_qux",
-			"schema": "one",
-			"name": "bar_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_bar_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_bar_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_bar",
-			"schema": "one",
-			"name": "foo_bar",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_bar",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_bar",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_baz",
-			"schema": "one",
-			"name": "foo_baz",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_baz",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_baz",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.foo_qux",
-			"schema": "one",
-			"name": "foo_qux",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INTEGER",
-					"default": "auto_increment",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "secret_col",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "pk_one_foo_qux",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_foo_qux",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.sponsors",
-			"schema": "one",
-			"name": "sponsors",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_sponsors_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_sponsors",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.tags",
-			"schema": "one",
-			"name": "tags",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_tags_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_tags",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.user_videos",
-			"schema": "one",
-			"name": "user_videos",
-			"columns": [
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.users",
-			"schema": "one",
-			"name": "users",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_users_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_users",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.video_tags",
-			"schema": "one",
-			"name": "video_tags",
-			"columns": [
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "tag_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_video_tags_1",
-					"columns": [
-						{
-							"name": "video_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "tag_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_video_tags",
-					"columns": [
-						"video_id",
-						"tag_id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_video_tags_0",
-						"columns": [
-							"tag_id"
-						],
-						"foreign_table": "one.tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_video_tags_1",
-						"columns": [
-							"video_id"
-						],
-						"foreign_table": "one.videos",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "one.videos",
-			"schema": "one",
-			"name": "videos",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_2",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_videos_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_one_videos",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_videos_0",
-						"columns": [
-							"sponsor_id"
-						],
-						"foreign_table": "one.sponsors",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_videos_1",
-						"columns": [
-							"user_id"
-						],
-						"foreign_table": "one.users",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_videos_2",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "sponsors",
-			"schema": "",
-			"name": "sponsors",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_sponsors_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_sponsors",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "tags",
-			"schema": "",
-			"name": "tags",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_tags_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_tags",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "test_index_expressions",
-			"schema": "",
-			"name": "test_index_expressions",
-			"columns": [
-				{
-					"name": "col1",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col2",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "col3",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "c",
-					"name": "idx6",
-					"columns": [
-						{
-							"name": "POW(col3, 2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx5",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": true,
-							"is_expression": false
-						},
-						{
-							"name": "col2",
-							"desc": true,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx4",
-					"columns": [
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx3",
-					"columns": [
-						{
-							"name": "col1",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "(col2 + col3)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx2",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						},
-						{
-							"name": "col3",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "c",
-					"name": "idx1",
-					"columns": [
-						{
-							"name": "(col1 + col2)",
-							"desc": false,
-							"is_expression": true
-						}
-					],
-					"unique": false,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "type_monsters",
-			"schema": "",
-			"name": "type_monsters",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "id_three",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bool_zero",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_one",
-					"db_type": "BOOL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_two",
-					"db_type": "BOOL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_three",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_four",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_five",
-					"db_type": "BOOL",
-					"default": "false",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bool_six",
-					"db_type": "BOOL",
-					"default": "true",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_zero",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_one",
-					"db_type": "VARCHAR(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_two",
-					"db_type": "VARCHAR(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_three",
-					"db_type": "VARCHAR(1)",
-					"default": "'a'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_four",
-					"db_type": "VARCHAR(1)",
-					"default": "'b'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_five",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_six",
-					"db_type": "VARCHAR(1000)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_seven",
-					"db_type": "VARCHAR(1000)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eight",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_nine",
-					"db_type": "VARCHAR(1000)",
-					"default": "'abcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_ten",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "string_eleven",
-					"db_type": "VARCHAR(1000)",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_zero",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_one",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_two",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_three",
-					"db_type": "BIGINT",
-					"default": "111111",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_four",
-					"db_type": "BIGINT",
-					"default": "222222",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_five",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "big_int_six",
-					"db_type": "BIGINT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "int_zero",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_one",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_two",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_three",
-					"db_type": "INT",
-					"default": "333333",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_four",
-					"db_type": "INT",
-					"default": "444444",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_five",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "int_six",
-					"db_type": "INT",
-					"default": "0",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "float_zero",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_one",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_two",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_three",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_four",
-					"db_type": "FLOAT(2,1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_five",
-					"db_type": "FLOAT(2,1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_six",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_seven",
-					"db_type": "FLOAT(2,1)",
-					"default": "1.1",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_eight",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "float_nine",
-					"db_type": "FLOAT(2,1)",
-					"default": "0.0",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_zero",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_one",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_two",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_three",
-					"db_type": "BINARY",
-					"default": "'a'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_four",
-					"db_type": "BINARY",
-					"default": "'b'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_five",
-					"db_type": "BINARY(100)",
-					"default": "'abcdefghabcdefghabcdefgh'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_six",
-					"db_type": "BINARY(100)",
-					"default": "'hgfedcbahgfedcbahgfedcba'",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_seven",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "bytea_eight",
-					"db_type": "BINARY",
-					"default": "''",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "time_zero",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_one",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_two",
-					"db_type": "TIMESTAMP",
-					"default": "null",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_three",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_five",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_nine",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_eleven",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_twelve",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "time_fifteen",
-					"db_type": "DATE",
-					"default": "'1999-01-08'",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "json_null",
-					"db_type": "JSON",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "json_nnull",
-					"db_type": "JSON",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "types.JSON[json.RawMessage]",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_null",
-					"db_type": "TINYINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint_nnull",
-					"db_type": "TINYINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int8",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_null",
-					"db_type": "TINYINT(1)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint1_nnull",
-					"db_type": "TINYINT(1)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_null",
-					"db_type": "TINYINT(2)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyint2_nnull",
-					"db_type": "TINYINT(2)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_null",
-					"db_type": "SMALLINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "smallint_nnull",
-					"db_type": "SMALLINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int16",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_null",
-					"db_type": "MEDIUMINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "mediumint_nnull",
-					"db_type": "MEDIUMINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_null",
-					"db_type": "BIGINT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "bigint_nnull",
-					"db_type": "BIGINT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int64",
-					"type_limits": null
-				},
-				{
-					"name": "float_null",
-					"db_type": "FLOAT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "float_nnull",
-					"db_type": "FLOAT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "double_null",
-					"db_type": "DOUBLE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "double_nnull",
-					"db_type": "DOUBLE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_null",
-					"db_type": "DOUBLE PRECISION",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "doubleprec_nnull",
-					"db_type": "DOUBLE PRECISION",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float64",
-					"type_limits": null
-				},
-				{
-					"name": "real_null",
-					"db_type": "REAL",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "real_nnull",
-					"db_type": "REAL",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "float32",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_null",
-					"db_type": "BOOLEAN",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "boolean_nnull",
-					"db_type": "BOOLEAN",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "bool",
-					"type_limits": null
-				},
-				{
-					"name": "date_null",
-					"db_type": "DATE",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "date_nnull",
-					"db_type": "DATE",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_null",
-					"db_type": "DATETIME",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "datetime_nnull",
-					"db_type": "DATETIME",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_null",
-					"db_type": "TIMESTAMP",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "timestamp_nnull",
-					"db_type": "TIMESTAMP",
-					"default": "current_timestamp",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "time.Time",
-					"type_limits": null
-				},
-				{
-					"name": "binary_null",
-					"db_type": "BINARY",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "binary_nnull",
-					"db_type": "BINARY",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_null",
-					"db_type": "VARBINARY(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varbinary_nnull",
-					"db_type": "VARBINARY(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_null",
-					"db_type": "TINYBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "tinyblob_nnull",
-					"db_type": "TINYBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "blob_null",
-					"db_type": "BLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "blob_nnull",
-					"db_type": "BLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "[]byte",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_null",
-					"db_type": "MEDIUMBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "mediumblob_nnull",
-					"db_type": "MEDIUMBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_null",
-					"db_type": "LONGBLOB",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "longblob_nnull",
-					"db_type": "LONGBLOB",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_null",
-					"db_type": "VARCHAR(100)",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "varchar_nnull",
-					"db_type": "VARCHAR(100)",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_null",
-					"db_type": "CHAR",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "char_nnull",
-					"db_type": "CHAR",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_null",
-					"db_type": "TEXT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				},
-				{
-					"name": "text_nnull",
-					"db_type": "TEXT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "string",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_type_monsters_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_type_monsters",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "user_videos",
-			"schema": "",
-			"name": "user_videos",
-			"columns": [
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [],
-			"constraints": {
-				"primary": null,
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "users",
-			"schema": "",
-			"name": "users",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_users_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_users",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "video_tags",
-			"schema": "",
-			"name": "video_tags",
-			"columns": [
-				{
-					"name": "video_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "tag_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_video_tags_1",
-					"columns": [
-						{
-							"name": "video_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "tag_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_video_tags",
-					"columns": [
-						"video_id",
-						"tag_id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_video_tags_0",
-						"columns": [
-							"tag_id"
-						],
-						"foreign_table": "tags",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_video_tags_1",
-						"columns": [
-							"video_id"
-						],
-						"foreign_table": "videos",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": null,
-				"check": null
-			},
-			"comment": ""
-		},
-		{
-			"key": "videos",
-			"schema": "",
-			"name": "videos",
-			"columns": [
-				{
-					"name": "id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "user_id",
-					"db_type": "INT",
-					"default": "",
-					"comment": "",
-					"nullable": false,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				},
-				{
-					"name": "sponsor_id",
-					"db_type": "INT",
-					"default": "NULL",
-					"comment": "",
-					"nullable": true,
-					"generated": false,
-					"autoincr": false,
-					"domain_name": "",
-					"type": "int32",
-					"type_limits": null
-				}
-			],
-			"indexes": [
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_3",
-					"columns": [
-						{
-							"name": "user_id",
-							"desc": false,
-							"is_expression": false
-						},
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "u",
-					"name": "sqlite_autoindex_videos_2",
-					"columns": [
-						{
-							"name": "sponsor_id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				},
-				{
-					"type": "pk",
-					"name": "sqlite_autoindex_videos_1",
-					"columns": [
-						{
-							"name": "id",
-							"desc": false,
-							"is_expression": false
-						}
-					],
-					"unique": true,
-					"comment": "",
-					"extra": {
-						"partial": false
-					}
-				}
-			],
-			"constraints": {
-				"primary": {
-					"name": "pk_main_videos",
-					"columns": [
-						"id"
-					],
-					"comment": "",
-					"extra": null
-				},
-				"foreign": [
-					{
-						"name": "fk_videos_0",
-						"columns": [
-							"sponsor_id"
-						],
-						"foreign_table": "sponsors",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "fk_videos_1",
-						"columns": [
-							"user_id"
-						],
-						"foreign_table": "users",
-						"foreign_columns": [
-							"id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"uniques": [
-					{
-						"name": "sqlite_autoindex_videos_3",
-						"columns": [
-							"user_id",
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					},
-					{
-						"name": "sqlite_autoindex_videos_2",
-						"columns": [
-							"sponsor_id"
-						],
-						"comment": "",
-						"extra": null
-					}
-				],
-				"check": null
-			},
-			"comment": ""
-		}
-	],
-	"query_folders": [],
-	"enums": null,
-	"extra_info": null,
-	"driver": "modernc.org/sqlite"
+  "tables": [
+    {
+      "key": "autoinckeywordtest",
+      "schema": "",
+      "name": "autoinckeywordtest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "something",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "another",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinckeywordtest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_2",
+          "columns": [
+            {
+              "name": "something",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "another",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_autoinckeywordtest_1",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinckeywordtest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinckeywordtest_0",
+            "columns": ["user_id", "sponsor_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_2",
+            "columns": ["something", "another"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_autoinckeywordtest_1",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "autoinctest",
+      "schema": "",
+      "name": "autoinctest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_autoinctest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_autoinctest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_autoinctest_0",
+            "columns": ["id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_baz",
+      "schema": "",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "bar_qux",
+      "schema": "",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_bar",
+      "schema": "",
+      "name": "foo_bar",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_bar",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_bar",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_baz",
+      "schema": "",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "foo_qux",
+      "schema": "",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "has_generated_columns",
+      "schema": "",
+      "name": "has_generated_columns",
+      "columns": [
+        {
+          "name": "a",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "c",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "d",
+          "db_type": "INT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "e",
+          "db_type": "TEXT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_main_has_generated_columns",
+          "columns": [
+            {
+              "name": "a",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_has_generated_columns",
+          "columns": ["a"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.as_generated_columns",
+      "schema": "one",
+      "name": "as_generated_columns",
+      "columns": [
+        {
+          "name": "a",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "c",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "d",
+          "db_type": "INT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "e",
+          "db_type": "TEXT",
+          "default": "auto_generated",
+          "comment": "",
+          "nullable": true,
+          "generated": true,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_as_generated_columns",
+          "columns": [
+            {
+              "name": "a",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_as_generated_columns",
+          "columns": ["a"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.autoinckeywordtest",
+      "schema": "one",
+      "name": "autoinckeywordtest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "b",
+          "db_type": "INTEGER",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_autoinckeywordtest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_autoinckeywordtest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.autoinctest",
+      "schema": "one",
+      "name": "autoinctest",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_autoinctest",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_autoinctest",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_baz",
+      "schema": "one",
+      "name": "bar_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.bar_qux",
+      "schema": "one",
+      "name": "bar_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_bar_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_bar_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_bar",
+      "schema": "one",
+      "name": "foo_bar",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_bar",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_bar",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_baz",
+      "schema": "one",
+      "name": "foo_baz",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_baz",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_baz",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.foo_qux",
+      "schema": "one",
+      "name": "foo_qux",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "BIGINT",
+          "default": "auto_increment",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "secret_col",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "pk_one_foo_qux",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_foo_qux",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.sponsors",
+      "schema": "one",
+      "name": "sponsors",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_sponsors_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_sponsors",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.tags",
+      "schema": "one",
+      "name": "tags",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_tags_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_tags",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.user_videos",
+      "schema": "one",
+      "name": "user_videos",
+      "columns": [
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.users",
+      "schema": "one",
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_users_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_users",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.video_tags",
+      "schema": "one",
+      "name": "video_tags",
+      "columns": [
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "tag_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_video_tags_1",
+          "columns": [
+            {
+              "name": "video_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "tag_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_video_tags",
+          "columns": ["video_id", "tag_id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_video_tags_0",
+            "columns": ["tag_id"],
+            "foreign_table": "one.tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_video_tags_1",
+            "columns": ["video_id"],
+            "foreign_table": "one.videos",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "one.videos",
+      "schema": "one",
+      "name": "videos",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_2",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_videos_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_one_videos",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_videos_0",
+            "columns": ["sponsor_id"],
+            "foreign_table": "one.sponsors",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_videos_1",
+            "columns": ["user_id"],
+            "foreign_table": "one.users",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_videos_2",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "sponsors",
+      "schema": "",
+      "name": "sponsors",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_sponsors_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_sponsors",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "tags",
+      "schema": "",
+      "name": "tags",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_tags_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_tags",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "test_index_expressions",
+      "schema": "",
+      "name": "test_index_expressions",
+      "columns": [
+        {
+          "name": "col1",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col2",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "col3",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "c",
+          "name": "idx6",
+          "columns": [
+            {
+              "name": "POW(col3, 2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx5",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": true,
+              "is_expression": false
+            },
+            {
+              "name": "col2",
+              "desc": true,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx4",
+          "columns": [
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx3",
+          "columns": [
+            {
+              "name": "col1",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "(col2 + col3)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx2",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            },
+            {
+              "name": "col3",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "c",
+          "name": "idx1",
+          "columns": [
+            {
+              "name": "(col1 + col2)",
+              "desc": false,
+              "is_expression": true
+            }
+          ],
+          "unique": false,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "type_monsters",
+      "schema": "",
+      "name": "type_monsters",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "id_three",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bool_zero",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_one",
+          "db_type": "BOOL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_two",
+          "db_type": "BOOL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_three",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_four",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_five",
+          "db_type": "BOOL",
+          "default": "false",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bool_six",
+          "db_type": "BOOL",
+          "default": "true",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_zero",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_one",
+          "db_type": "VARCHAR(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_two",
+          "db_type": "VARCHAR(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_three",
+          "db_type": "VARCHAR(1)",
+          "default": "'a'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_four",
+          "db_type": "VARCHAR(1)",
+          "default": "'b'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_five",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_six",
+          "db_type": "VARCHAR(1000)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_seven",
+          "db_type": "VARCHAR(1000)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eight",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_nine",
+          "db_type": "VARCHAR(1000)",
+          "default": "'abcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_ten",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "string_eleven",
+          "db_type": "VARCHAR(1000)",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_zero",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_one",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_two",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_three",
+          "db_type": "BIGINT",
+          "default": "111111",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_four",
+          "db_type": "BIGINT",
+          "default": "222222",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_five",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "big_int_six",
+          "db_type": "BIGINT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "int_zero",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_one",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_two",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_three",
+          "db_type": "INT",
+          "default": "333333",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_four",
+          "db_type": "INT",
+          "default": "444444",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_five",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "int_six",
+          "db_type": "INT",
+          "default": "0",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "float_zero",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_one",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_two",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_three",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_four",
+          "db_type": "FLOAT(2,1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_five",
+          "db_type": "FLOAT(2,1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_six",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_seven",
+          "db_type": "FLOAT(2,1)",
+          "default": "1.1",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_eight",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "float_nine",
+          "db_type": "FLOAT(2,1)",
+          "default": "0.0",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_zero",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_one",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_two",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_three",
+          "db_type": "BINARY",
+          "default": "'a'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_four",
+          "db_type": "BINARY",
+          "default": "'b'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_five",
+          "db_type": "BINARY(100)",
+          "default": "'abcdefghabcdefghabcdefgh'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_six",
+          "db_type": "BINARY(100)",
+          "default": "'hgfedcbahgfedcbahgfedcba'",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_seven",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "bytea_eight",
+          "db_type": "BINARY",
+          "default": "''",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "time_zero",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_one",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_two",
+          "db_type": "TIMESTAMP",
+          "default": "null",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_three",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_five",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_nine",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_eleven",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_twelve",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "time_fifteen",
+          "db_type": "DATE",
+          "default": "'1999-01-08'",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "json_null",
+          "db_type": "JSON",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "json_nnull",
+          "db_type": "JSON",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "types.JSON[json.RawMessage]",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_null",
+          "db_type": "TINYINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint_nnull",
+          "db_type": "TINYINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int8",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_null",
+          "db_type": "TINYINT(1)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint1_nnull",
+          "db_type": "TINYINT(1)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_null",
+          "db_type": "TINYINT(2)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyint2_nnull",
+          "db_type": "TINYINT(2)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_null",
+          "db_type": "SMALLINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "smallint_nnull",
+          "db_type": "SMALLINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int16",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_null",
+          "db_type": "MEDIUMINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "mediumint_nnull",
+          "db_type": "MEDIUMINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_null",
+          "db_type": "BIGINT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "bigint_nnull",
+          "db_type": "BIGINT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int64",
+          "type_limits": null
+        },
+        {
+          "name": "float_null",
+          "db_type": "FLOAT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "float_nnull",
+          "db_type": "FLOAT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "double_null",
+          "db_type": "DOUBLE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "double_nnull",
+          "db_type": "DOUBLE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_null",
+          "db_type": "DOUBLE PRECISION",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "doubleprec_nnull",
+          "db_type": "DOUBLE PRECISION",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float64",
+          "type_limits": null
+        },
+        {
+          "name": "real_null",
+          "db_type": "REAL",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "real_nnull",
+          "db_type": "REAL",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "float32",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_null",
+          "db_type": "BOOLEAN",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "boolean_nnull",
+          "db_type": "BOOLEAN",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "bool",
+          "type_limits": null
+        },
+        {
+          "name": "date_null",
+          "db_type": "DATE",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "date_nnull",
+          "db_type": "DATE",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_null",
+          "db_type": "DATETIME",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "datetime_nnull",
+          "db_type": "DATETIME",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_null",
+          "db_type": "TIMESTAMP",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "timestamp_nnull",
+          "db_type": "TIMESTAMP",
+          "default": "current_timestamp",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "time.Time",
+          "type_limits": null
+        },
+        {
+          "name": "binary_null",
+          "db_type": "BINARY",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "binary_nnull",
+          "db_type": "BINARY",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_null",
+          "db_type": "VARBINARY(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varbinary_nnull",
+          "db_type": "VARBINARY(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_null",
+          "db_type": "TINYBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "tinyblob_nnull",
+          "db_type": "TINYBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "blob_null",
+          "db_type": "BLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "blob_nnull",
+          "db_type": "BLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "[]byte",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_null",
+          "db_type": "MEDIUMBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "mediumblob_nnull",
+          "db_type": "MEDIUMBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_null",
+          "db_type": "LONGBLOB",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "longblob_nnull",
+          "db_type": "LONGBLOB",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_null",
+          "db_type": "VARCHAR(100)",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "varchar_nnull",
+          "db_type": "VARCHAR(100)",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_null",
+          "db_type": "CHAR",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "char_nnull",
+          "db_type": "CHAR",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_null",
+          "db_type": "TEXT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        },
+        {
+          "name": "text_nnull",
+          "db_type": "TEXT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "string",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_type_monsters_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_type_monsters",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "user_videos",
+      "schema": "",
+      "name": "user_videos",
+      "columns": [
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [],
+      "constraints": {
+        "primary": null,
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "users",
+      "schema": "",
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_users_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_users",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "video_tags",
+      "schema": "",
+      "name": "video_tags",
+      "columns": [
+        {
+          "name": "video_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "tag_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_video_tags_1",
+          "columns": [
+            {
+              "name": "video_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "tag_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_video_tags",
+          "columns": ["video_id", "tag_id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_video_tags_0",
+            "columns": ["tag_id"],
+            "foreign_table": "tags",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_video_tags_1",
+            "columns": ["video_id"],
+            "foreign_table": "videos",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": null,
+        "check": null
+      },
+      "comment": ""
+    },
+    {
+      "key": "videos",
+      "schema": "",
+      "name": "videos",
+      "columns": [
+        {
+          "name": "id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "user_id",
+          "db_type": "INT",
+          "default": "",
+          "comment": "",
+          "nullable": false,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        },
+        {
+          "name": "sponsor_id",
+          "db_type": "INT",
+          "default": "NULL",
+          "comment": "",
+          "nullable": true,
+          "generated": false,
+          "autoincr": false,
+          "domain_name": "",
+          "type": "int32",
+          "type_limits": null
+        }
+      ],
+      "indexes": [
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_3",
+          "columns": [
+            {
+              "name": "user_id",
+              "desc": false,
+              "is_expression": false
+            },
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "u",
+          "name": "sqlite_autoindex_videos_2",
+          "columns": [
+            {
+              "name": "sponsor_id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        },
+        {
+          "type": "pk",
+          "name": "sqlite_autoindex_videos_1",
+          "columns": [
+            {
+              "name": "id",
+              "desc": false,
+              "is_expression": false
+            }
+          ],
+          "unique": true,
+          "comment": "",
+          "extra": {
+            "partial": false
+          }
+        }
+      ],
+      "constraints": {
+        "primary": {
+          "name": "pk_main_videos",
+          "columns": ["id"],
+          "comment": "",
+          "extra": null
+        },
+        "foreign": [
+          {
+            "name": "fk_videos_0",
+            "columns": ["sponsor_id"],
+            "foreign_table": "sponsors",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "fk_videos_1",
+            "columns": ["user_id"],
+            "foreign_table": "users",
+            "foreign_columns": ["id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "uniques": [
+          {
+            "name": "sqlite_autoindex_videos_3",
+            "columns": ["user_id", "sponsor_id"],
+            "comment": "",
+            "extra": null
+          },
+          {
+            "name": "sqlite_autoindex_videos_2",
+            "columns": ["sponsor_id"],
+            "comment": "",
+            "extra": null
+          }
+        ],
+        "check": null
+      },
+      "comment": ""
+    }
+  ],
+  "query_folders": [],
+  "enums": null,
+  "extra_info": null,
+  "driver": "modernc.org/sqlite"
 }


### PR DESCRIPTION
Hey again,

In the SQLite docs, it states:

> In SQLite, a column with type INTEGER PRIMARY KEY is an alias for the [ROWID](https://www.sqlite.org/lang_createtable.html#rowid) (except in [WITHOUT ROWID](https://www.sqlite.org/withoutrowid.html) tables) which is always a 64-bit signed integer.

But currently the parser sees `INTEGER` and generates `int32` (Which is sensible, but SQLite isn't 😆).

Hopefully this approach is okay - or do you want some special parsing so that we don't obfuscate the actual DB source type?

Also, I'm getting the following failures but I'm not quite sure where they're coming from - are these generated in-memory?

```
-----------------
models/autoinctest.bob.go:378:7: cannot use omit.From(tag1.ID) (value of struct type omit.Val[int32]) as omit.Val[int64] value in struct literal
 375|
 376| func attachAutoinctestIDTag0(ctx context.Context, exec bob.Executor, count int, autoinctest0 *Autoinctest, tag1 *Tag) (*Autoinctest, error) {
 377|   setter := &AutoinctestSetter{
•378|           ID: omit.From(tag1.ID),
 379|   }
 380|
 381|   err := autoinctest0.Update(ctx, exec, setter)
 382|   if err != nil {
-----------------

-----------------
models/autoinctest.bob.go:538:17: invalid operation: o.ID == rel.ID (mismatched types int64 and int32)
 535|
 536|           for _, rel := range tags {
 537|
•538|                   if !(o.ID == rel.ID) {
 539|                           continue
 540|                   }
 541|
 542|                   rel.R.IDAutoinctest = o
-----------------

-----------------
models/tags.bob.go:404:20: cannot use omit.From(tag0.ID) (value of struct type omit.Val[int32]) as omit.Val[int64] value in assignment
 401| }
 402|
 403| func insertTagIDAutoinctest0(ctx context.Context, exec bob.Executor, autoinctest1 *AutoinctestSetter, tag0 *Tag) (*Autoinctest, error) {
•404|   autoinctest1.ID = omit.From(tag0.ID)
 405|
 406|   ret, err := Autoinctests.Insert(autoinctest1).One(ctx, exec)
 407|   if err != nil {
 408|           return ret, fmt.Errorf("insertTagIDAutoinctest0: %w", err)
-----------------

-----------------
models/tags.bob.go:416:7: cannot use omit.From(tag0.ID) (value of struct type omit.Val[int32]) as omit.Val[int64] value in struct literal
 413|
 414| func attachTagIDAutoinctest0(ctx context.Context, exec bob.Executor, count int, autoinctest1 *Autoinctest, tag0 *Tag) (*Autoinctest, error) {
 415|   setter := &AutoinctestSetter{
•416|           ID: omit.From(tag0.ID),
 417|   }
 418|
 419|   err := autoinctest1.Update(ctx, exec, setter)
 420|   if err != nil {
-----------------

-----------------
models/tags.bob.go:660:17: invalid operation: o.ID == rel.ID (mismatched types int32 and int64)
 657|
 658|           for _, rel := range autoinctests {
 659|
•660|                   if !(o.ID == rel.ID) {
 661|                           continue
 662|                   }
 663|
 664|                   rel.R.IDTag = o
-----------------
```