### PR TITLE
Batch LoadCount for slices

### DIFF
--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -171,12 +171,18 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		if o == nil {
 			continue
 		}
+		{{if eq (len $firstSide.FromColumns) 1 -}}
+		{{$local := index $firstSide.FromColumns 0 -}}
+		{{$fromCol := index $firstFrom.Columns $local -}}
+		PKArgSlice = append(PKArgSlice, {{$.Dialect}}.Arg(o.{{$fromCol}}))
+		{{- else -}}
 		PKArgSlice = append(PKArgSlice, {{$.Dialect}}.ArgGroup(
 			{{- range $index, $local := $firstSide.FromColumns -}}
 			{{- $fromCol := index $firstFrom.Columns $local -}}
 			o.{{$fromCol}},
 			{{- end -}}
 		))
+		{{- end}}
 	}
 	PKArgExpr := {{$.Dialect}}.Group(PKArgSlice...)
 	{{- else}}
@@ -264,6 +270,12 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		{{end -}}
 		{{- end}}
 		// WHERE fk IN (parent PKs)
+		{{if eq (len $firstSide.FromColumns) 1 -}}
+		{{$local := index $firstSide.FromColumns 0 -}}
+		{{$toLocal := index $firstSide.ToColumns 0 -}}
+		{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.In(PKArgExpr)),
+		{{- else -}}
 		sm.Where({{$.Dialect}}.Group(
 			{{range $index, $local := $firstSide.FromColumns -}}
 			{{$toLocal := index $firstSide.ToColumns $index -}}
@@ -271,6 +283,7 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 			{{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}},
 			{{end -}}
 		).In(PKArgExpr)),
