### PR TITLE
fix: support scanning Uint64 from uint64 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where `bobgen-mysql` could not detect unsigned integer columns in queries.
 - Properly close `pgx` transactions if the context used in `BeginTx` is cancelled.
 - Fix issues with generating code for relationships defined with `WhereExpr`.
+- Support `uint64` type when scanning columns as `types.Uint64`. This fixes scanning `BIGINT UNSIGNED` MySQL columns as `types.Uint64` when `interpolateParams` is enabled. (thanks @luiscleto)
 
 ## [v0.40.2] - 2025-08-16
 

--- a/types/uint64.go
+++ b/types/uint64.go
@@ -25,6 +25,9 @@ func (u *Uint64) Scan(src any) error {
 	case int64:
 		*u = Uint64(v)
 		return nil
+	case uint64:
+		*u = Uint64(v)
+		return nil
 	case nil:
 		return fmt.Errorf("cannot scan nil value into Uint64")
 	default:


### PR DESCRIPTION
Should fix https://github.com/stephenafamo/bob/issues/558: failure to scan uint64s when interpolateParams=true