### PR TITLE
perf(query): use copy-on-write select clones

### DIFF
--- a/clause/clone.go
+++ b/clause/clone.go
@@ -1,0 +1,93 @@
+package clause
+
+import "slices"
+
+func (w With) Clone() With {
+	w.CTEs = slices.Clone(w.CTEs)
+
+	return w
+}
+
+func (s SelectList) Clone() SelectList {
+	s.Columns = slices.Clone(s.Columns)
+	s.PreloadColumns = slices.Clone(s.PreloadColumns)
+
+	return s
+}
+
+func (f TableRef) Clone() TableRef {
+	f.Columns = slices.Clone(f.Columns)
+	f.Partitions = slices.Clone(f.Partitions)
+	f.IndexHints = slices.Clone(f.IndexHints)
+	f.Joins = cloneJoins(f.Joins)
+
+	if f.IndexedBy != nil {
+		indexedBy := *f.IndexedBy
+		f.IndexedBy = &indexedBy
+	}
+
+	return f
+}
+
+func cloneJoins(joins []Join) []Join {
+	if joins == nil {
+		return nil
+	}
+
+	cloned := make([]Join, len(joins))
+	for i, join := range joins {
+		cloned[i] = join.Clone()
+	}
+
+	return cloned
+}
+
+func (j Join) Clone() Join {
+	j.To = j.To.Clone()
+	j.On = slices.Clone(j.On)
+	j.Using = slices.Clone(j.Using)
+
+	return j
+}
+
+func (w Where) Clone() Where {
+	w.Conditions = slices.Clone(w.Conditions)
+
+	return w
+}
+
+func (g GroupBy) Clone() GroupBy {
+	g.Groups = slices.Clone(g.Groups)
+
+	return g
+}
+
+func (h Having) Clone() Having {
+	h.Conditions = slices.Clone(h.Conditions)
+
+	return h
+}
+
+func (w Windows) Clone() Windows {
+	w.Windows = slices.Clone(w.Windows)
+
+	return w
+}
+
+func (c Combines) Clone() Combines {
+	c.Queries = slices.Clone(c.Queries)
+
+	return c
+}
+
+func (o OrderBy) Clone() OrderBy {
+	o.Expressions = slices.Clone(o.Expressions)
+
+	return o
+}
+
+func (l Locks) Clone() Locks {
+	l.Locks = slices.Clone(l.Locks)
+
+	return l
+}