+		{{- end}}
 		// GROUP BY fk columns
 		{{range $index, $local := $firstSide.FromColumns -}}
 		{{$toLocal := index $firstSide.ToColumns $index -}}

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -222,7 +222,8 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		sm.Columns(
 			{{range $index, $local := $firstSide.FromColumns -}}
 			{{$toLocal := index $firstSide.ToColumns $index -}}
-			{{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}}).As({{quote $local}}),
+			{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+			{{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.As({{quote $local}}),
 			{{end -}}
 			{{$.Dialect}}.Raw("count(*) as count"),
 		),
@@ -230,13 +231,15 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		// Single-hop: FROM related table directly
 		sm.From({{$fAlias.UpPlural}}.NameAs()),
 		{{range $where := $firstSide.ToWhere -}}
-		sm.Where({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
+		{{$whereColAlias := index $firstTo.Columns $where.Column -}}
+		sm.Where({{$firstTo.UpPlural}}.Columns.{{$whereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
 		{{end -}}
 		{{- else -}}
 		// Multi-hop: FROM first join table, JOIN through to final related table
 		sm.From({{$firstTo.UpPlural}}.NameAs()),
 		{{range $where := $firstSide.ToWhere -}}
-		sm.Where({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
+		{{$whereColAlias := index $firstTo.Columns $where.Column -}}
+		sm.Where({{$firstTo.UpPlural}}.Columns.{{$whereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
 		{{end -}}
 		{{range $sideIndex, $side := $rel.Sides -}}
 		{{if eq $sideIndex 0 -}}{{continue}}{{end -}}
@@ -245,13 +248,17 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		sm.InnerJoin({{$sideTo.UpPlural}}.NameAs()).On(
 			{{range $i, $fromColKey := $side.FromColumns -}}
 			{{$toColKey := index $side.ToColumns $i -}}
-			{{$.Dialect}}.Quote({{$sideTo.UpPlural}}.Alias(), {{quote $toColKey}}).EQ({{$.Dialect}}.Quote({{$sideFrom.UpPlural}}.Alias(), {{quote $fromColKey}})),
+			{{$sideToColAlias := index $sideTo.Columns $toColKey -}}
+			{{$sideFromColAlias := index $sideFrom.Columns $fromColKey -}}
+			{{$sideTo.UpPlural}}.Columns.{{$sideToColAlias}}.EQ({{$sideFrom.UpPlural}}.Columns.{{$sideFromColAlias}}),
 			{{end -}}
 			{{range $where := $side.FromWhere -}}
-			{{$.Dialect}}.Quote({{$sideFrom.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
+			{{$fromWhereColAlias := index $sideFrom.Columns $where.Column -}}
+			{{$sideFrom.UpPlural}}.Columns.{{$fromWhereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
 			{{end -}}
 			{{range $where := $side.ToWhere -}}
-			{{$.Dialect}}.Quote({{$sideTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
+			{{$toWhereColAlias := index $sideTo.Columns $where.Column -}}
+			{{$sideTo.UpPlural}}.Columns.{{$toWhereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
 			{{end -}}
 		),
 		{{end -}}
@@ -260,13 +267,15 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		sm.Where({{$.Dialect}}.Group(
 			{{range $index, $local := $firstSide.FromColumns -}}
 			{{$toLocal := index $firstSide.ToColumns $index -}}
-			{{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}}),
+			{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+			{{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}},
 			{{end -}}
-		).OP("IN", PKArgExpr)),
+		).In(PKArgExpr)),
 		// GROUP BY fk columns
 		{{range $index, $local := $firstSide.FromColumns -}}
 		{{$toLocal := index $firstSide.ToColumns $index -}}
-		sm.GroupBy({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}})),
+		{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+		sm.GroupBy({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}),
 		{{end -}}
 	}
 	batchMods = append(batchMods, mods...)

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -10,6 +10,7 @@
 {{$.Importer.Import "context"}}
 {{$.Importer.Import "github.com/stephenafamo/bob"}}
 {{$.Importer.Import "github.com/stephenafamo/bob/orm"}}
+{{$.Importer.Import "github.com/stephenafamo/scan"}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s" $.Dialect)}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/dialect" $.Dialect)}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/sm" $.Dialect)}}
@@ -153,17 +154,180 @@ func (o *{{$tAlias.UpSingular}}) LoadCount{{$relAlias}}(ctx context.Context, exe
 	return nil
 }
 
-// LoadCount{{$relAlias}} loads the count of {{$relAlias}} for a slice
+// LoadCount{{$relAlias}} loads the count of {{$relAlias}} for a slice in a single batch query
 func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
 	if len(os) == 0 {
 		return nil
 	}
 
+	{{$firstSide := index $rel.Sides 0 -}}
+	{{$firstFrom := $.Aliases.Table $firstSide.From -}}
+	{{$firstTo := $.Aliases.Table $firstSide.To -}}
+
+	// Build the IN arg expression from parent PKs
+	{{- if ne $.Dialect "psql"}}
+	PKArgSlice := make([]bob.Expression, 0, len(os))
 	for _, o := range os {
-		if err := o.LoadCount{{$relAlias}}(ctx, exec, mods...); err != nil {
-			return err
+		if o == nil {
+			continue
 		}
+		PKArgSlice = append(PKArgSlice, {{$.Dialect}}.ArgGroup(
+			{{- range $index, $local := $firstSide.FromColumns -}}
+			{{- $fromCol := index $firstFrom.Columns $local -}}
+			o.{{$fromCol}},
+			{{- end -}}
+		))
 	}
+	PKArgExpr := {{$.Dialect}}.Group(PKArgSlice...)
+	{{- else}}
+	{{$.Importer.Import "github.com/stephenafamo/bob/types/pgtypes" -}}
+	{{- range $index, $local := $firstSide.FromColumns -}}
+	{{- $column := $.Table.GetColumn $local -}}
+	{{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+	{{- $fromCol := index $firstFrom.Columns $local}}
+	pk{{$fromCol}} := make(pgtypes.Array[{{$colTyp}}], 0, len(os))
+	{{- end}}
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		{{- range $index, $local := $firstSide.FromColumns -}}
+		{{- $fromCol := index $firstFrom.Columns $local}}
+		pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
+		{{- end}}
+	}
+	PKArgExpr := {{$.Dialect}}.Select(sm.Columns(
+		{{- range $index, $local := $firstSide.FromColumns -}}
+		{{- $column := $.Table.GetColumn $local -}}
+		{{- $fromCol := index $firstFrom.Columns $local}}
+		{{$.Dialect}}.F("unnest", {{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]")),
+		{{- end}}
+	))
+	{{- end}}
+
+	// countResult holds one scanned row from the batch count query.
+	// FK columns are aliased to the parent PK column names for direct map lookup.
+	type countResult struct {
+		{{range $index, $local := $firstSide.FromColumns -}}
+		{{- $column := $.Table.GetColumn $local -}}
+		{{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+		{{- $fromCol := index $firstFrom.Columns $local}}
+		{{$fromCol}} {{$colTyp}}
+		{{end -}}
+		Count int64
+	}
+
+	batchMods := []bob.Mod[*dialect.SelectQuery]{
+		// SELECT fk AS parent_pk, count(*)
+		sm.Columns(
+			{{range $index, $local := $firstSide.FromColumns -}}
+			{{$toLocal := index $firstSide.ToColumns $index -}}
+			{{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}}).As({{quote $local}}),
+			{{end -}}
+			{{$.Dialect}}.Raw("count(*) as count"),
+		),
+		{{if eq (len $rel.Sides) 1 -}}
+		// Single-hop: FROM related table directly
+		sm.From({{$fAlias.UpPlural}}.NameAs()),
+		{{range $where := $firstSide.ToWhere -}}
+		sm.Where({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
+		{{end -}}
+		{{- else -}}
+		// Multi-hop: FROM first join table, JOIN through to final related table
+		sm.From({{$firstTo.UpPlural}}.NameAs()),
+		{{range $where := $firstSide.ToWhere -}}
+		sm.Where({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
+		{{end -}}
+		{{range $sideIndex, $side := $rel.Sides -}}
+		{{if eq $sideIndex 0 -}}{{continue}}{{end -}}
+		{{$sideFrom := $.Aliases.Table $side.From -}}
+		{{$sideTo := $.Aliases.Table $side.To -}}
+		sm.InnerJoin({{$sideTo.UpPlural}}.NameAs()).On(
+			{{range $i, $fromColKey := $side.FromColumns -}}
+			{{$toColKey := index $side.ToColumns $i -}}
+			{{$.Dialect}}.Quote({{$sideTo.UpPlural}}.Alias(), {{quote $toColKey}}).EQ({{$.Dialect}}.Quote({{$sideFrom.UpPlural}}.Alias(), {{quote $fromColKey}})),
+			{{end -}}
+			{{range $where := $side.FromWhere -}}
+			{{$.Dialect}}.Quote({{$sideFrom.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
+			{{end -}}
+			{{range $where := $side.ToWhere -}}
+			{{$.Dialect}}.Quote({{$sideTo.UpPlural}}.Alias(), {{quote $where.Column}}).EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}})),
+			{{end -}}
+		),
+		{{end -}}
+		{{- end}}
+		// WHERE fk IN (parent PKs)
+		sm.Where({{$.Dialect}}.Group(
+			{{range $index, $local := $firstSide.FromColumns -}}
+			{{$toLocal := index $firstSide.ToColumns $index -}}
+			{{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}}),
+			{{end -}}
+		).OP("IN", PKArgExpr)),
+		// GROUP BY fk columns
+		{{range $index, $local := $firstSide.FromColumns -}}
+		{{$toLocal := index $firstSide.ToColumns $index -}}
+		sm.GroupBy({{$.Dialect}}.Quote({{$firstTo.UpPlural}}.Alias(), {{quote $toLocal}})),
+		{{end -}}
+	}
+	batchMods = append(batchMods, mods...)
+
+	results, err := bob.All(ctx, exec,
+		{{$.Dialect}}.Select(batchMods...),
+		scan.StructMapper[countResult](),
+	)
+	if err != nil {
+		return err
+	}
+
+	{{if eq (len $firstSide.FromColumns) 1 -}}
+	{{$local := index $firstSide.FromColumns 0 -}}
+	{{$column := $.Table.GetColumn $local -}}
+	{{$colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+	{{$fromCol := index $firstFrom.Columns $local -}}
+	// Single-column FK: direct map lookup
+	countMap := make(map[{{$colTyp}}]int64, len(results))
+	for _, r := range results {
+		countMap[r.{{$fromCol}}] = r.Count
+	}
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		count := countMap[o.{{$fromCol}}]
+		o.C.{{$relAlias}} = &count
+	}
+	{{- else -}}
+	// Composite FK: use a key struct
+	type countKey struct {
+		{{range $index, $local := $firstSide.FromColumns -}}
+		{{- $column := $.Table.GetColumn $local -}}
+		{{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+		{{- $fromCol := index $firstFrom.Columns $local}}
+		{{$fromCol}} {{$colTyp}}
+		{{end -}}
+	}
+	countMap := make(map[countKey]int64, len(results))
+	for _, r := range results {
+		countMap[countKey{
+			{{range $index, $local := $firstSide.FromColumns -}}
+			{{- $fromCol := index $firstFrom.Columns $local}}
+			{{$fromCol}}: r.{{$fromCol}},
+			{{end -}}
+		}] = r.Count
+	}
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		count := countMap[countKey{
+			{{range $index, $local := $firstSide.FromColumns -}}
+			{{- $fromCol := index $firstFrom.Columns $local}}
+			{{$fromCol}}: o.{{$fromCol}},
+			{{end -}}
+		}]
+		o.C.{{$relAlias}} = &count
+	}
+	{{- end}}
 
 	return nil
 }

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -274,7 +274,7 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		{{$local := index $firstSide.FromColumns 0 -}}
 		{{$toLocal := index $firstSide.ToColumns 0 -}}
 		{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
-		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.In(PKArgExpr)),
+		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.OP("IN", PKArgExpr)),
 		{{- else -}}
 		sm.Where({{$.Dialect}}.Group(
 			{{range $index, $local := $firstSide.FromColumns -}}
@@ -282,7 +282,7 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 			{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
 			{{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}},
 			{{end -}}
-		).In(PKArgExpr)),
+		).OP("IN", PKArgExpr)),
 		{{- end}}
 		// GROUP BY fk columns
 		{{range $index, $local := $firstSide.FromColumns -}}

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -492,34 +492,30 @@ func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
 	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 
-	// Create 3 videos for user1, capturing the first one's ID for filtering
-	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	for i := 0; i < 2; i++ {
-		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	}
-	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	// Create 3 videos for each user
 	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
 		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
 	}
 
 	users := models.UserSlice{user1, user2}
-	// Filter: only count videos with ID > firstVideo.ID
-	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
-	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+	// Filter: only count videos belonging to user1.
+	// user1: 3 (all their videos match), user2: 0 (none of their videos match)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.UserID.EQ(user1.ID)); err != nil {
 		t.Fatalf("Error loading count for Videos with mod: %v", err)
 	}
 
 	if user1.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user1, got nil")
 	}
-	if *user1.C.Videos != 2 {
-		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	if *user1.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 3, got %d", *user1.C.Videos)
 	}
 	if user2.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user2, got nil")
 	}
-	if *user2.C.Videos != 3 {
-		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
+	if *user2.C.Videos != 0 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 0, got %d", *user2.C.Videos)
 	}
 }
 

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -446,12 +446,12 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 	}
 	defer tx.Rollback(ctx)
 
-	// Create 2 users
-	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 2)
+	// Create 3 users
+	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 3)
 
-	// Create different number of videos for each user
+	// Create different number of videos for each user (0, 1, 2)
 	for i, user := range users {
-		numVideos := i + 1 // First user gets 1, second gets 2
+		numVideos := i // First user gets 0, second gets 1, third gets 2
 		for j := 0; j < numVideos; j++ {
 			New().NewVideoWithContext(ctx,
 				VideoMods.WithExistingUser(user),
@@ -464,15 +464,62 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 		t.Fatalf("Error loading count for Videos: %v", err)
 	}
 
-	// Verify counts
+	// Verify counts, including the zero-count case
 	for i, user := range users {
-		expectedCount := int64(i + 1)
+		expectedCount := int64(i)
 		if user.C.Videos == nil {
 			t.Fatalf("Expected Videos count to be set for user %d, got nil", i)
 		}
 		if *user.C.Videos != expectedCount {
 			t.Fatalf("Expected Videos count for user %d to be %d, got %d", i, expectedCount, *user.C.Videos)
 		}
+	}
+}
+
+// TestLoadCountUserVideosSliceWithMods tests that user-provided mods are applied to the batch count query
+func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	// Create 3 videos for user1, capturing the first one's ID for filtering
+	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	for i := 0; i < 2; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	}
+	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
+	}
+
+	users := models.UserSlice{user1, user2}
+	// Filter: only count videos with ID > firstVideo.ID
+	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+		t.Fatalf("Error loading count for Videos with mod: %v", err)
+	}
+
+	if user1.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user1, got nil")
+	}
+	if *user1.C.Videos != 2 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	}
+	if user2.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user2, got nil")
+	}
+	if *user2.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
 	}
 }
 

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -847,6 +847,65 @@ func TestLoadCountTagVideos(t *testing.T) {
 		t.Fatalf("Expected Videos count to be 3, got %d", *tag.C.Videos)
 	}
 }
+
+// TestLoadCountVideoTagsSlice tests that LoadCountTags works correctly for VideoSlice (multi-hop/many-to-many)
+func TestLoadCountVideoTagsSlice(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Create 3 videos: first gets 0 tags, second gets 1, third gets 3
+	video0 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video1 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video3 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	for i := 0; i < 1; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video1.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video1: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video3.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video3: %v", err)
+		}
+	}
+
+	videos := models.VideoSlice{video0, video1, video3}
+	if err := videos.LoadCountTags(ctx, tx); err != nil {
+		t.Fatalf("Error loading count for Tags on VideoSlice: %v", err)
+	}
+
+	// video0 has no tags — batch must set count to 0, not nil
+	if videos[0].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set (0) for video0, got nil")
+	}
+	if *videos[0].C.Tags != 0 {
+		t.Fatalf("Expected Tags count for video0 to be 0, got %d", *videos[0].C.Tags)
+	}
+
+	if videos[1].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video1, got nil")
+	}
+	if *videos[1].C.Tags != 1 {
+		t.Fatalf("Expected Tags count for video1 to be 1, got %d", *videos[1].C.Tags)
+	}
+
+	if videos[2].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video3, got nil")
+	}
+	if *videos[2].C.Tags != 3 {
+		t.Fatalf("Expected Tags count for video3 to be 3, got %d", *videos[2].C.Tags)
+	}
+}
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -492,34 +492,30 @@ func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
 	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 
-	// Create 3 videos for user1, capturing the first one's ID for filtering
-	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	for i := 0; i < 2; i++ {
-		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	}
-	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	// Create 3 videos for each user
 	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
 		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
 	}
 
 	users := models.UserSlice{user1, user2}
-	// Filter: only count videos with ID > firstVideo.ID
-	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
-	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+	// Filter: only count videos belonging to user1.
+	// user1: 3 (all their videos match), user2: 0 (none of their videos match)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.UserID.EQ(user1.ID)); err != nil {
 		t.Fatalf("Error loading count for Videos with mod: %v", err)
 	}
 
 	if user1.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user1, got nil")
 	}
