### PR TITLE
feat: add Unqualified method to return columns without table alias/pr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Unqualified()` method to generated column structures that returns columns without table alias/prefix. (thanks @atzedus)
 - Added `PreloadCount` and `ThenLoadCount` to generate code for preloading and then loading counts for relationships. (thanks @jacobmolby)
 - MySQL support for insert queries executing loaders (e.g., `InsertThenLoad`, `InsertThenLoadCount`). (thanks @jacobmolby)
 - Added overwritable hooks that are run before the exec or scanning test of generated queries. This allows seeding data before the test runs.

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -61,15 +61,19 @@ type {{$tAlias.DownSingular}}R struct {
 
 {{$.Importer.Import "github.com/stephenafamo/bob/expr"}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s" $.Dialect)}}
-func build{{$tAlias.UpSingular}}Columns(alias string) {{$tAlias.DownSingular}}Columns {
+func build{{$tAlias.UpSingular}}Columns(tableName string) {{$tAlias.DownSingular}}Columns {
+  columnsExpr := expr.NewColumnsExpr(
+    {{range $column := $table.Columns -}}{{quote $column.Name}},{{end}}
+  )
+  if tableName != "" {
+    columnsExpr = columnsExpr.WithParent(tableName)
+  }
   return {{$tAlias.DownSingular}}Columns{
-    ColumnsExpr: expr.NewColumnsExpr(
-      {{range $column := $table.Columns -}}{{quote $column.Name}},{{end}}
-    ).WithParent({{quote $table.Key}}),
-    tableAlias: alias,
+    ColumnsExpr: columnsExpr,
+    tableAlias: tableName,
     {{range $column := $table.Columns -}}
     {{- $colAlias := $tAlias.Column $column.Name -}}
-    {{$colAlias}}: {{$.Dialect}}.Quote(alias, {{quote $column.Name}}),
+    {{$colAlias}}: {{$.Dialect}}.Quote(tableName, {{quote $column.Name}}),
     {{end -}}
   }
 }
@@ -87,6 +91,10 @@ func (c {{$tAlias.DownSingular}}Columns) Alias() string {
   return c.tableAlias
 }
 
-func ({{$tAlias.DownSingular}}Columns) AliasedAs(alias string) {{$tAlias.DownSingular}}Columns {
-  return build{{$tAlias.UpSingular}}Columns(alias)
+func ({{$tAlias.DownSingular}}Columns) AliasedAs(tableName string) {{$tAlias.DownSingular}}Columns {
+  return build{{$tAlias.UpSingular}}Columns(tableName)
+}
+
+func (c {{$tAlias.DownSingular}}Columns) Unqualified() {{$tAlias.DownSingular}}Columns {
+  return build{{$tAlias.UpSingular}}Columns("")
 }


### PR DESCRIPTION
## Add `Unqualified()` method to generated column structures

### Summary

This PR adds a new `Unqualified()` method to generated column structures that returns columns without table alias/prefix. This is useful when you need to reference column names without table qualification, for example in `INSERT ... ON CONFLICT` clauses or when building dynamic queries.

### Changes

- Added `Unqualified()` method to generated `*Columns` structures
- Modified `buildXColumns()` function to conditionally call `WithParent()` only when `tableName` is not empty
- Renamed parameter from `alias` to `tableName` for better clarity

### Example

Before this change, columns were always qualified with table name:
```go
Orders.Columns.ID  // generates: "orders"."id"
```

Now you can get unqualified column names:
```go
Orders.Columns.Unqualified().ID  // generates: "id"
```

### Use Case

This is particularly useful for `ON CONFLICT` clauses where you need column names without table prefix:
```go
psql.Insert(...).
    OnConflict(Orders.Columns.Unqualified().ID).
    DoUpdate(...)
```