### PR TITLE
Add `BeforeUpdateSetterHooks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bob.Each` function to iterate over query results (range-over-func). (thanks @toqueteos)
 - Added support for the `VALUES` statement in MySQL, PostgreSQL, and SQLite. (thanks @manhrev)
 - Added MariaDB compatibility check in gen/bobgen-mysql (thanks @dumdev25)
+- Added `BeforeUpdateSetterHooks`. (thanks @toqueteos)
 
 ### Fixed
 

--- a/dialect/mysql/table.go
+++ b/dialect/mysql/table.go
@@ -60,8 +60,9 @@ type Table[T any, Tslice ~[]T, Tset setter[T], C bob.Expression] struct {
 	BeforeInsertHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
 	AfterInsertHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
-	BeforeUpdateHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
-	AfterUpdateHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateHooks       bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateSetterHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
+	AfterUpdateHooks        bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
 	BeforeDeleteHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
 	AfterDeleteHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]

--- a/dialect/psql/table.go
+++ b/dialect/psql/table.go
@@ -50,8 +50,9 @@ type Table[T any, Tslice ~[]T, Tset setter[T], C bob.Expression] struct {
 	BeforeInsertHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
 	AfterInsertHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
-	BeforeUpdateHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
-	AfterUpdateHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateHooks       bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateSetterHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
+	AfterUpdateHooks        bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
 	BeforeDeleteHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
 	AfterDeleteHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]

--- a/dialect/sqlite/table.go
+++ b/dialect/sqlite/table.go
@@ -47,8 +47,9 @@ type Table[T any, Tslice ~[]T, Tset setter[T], C bob.Expression] struct {
 	BeforeInsertHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
 	AfterInsertHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
-	BeforeUpdateHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
-	AfterUpdateHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateHooks       bob.Hooks[Tslice, bob.SkipModelHooksKey]
+	BeforeUpdateSetterHooks bob.Hooks[Tset, bob.SkipModelHooksKey]
+	AfterUpdateHooks        bob.Hooks[Tslice, bob.SkipModelHooksKey]
 
 	BeforeDeleteHooks bob.Hooks[Tslice, bob.SkipModelHooksKey]
 	AfterDeleteHooks  bob.Hooks[Tslice, bob.SkipModelHooksKey]

--- a/website/docs/models/hooks.md
+++ b/website/docs/models/hooks.md
@@ -20,6 +20,7 @@ In **addition**, TableModels have:
 * `BeforeUpsertHooks`
 * `AfterUpsertHooks`
 * `BeforeUpdateHooks`
+* `BeforeUpdateSetterHooks`
 * `AfterUpdateHooks`
 * `BeforeDeleteHooks`
 * `AfterDeleteHooks`


### PR DESCRIPTION
A BeforeUpdate hook that surfaces the Setter seems useful (and apparently something people have been wanting from some time ago https://github.com/stephenafamo/bob/issues/295)

Also it seems to address the issue from https://github.com/stephenafamo/bob/issues/616

The same can probably be done for `BeforeDelete`.