-	if *user1.C.Videos != 2 {
-		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	if *user1.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 3, got %d", *user1.C.Videos)
 	}
 	if user2.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user2, got nil")
 	}
-	if *user2.C.Videos != 3 {
-		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
+	if *user2.C.Videos != 0 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 0, got %d", *user2.C.Videos)
 	}
 }
 

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -446,12 +446,12 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 	}
 	defer tx.Rollback(ctx)
 
-	// Create 2 users
-	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 2)
+	// Create 3 users
+	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 3)
 
-	// Create different number of videos for each user
+	// Create different number of videos for each user (0, 1, 2)
 	for i, user := range users {
-		numVideos := i + 1 // First user gets 1, second gets 2
+		numVideos := i // First user gets 0, second gets 1, third gets 2
 		for j := 0; j < numVideos; j++ {
 			New().NewVideoWithContext(ctx,
 				VideoMods.WithExistingUser(user),
@@ -464,15 +464,62 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 		t.Fatalf("Error loading count for Videos: %v", err)
 	}
 
-	// Verify counts
+	// Verify counts, including the zero-count case
 	for i, user := range users {
-		expectedCount := int64(i + 1)
+		expectedCount := int64(i)
 		if user.C.Videos == nil {
 			t.Fatalf("Expected Videos count to be set for user %d, got nil", i)
 		}
 		if *user.C.Videos != expectedCount {
 			t.Fatalf("Expected Videos count for user %d to be %d, got %d", i, expectedCount, *user.C.Videos)
 		}
+	}
+}
+
+// TestLoadCountUserVideosSliceWithMods tests that user-provided mods are applied to the batch count query
+func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	// Create 3 videos for user1, capturing the first one's ID for filtering
+	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	for i := 0; i < 2; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	}
+	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
+	}
+
+	users := models.UserSlice{user1, user2}
+	// Filter: only count videos with ID > firstVideo.ID
+	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+		t.Fatalf("Error loading count for Videos with mod: %v", err)
+	}
+
+	if user1.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user1, got nil")
+	}
+	if *user1.C.Videos != 2 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	}
+	if user2.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user2, got nil")
+	}
+	if *user2.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
 	}
 }
 

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -847,6 +847,65 @@ func TestLoadCountTagVideos(t *testing.T) {
 		t.Fatalf("Expected Videos count to be 3, got %d", *tag.C.Videos)
 	}
 }
