### PR TITLE
feat(query): add immutable with helpers

### DIFF
--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -95,6 +95,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -107,6 +107,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -1,0 +1,156 @@
+package psql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func TestBaseQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := Select(
+		sm.Columns("id"),
+		sm.From("users"),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Type() != bob.QueryTypeSelect {
+		t.Fatalf("expected derived query type %q, got %q", bob.QueryTypeSelect, derived.Type())
+	}
+
+	baseSQL := selectToString(t, base, 0)
+	if baseSQL != "SELECT \nid\nFROM users\n" {
+		t.Fatalf("base query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived, 0)
+	if derivedSQL != "SELECT \nid\nFROM users\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived query mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestViewQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := someStructView.Query(
+		sm.Where(Quote("id").GT(Arg(0))),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Scanner == nil {
+		t.Fatal("expected derived view query to preserve scanner")
+	}
+
+	baseSQL := selectToString(t, base.BaseQuery, 1)
+	if baseSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\n" {
+		t.Fatalf("base view query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived.BaseQuery, 1)
+	if derivedSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived view query mismatch: %#v", derivedSQL)
+	}
+}
+
+func BenchmarkBaseQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBaseQueryWithImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -117,6 +117,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/hooks.go
+++ b/hooks.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 	"sync"
 )
 
@@ -84,6 +85,12 @@ func (h *Hooks[T, K]) RunHooks(ctx context.Context, exec Executor, o T) (context
 
 type EmbeddedHook struct {
 	Hooks []func(context.Context, Executor) (context.Context, error)
+}
+
+func (h EmbeddedHook) Clone() EmbeddedHook {
+	h.Hooks = slices.Clone(h.Hooks)
+
+	return h
 }
 
 func (h *EmbeddedHook) SetHooks(hooks ...func(context.Context, Executor) (context.Context, error)) {

--- a/load.go
+++ b/load.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 
 	"github.com/stephenafamo/scan"
 )
@@ -35,6 +36,13 @@ func (l LoaderFunc) Load(ctx context.Context, exec Executor, retrieved any) erro
 type Load struct {
 	loadFuncs         []Loader
 	preloadMapperMods []scan.MapperMod
+}
+
+func (l Load) Clone() Load {
+	l.loadFuncs = slices.Clone(l.loadFuncs)
+	l.preloadMapperMods = slices.Clone(l.preloadMapperMods)
+
+	return l
 }
 
 func (l *Load) SetMapperMods(mods ...scan.MapperMod) {

--- a/mods.go
+++ b/mods.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 )
 
 // Mod is a generic interface for modifying a query
@@ -51,6 +52,12 @@ func (c ContextualModFunc[T]) Apply(ctx context.Context, o T) (context.Context, 
 
 type ContextualModdable[T any] struct {
 	Mods []ContextualMod[T]
+}
+
+func (h ContextualModdable[T]) Clone() ContextualModdable[T] {
+	h.Mods = slices.Clone(h.Mods)
+
+	return h
 }
 
 // AppendContextualMod a hook to the set

--- a/orm/query.go
+++ b/orm/query.go
@@ -22,6 +22,13 @@ func (q ExecQuery[Q]) Clone() ExecQuery[Q] {
 	}
 }
 
+func (q ExecQuery[Q]) With(mods ...bob.Mod[Q]) ExecQuery[Q] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
+}
+
 func (q ExecQuery[Q]) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
 	var err error
 
@@ -55,7 +62,15 @@ type Query[Q bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
 func (q Query[Q, T, Ts, Tr]) Clone() Query[Q, T, Ts, Tr] {
 	return Query[Q, T, Ts, Tr]{
 		ExecQuery: q.ExecQuery.Clone(),
+		Scanner:   q.Scanner,
 	}
+}
+
+func (q Query[Q, T, Ts, Tr]) With(mods ...bob.Mod[Q]) Query[Q, T, Ts, Tr] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 // First matching row

--- a/query.go
+++ b/query.go
@@ -71,12 +71,14 @@ func (b BaseQuery[E]) Clone() BaseQuery[E] {
 		return BaseQuery[E]{
 			Expression: c.Clone(),
 			Dialect:    b.Dialect,
+			QueryType:  b.QueryType,
 		}
 	}
 
 	return BaseQuery[E]{
 		Expression: reprint.This(b.Expression).(E),
 		Dialect:    b.Dialect,
+		QueryType:  b.QueryType,
 	}
 }
 
@@ -116,6 +118,13 @@ func (b BaseQuery[E]) Apply(mods ...Mod[E]) {
 	for _, mod := range mods {
 		mod.Apply(b.Expression)
 	}
+}
+
+func (b BaseQuery[E]) With(mods ...Mod[E]) BaseQuery[E] {
+	clone := b.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 func (b BaseQuery[E]) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {


### PR DESCRIPTION
Adds an immutable-style query derivation API without changing the existing mutable `Apply(...)` behavior.

This PR introduces `With(...)` on the core query wrappers so callers can derive a modified query while leaving the source query unchanged.

Stack:
- 1/5
- branch: `query-with-helpers`
- base: `main`
- later PRs in this stack build on top of this branch locally, but GitHub requires them to target `main` in the upstream repo, so their diffs will include earlier commits until this lands.

Benchmarks

Upstream `main` baseline:
```text
BenchmarkBaseQueryApplyMain                     3039 ns/op   2865 B/op    48 allocs/op
BenchmarkViewQueryCountThenPaginateApplyMain  10070 ns/op   7424 B/op   130 allocs/op
```

This branch immutable path:
```text
BenchmarkBaseQueryWithImmutableWithHelpers                     10425 ns/op   5330 B/op    98 allocs/op
BenchmarkViewQueryCountThenPaginateImmutableWithHelpers       22045 ns/op   9863 B/op   178 allocs/op
```

Verification:
- `go test ./dialect/psql ./dialect/mysql ./dialect/sqlite ./orm`
- `go test ./dialect/psql -run '^$' -bench 'Benchmark(BaseQueryApplyMain|BaseQueryWithImmutableWithHelpers|ViewQueryCountThenPaginateApplyMain|ViewQueryCountThenPaginateImmutableWithHelpers)$' -benchmem`
