### PR TITLE
fix: replace RandInt with NextUniqueInt for alias generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix collisions for preloader alias generation. Replaced `RandInt` with `NextUniqueInt` (thanks @atzedus)
 - Fix an issue where the random function of aliased custom types were not being used in generated query tests.
 - Properly recognize placeholders in LIMIT and OFFSET when generating queries for PostgreSQL.
 - Throw an error on an empty SET clause during SQL generation rather than sending invalid syntax to database. (thanks @Xaeroxe)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -52,6 +52,7 @@ func FilterNonZero[T comparable](s []T) []T {
 	return filtered
 }
 
+//nolint:gochecknoglobals
 var uniqueCounter int64
 
 func NextUniqueInt() int64 {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,8 +1,8 @@
 package internal
 
 import (
-	"hash/maphash"
 	"strings"
+	"sync/atomic"
 )
 
 func Pointer[T any](val T) *T {
@@ -52,14 +52,10 @@ func FilterNonZero[T comparable](s []T) []T {
 	return filtered
 }
 
-func RandInt() int64 {
-	out := int64(new(maphash.Hash).Sum64())
+var uniqueCounter int64
 
-	if out < 0 {
-		return -out % 10000
-	}
-
-	return out % 10000
+func NextUniqueInt() int64 {
+	return atomic.AddInt64(&uniqueCounter, 1) + 10000
 }
 
 func SliceMatch[T comparable, Ts ~[]T](a, b Ts) bool {

--- a/orm/load.go
+++ b/orm/load.go
@@ -230,7 +230,7 @@ func Preload[T Preloadable, Ts ~[]T, E bob.Expression, Q PreloadableQuery](rel P
 		}
 
 		var alias string
-		var queryMods mods.QueryMods[Q]
+		queryMods := make(mods.QueryMods[Q], 0, len(rel.Sides)+1)
 
 		for i, side := range rel.Sides {
 			alias = settings.Alias

--- a/orm/load.go
+++ b/orm/load.go
@@ -235,7 +235,7 @@ func Preload[T Preloadable, Ts ~[]T, E bob.Expression, Q PreloadableQuery](rel P
 		for i, side := range rel.Sides {
 			alias = settings.Alias
 			if settings.Alias == "" {
-				alias = fmt.Sprintf("%s_%d", side.To.Alias(), internal.RandInt())
+				alias = fmt.Sprintf("%s_%d", side.To.Alias(), internal.NextUniqueInt())
 			}
 			on := make([]bob.Expression, 0, len(side.FromColumns)+len(side.FromWhere)+len(side.ToWhere))
 			for i, fromCol := range side.FromColumns {


### PR DESCRIPTION
Replaced random alias suffix generator (internal.RandInt) with a monotonic atomic counter (internal.NextUniqueInt) to guarantee uniqueness of table aliases during query preloading. This prevents potential collisions that could occur with random values, ensuring reliable alias generation even in concurrent scenarios. The change is safe for practical use, as int64 provides a vast range of unique values.

A collision with the random alias generator was observed in a production system, which led to the creation of this PR to address the issue and improve reliability.