+
+// TestLoadCountVideoTagsSlice tests that LoadCountTags works correctly for VideoSlice (multi-hop/many-to-many)
+func TestLoadCountVideoTagsSlice(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Create 3 videos: first gets 0 tags, second gets 1, third gets 3
+	video0 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video1 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video3 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	for i := 0; i < 1; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video1.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video1: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video3.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video3: %v", err)
+		}
+	}
+
+	videos := models.VideoSlice{video0, video1, video3}
+	if err := videos.LoadCountTags(ctx, tx); err != nil {
+		t.Fatalf("Error loading count for Tags on VideoSlice: %v", err)
+	}
+
+	// video0 has no tags — batch must set count to 0, not nil
+	if videos[0].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set (0) for video0, got nil")
+	}
+	if *videos[0].C.Tags != 0 {
+		t.Fatalf("Expected Tags count for video0 to be 0, got %d", *videos[0].C.Tags)
+	}
+
+	if videos[1].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video1, got nil")
+	}
+	if *videos[1].C.Tags != 1 {
+		t.Fatalf("Expected Tags count for video1 to be 1, got %d", *videos[1].C.Tags)
+	}
+
+	if videos[2].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video3, got nil")
+	}
+	if *videos[2].C.Tags != 3 {
+		t.Fatalf("Expected Tags count for video3 to be 3, got %d", *videos[2].C.Tags)
+	}
+}
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -822,6 +822,65 @@ func TestLoadCountTagVideos(t *testing.T) {
 		t.Fatalf("Expected Videos count to be 3, got %d", *tag.C.Videos)
 	}
 }