--- a/dialect/mysql/dialect/clone.go
+++ b/dialect/mysql/dialect/clone.go
@@ -1,0 +1,259 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedHints selectShared = 1 << iota
+	sharedModifiers
+	sharedWith
+	sharedSelect
+	sharedPreloadSelect
+	sharedPartitions
+	sharedIndexHints
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedCombinedOrder
+	sharedLocks
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedHints |
+	sharedModifiers |
+	sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedPartitions |
+	sharedIndexHints |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedCombinedOrder |
+	sharedLocks |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedHints:
+		s.hints.hints = slices.Clone(s.hints.hints)
+	case sharedModifiers:
+		s.modifiers.modifiers = slices.Clone(s.modifiers.modifiers)
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedPartitions:
+		s.TableRef.Partitions = slices.Clone(s.TableRef.Partitions)
+	case sharedIndexHints:
+		s.TableRef.IndexHints = slices.Clone(s.TableRef.IndexHints)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedCombinedOrder:
+		s.CombinedOrder.Expressions = slices.Clone(s.CombinedOrder.Expressions)
+	case sharedLocks:
+		s.Locks.Locks = slices.Clone(s.Locks.Locks)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendHint(hint string) {
+	s.cloneOnWrite(sharedHints)
+	s.hints.AppendHint(hint)
+}
+
+func (s *SelectQuery) AppendModifier(modifier any) {
+	s.cloneOnWrite(sharedModifiers)
+	s.modifiers.AppendModifier(modifier)
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPartition(partitions ...string) {
+	s.cloneOnWrite(sharedPartitions)
+	s.TableRef.AppendPartition(partitions...)
+}
+
+func (s *SelectQuery) AppendIndexHint(hint clause.IndexHint) {
+	s.cloneOnWrite(sharedIndexHints)
+	s.TableRef.AppendIndexHint(hint)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendCombinedOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedCombinedOrder)
+	s.CombinedOrder.AppendOrder(order)
+}
+
+func (s *SelectQuery) AppendLock(lock bob.Expression) {
+	s.cloneOnWrite(sharedLocks)
+	s.Locks.AppendLock(lock)
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/mysql/dialect/mods.go
+++ b/dialect/mysql/dialect/mods.go
@@ -260,7 +260,7 @@ func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
 type OrderCombined OrderBy[*SelectQuery]
 
 func (o OrderCombined) Apply(q *SelectQuery) {
-	q.CombinedOrder.AppendOrder(o())
+	q.AppendCombinedOrder(o())
 }
 
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef

--- a/dialect/mysql/dialect/select.go
+++ b/dialect/mysql/dialect/select.go
@@ -35,6 +35,8 @@ type SelectQuery struct {
 	CombinedOrder  clause.OrderBy
 	CombinedLimit  clause.Limit
 	CombinedOffset clause.Offset
+
+	shared selectShared
 }
 
 func (s *SelectQuery) SetInto(i any) {

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -95,6 +95,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/dialect/clone.go
+++ b/dialect/psql/dialect/clone.go
@@ -1,0 +1,227 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedWith selectShared = 1 << iota
+	sharedSelect
+	sharedPreloadSelect
+	sharedDistinctOn
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedCombinedOrder
+	sharedLocks
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedDistinctOn |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedCombinedOrder |
+	sharedLocks |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedDistinctOn:
+		s.Distinct.On = slices.Clone(s.Distinct.On)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedCombinedOrder:
+		s.CombinedOrder.Expressions = slices.Clone(s.CombinedOrder.Expressions)
+	case sharedLocks:
+		s.Locks.Locks = slices.Clone(s.Locks.Locks)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) AppendCombinedOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedCombinedOrder)
+	s.CombinedOrder.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendLock(lock bob.Expression) {
+	s.cloneOnWrite(sharedLocks)
+	s.Locks.AppendLock(lock)
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -220,7 +220,7 @@ func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
 type OrderCombined OrderBy[*SelectQuery]
 
 func (o OrderCombined) Apply(q *SelectQuery) {
-	q.CombinedOrder.AppendOrder(o())
+	q.AppendCombinedOrder(o())
 }
 
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -34,6 +34,8 @@ type SelectQuery struct {
 	CombinedLimit  clause.Limit
 	CombinedFetch  clause.Fetch
 	CombinedOffset clause.Offset
+
+	shared selectShared
 }
 
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -107,6 +107,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -83,7 +83,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkBaseQueryWithImmutableWithHelpers(b *testing.B) {
+func BenchmarkBaseQueryWithImmutableCopyOnWrite(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -130,7 +130,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkViewQueryCountThenPaginateImmutableWithHelpers(b *testing.B) {
+func BenchmarkViewQueryCountThenPaginateImmutableCopyOnWrite(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -1,0 +1,156 @@
+package psql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func TestBaseQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := Select(
+		sm.Columns("id"),
+		sm.From("users"),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Type() != bob.QueryTypeSelect {
+		t.Fatalf("expected derived query type %q, got %q", bob.QueryTypeSelect, derived.Type())
+	}
+
+	baseSQL := selectToString(t, base, 0)
+	if baseSQL != "SELECT \nid\nFROM users\n" {
+		t.Fatalf("base query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived, 0)
+	if derivedSQL != "SELECT \nid\nFROM users\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived query mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestViewQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := someStructView.Query(
+		sm.Where(Quote("id").GT(Arg(0))),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Scanner == nil {
+		t.Fatal("expected derived view query to preserve scanner")
+	}
+
+	baseSQL := selectToString(t, base.BaseQuery, 1)
+	if baseSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\n" {
+		t.Fatalf("base view query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived.BaseQuery, 1)
+	if derivedSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived view query mismatch: %#v", derivedSQL)
+	}
+}
+
+func BenchmarkBaseQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBaseQueryWithImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dialect/sqlite/dialect/clone.go
+++ b/dialect/sqlite/dialect/clone.go
@@ -1,0 +1,205 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedWith selectShared = 1 << iota
+	sharedSelect
+	sharedPreloadSelect
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/sqlite/dialect/select.go
+++ b/dialect/sqlite/dialect/select.go
@@ -27,6 +27,8 @@ type SelectQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*SelectQuery]
+
+	shared selectShared
 }
 
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -117,6 +117,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/hooks.go
+++ b/hooks.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 	"sync"
 )
 
@@ -84,6 +85,12 @@ func (h *Hooks[T, K]) RunHooks(ctx context.Context, exec Executor, o T) (context
 
 type EmbeddedHook struct {
 	Hooks []func(context.Context, Executor) (context.Context, error)
+}
+
+func (h EmbeddedHook) Clone() EmbeddedHook {
+	h.Hooks = slices.Clone(h.Hooks)
+
+	return h
 }
 
 func (h *EmbeddedHook) SetHooks(hooks ...func(context.Context, Executor) (context.Context, error)) {

--- a/load.go
+++ b/load.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 
 	"github.com/stephenafamo/scan"
 )
@@ -35,6 +36,13 @@ func (l LoaderFunc) Load(ctx context.Context, exec Executor, retrieved any) erro
 type Load struct {
 	loadFuncs         []Loader
 	preloadMapperMods []scan.MapperMod
+}
+
+func (l Load) Clone() Load {
+	l.loadFuncs = slices.Clone(l.loadFuncs)
+	l.preloadMapperMods = slices.Clone(l.preloadMapperMods)
+
+	return l
 }
 
 func (l *Load) SetMapperMods(mods ...scan.MapperMod) {

--- a/mods.go
+++ b/mods.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 )
 
 // Mod is a generic interface for modifying a query
@@ -51,6 +52,12 @@ func (c ContextualModFunc[T]) Apply(ctx context.Context, o T) (context.Context, 
 
 type ContextualModdable[T any] struct {
 	Mods []ContextualMod[T]
+}
+
+func (h ContextualModdable[T]) Clone() ContextualModdable[T] {
+	h.Mods = slices.Clone(h.Mods)
+
+	return h
 }
 
 // AppendContextualMod a hook to the set

--- a/orm/query.go
+++ b/orm/query.go
@@ -22,6 +22,13 @@ func (q ExecQuery[Q]) Clone() ExecQuery[Q] {
 	}
 }
 
+func (q ExecQuery[Q]) With(mods ...bob.Mod[Q]) ExecQuery[Q] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
+}
+
 func (q ExecQuery[Q]) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
 	var err error
 
@@ -55,7 +62,15 @@ type Query[Q bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
 func (q Query[Q, T, Ts, Tr]) Clone() Query[Q, T, Ts, Tr] {
 	return Query[Q, T, Ts, Tr]{
 		ExecQuery: q.ExecQuery.Clone(),
+		Scanner:   q.Scanner,
 	}
+}
+
+func (q Query[Q, T, Ts, Tr]) With(mods ...bob.Mod[Q]) Query[Q, T, Ts, Tr] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 // First matching row

--- a/query.go
+++ b/query.go
@@ -71,12 +71,14 @@ func (b BaseQuery[E]) Clone() BaseQuery[E] {
 		return BaseQuery[E]{
 			Expression: c.Clone(),
 			Dialect:    b.Dialect,
+			QueryType:  b.QueryType,
 		}
 	}
 
 	return BaseQuery[E]{
 		Expression: reprint.This(b.Expression).(E),
 		Dialect:    b.Dialect,
+		QueryType:  b.QueryType,
 	}
 }
 
@@ -116,6 +118,13 @@ func (b BaseQuery[E]) Apply(mods ...Mod[E]) {
 	for _, mod := range mods {
 		mod.Apply(b.Expression)
 	}
+}
+
+func (b BaseQuery[E]) With(mods ...Mod[E]) BaseQuery[E] {
+	clone := b.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 func (b BaseQuery[E]) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {


### PR DESCRIPTION
Optimizes the immutable query path by switching select query clones to copy-on-write behavior.

This branch is intended to be reviewed after #651. GitHub requires this PR to target `main`, so the diff includes the earlier stack commit until #651 lands.

Stack:
- 2/5
- branch: `query-copy-on-write`
- builds on: #651

Benchmarks

Upstream `main` baseline:
```text
BenchmarkBaseQueryApplyMain                     3039 ns/op   2865 B/op    48 allocs/op
BenchmarkViewQueryCountThenPaginateApplyMain  10070 ns/op   7424 B/op   130 allocs/op
```

This branch immutable path:
```text
BenchmarkBaseQueryWithImmutableCopyOnWrite                     6687 ns/op   3569 B/op    49 allocs/op
BenchmarkViewQueryCountThenPaginateImmutableCopyOnWrite       7382 ns/op   6488 B/op    86 allocs/op
```

Verification:
- `go test ./dialect/psql ./dialect/mysql ./dialect/sqlite ./orm`
- `go test ./dialect/psql -run '^$' -bench 'Benchmark(BaseQueryApplyMain|BaseQueryWithImmutableCopyOnWrite|ViewQueryCountThenPaginateApplyMain|ViewQueryCountThenPaginateImmutableCopyOnWrite)$' -benchmem`