+
+// TestLoadCountVideoTagsSlice tests that LoadCountTags works correctly for VideoSlice (multi-hop/many-to-many)
+func TestLoadCountVideoTagsSlice(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Create 3 videos: first gets 0 tags, second gets 1, third gets 3
+	video0 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video1 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+	video3 := New().NewVideoWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	for i := 0; i < 1; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video1.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video1: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		tag := New().NewTagWithContext(ctx).CreateOrFail(ctx, t, tx)
+		if err := video3.AttachTags(ctx, tx, tag); err != nil {
+			t.Fatalf("Error attaching Tag to video3: %v", err)
+		}
+	}
+
+	videos := models.VideoSlice{video0, video1, video3}
+	if err := videos.LoadCountTags(ctx, tx); err != nil {
+		t.Fatalf("Error loading count for Tags on VideoSlice: %v", err)
+	}
+
+	// video0 has no tags — batch must set count to 0, not nil
+	if videos[0].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set (0) for video0, got nil")
+	}
+	if *videos[0].C.Tags != 0 {
+		t.Fatalf("Expected Tags count for video0 to be 0, got %d", *videos[0].C.Tags)
+	}
+
+	if videos[1].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video1, got nil")
+	}
+	if *videos[1].C.Tags != 1 {
+		t.Fatalf("Expected Tags count for video1 to be 1, got %d", *videos[1].C.Tags)
+	}
+
+	if videos[2].C.Tags == nil {
+		t.Fatal("Expected Tags count to be set for video3, got nil")
+	}
+	if *videos[2].C.Tags != 3 {
+		t.Fatalf("Expected Tags count for video3 to be 3, got %d", *videos[2].C.Tags)
+	}
+}
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -461,34 +461,30 @@ func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
 	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
 
-	// Create 3 videos for user1, capturing the first one's ID for filtering
-	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	for i := 0; i < 2; i++ {
-		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
-	}
-	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	// Create 3 videos for each user
 	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
 		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
 	}
 
 	users := models.UserSlice{user1, user2}
-	// Filter: only count videos with ID > firstVideo.ID
-	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
-	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+	// Filter: only count videos belonging to user1.
+	// user1: 3 (all their videos match), user2: 0 (none of their videos match)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.UserID.EQ(user1.ID)); err != nil {
 		t.Fatalf("Error loading count for Videos with mod: %v", err)
 	}
 
 	if user1.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user1, got nil")
 	}
-	if *user1.C.Videos != 2 {
-		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	if *user1.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 3, got %d", *user1.C.Videos)
 	}
 	if user2.C.Videos == nil {
 		t.Fatal("Expected Videos count to be set for user2, got nil")
 	}
-	if *user2.C.Videos != 3 {
-		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
+	if *user2.C.Videos != 0 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 0, got %d", *user2.C.Videos)
 	}
 }
 

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -415,12 +415,12 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 	}
 	defer tx.Rollback(ctx)
 
-	// Create 2 users
-	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 2)
+	// Create 3 users
+	users := New().NewUserWithContext(ctx).CreateManyOrFail(ctx, t, tx, 3)
 
-	// Create different number of videos for each user
+	// Create different number of videos for each user (0, 1, 2)
 	for i, user := range users {
-		numVideos := i + 1 // First user gets 1, second gets 2
+		numVideos := i // First user gets 0, second gets 1, third gets 2
 		for j := 0; j < numVideos; j++ {
 			New().NewVideoWithContext(ctx,
 				VideoMods.WithExistingUser(user),
@@ -433,15 +433,62 @@ func TestLoadCountUserVideosSlice(t *testing.T) {
 		t.Fatalf("Error loading count for Videos: %v", err)
 	}
 
-	// Verify counts
+	// Verify counts, including the zero-count case
 	for i, user := range users {
-		expectedCount := int64(i + 1)
+		expectedCount := int64(i)
 		if user.C.Videos == nil {
 			t.Fatalf("Expected Videos count to be set for user %d, got nil", i)
 		}
 		if *user.C.Videos != expectedCount {
 			t.Fatalf("Expected Videos count for user %d to be %d, got %d", i, expectedCount, *user.C.Videos)
 		}
+	}
+}
+
+// TestLoadCountUserVideosSliceWithMods tests that user-provided mods are applied to the batch count query
+func TestLoadCountUserVideosSliceWithMods(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	user1 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+	user2 := New().NewUserWithContext(ctx).CreateOrFail(ctx, t, tx)
+
+	// Create 3 videos for user1, capturing the first one's ID for filtering
+	firstVideo := New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	for i := 0; i < 2; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user1)).CreateOrFail(ctx, t, tx)
+	}
+	// Create 3 videos for user2 (all with IDs greater than user1's videos)
+	for i := 0; i < 3; i++ {
+		New().NewVideoWithContext(ctx, VideoMods.WithExistingUser(user2)).CreateOrFail(ctx, t, tx)
+	}
+
+	users := models.UserSlice{user1, user2}
+	// Filter: only count videos with ID > firstVideo.ID
+	// user1: 2 (the first video is excluded), user2: 3 (all IDs are greater)
+	if err := users.LoadCountVideos(ctx, tx, models.SelectWhere.Videos.ID.GT(firstVideo.ID)); err != nil {
+		t.Fatalf("Error loading count for Videos with mod: %v", err)
+	}
+
+	if user1.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user1, got nil")
+	}
+	if *user1.C.Videos != 2 {
+		t.Fatalf("Expected filtered Videos count for user1 to be 2, got %d", *user1.C.Videos)
+	}
+	if user2.C.Videos == nil {
+		t.Fatal("Expected Videos count to be set for user2, got nil")
+	}
+	if *user2.C.Videos != 3 {
+		t.Fatalf("Expected filtered Videos count for user2 to be 3, got %d", *user2.C.Videos)
 	}
 }
 


### PR DESCRIPTION
## Batch `LoadCount` for slices                                                                                                                         
                                                            
### Problem                                                                                                                                             
                                                                                                                                                        
`<Model>Slice.LoadCount<Rel>()` previously executed one `SELECT COUNT(*)` query per item                                                                
in the slice - an N+1 pattern. For a slice of 100 videos, loading the tag count fired 100
separate queries.                                                                                                                                       
                                                          
### Solution                                                                                                                                            
                                                          
Rewrite the generated slice `LoadCount` methods to execute a **single batch query** that                                                                
fetches counts for all parents at once, then distribute results to each model in Go.
                                                                                                                                                        
The generated SQL looks like:                                                                                                                           
                                                                                                                                                        
```sql                                                                                                                                                  
SELECT fk_col, count(*) as count                          
FROM related_table
WHERE fk_col IN ($1, $2, ...)   -- MySQL/SQLite, single-column FK
GROUP BY fk_col                                                                                                                                         
 ```
Results are scanned into a local struct and distributed via a map lookup. Parents with no                                                               
related rows get count = 0.                               
                                                                                                                                                        
### Code paths                                                
                                                                                                                                                        
#### IN clause - dialect-specific                                                                                                                            
 
- MySQL / SQLite, single-column FK: `col IN ($1, $2, ...)` - plain scalar list                                                                            
- MySQL / SQLite, composite FK: `(col1, col2) IN (($1, $2), ($3, $4), ...)` - row value form, which SQLite supports for multi-column tuples
- PostgreSQL: `unnest(CAST($1 AS type[]))` - a single array argument instead of N placeholders, avoiding prepared-statement parameter limits on large slices                                                                                                                                                  
                                                                                                                                                        
                                 
#### Relationship hops                                                                                                                                       
                                                                                                                                                        
- **Single-hop** (e.g. `Video → Tags` via direct FK):
  `FROM related_table WHERE fk IN (...) GROUP BY fk`
- **Multi-hop** (e.g. `Video → Tags` via `video_tags` join table):
  `FROM join_table INNER JOIN related_table ON ... WHERE join_fk IN (...) GROUP BY join_fk`
  - Static `FromWhere`/`ToWhere` filters are applied per side                                                                                         
                                                                                                                                                        
#### FK arity

- **Single-column FK**: map key is the FK type directly - `map[uint64]int64`
- **Composite FK**: a local `countKey` struct is generated as the map key - `map[countKey]int64`

#### `ThenLoadCount`

No changes needed. `ThenLoadCount` delegates to `LoadCount` via `AfterPreloader` and
automatically benefits from this change.

#### Single-model `LoadCount`

Unchanged - continues to use the typed query method (`.Count(ctx, exec)`), which is
appropriate for the single-item case.