### PR TITLE
refactor(psql): simplify order writer dispatch

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,8 +1,8 @@
 package bob
 
 import (
-	"bytes"
 	"context"
+	"strings"
 )
 
 // MustBuild builds a query and panics on error
@@ -27,8 +27,8 @@ func Build(ctx context.Context, q Query) (string, []any, error) {
 
 // Convinient function to build query from a point
 func BuildN(ctx context.Context, q Query, start int) (string, []any, error) {
-	b := &bytes.Buffer{}
-	args, err := q.WriteQuery(ctx, b, start)
+	var b strings.Builder
+	args, err := q.WriteQuery(ctx, &b, start)
 
 	return b.String(), args, err
 }

--- a/clause/clone.go
+++ b/clause/clone.go
@@ -1,0 +1,93 @@
+package clause
+
+import "slices"
+
+func (w With) Clone() With {
+	w.CTEs = slices.Clone(w.CTEs)
+
+	return w
+}
+
+func (s SelectList) Clone() SelectList {
+	s.Columns = slices.Clone(s.Columns)
+	s.PreloadColumns = slices.Clone(s.PreloadColumns)
+
+	return s
+}
+
+func (f TableRef) Clone() TableRef {
+	f.Columns = slices.Clone(f.Columns)
+	f.Partitions = slices.Clone(f.Partitions)
+	f.IndexHints = slices.Clone(f.IndexHints)
+	f.Joins = cloneJoins(f.Joins)
+
+	if f.IndexedBy != nil {
+		indexedBy := *f.IndexedBy
+		f.IndexedBy = &indexedBy
+	}
+
+	return f
+}
+
+func cloneJoins(joins []Join) []Join {
+	if joins == nil {
+		return nil
+	}
+
+	cloned := make([]Join, len(joins))
+	for i, join := range joins {
+		cloned[i] = join.Clone()
+	}
+
+	return cloned
+}
+
+func (j Join) Clone() Join {
+	j.To = j.To.Clone()
+	j.On = slices.Clone(j.On)
+	j.Using = slices.Clone(j.Using)
+
+	return j
+}
+
+func (w Where) Clone() Where {
+	w.Conditions = slices.Clone(w.Conditions)
+
+	return w
+}
+
+func (g GroupBy) Clone() GroupBy {
+	g.Groups = slices.Clone(g.Groups)
+
+	return g
+}
+
+func (h Having) Clone() Having {
+	h.Conditions = slices.Clone(h.Conditions)
+
+	return h
+}
+
+func (w Windows) Clone() Windows {
+	w.Windows = slices.Clone(w.Windows)
+
+	return w
+}
+
+func (c Combines) Clone() Combines {
+	c.Queries = slices.Clone(c.Queries)
+
+	return c
+}
+
+func (o OrderBy) Clone() OrderBy {
+	o.Expressions = slices.Clone(o.Expressions)
+
+	return o
+}
+
+func (l Locks) Clone() Locks {
+	l.Locks = slices.Clone(l.Locks)
+
+	return l
+}

--- a/clause/order_by.go
+++ b/clause/order_by.go
@@ -2,7 +2,6 @@ package clause
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/stephenafamo/bob"
@@ -32,9 +31,14 @@ type OrderDef struct {
 }
 
 func (o OrderDef) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	args, err := bob.Express(ctx, w, d, start, o.Expression)
-	if err != nil {
-		return nil, err
+	var args []any
+	err := o.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (o OrderDef) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
+	if err := bob.ExpressTo(ctx, w, d, start, o.Expression, args); err != nil {
+		return err
 	}
 
 	if o.Collation != "" {
@@ -48,8 +52,9 @@ func (o OrderDef) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect
 	}
 
 	if o.Nulls != "" {
-		w.WriteString(fmt.Sprintf(" NULLS %s", o.Nulls))
+		w.WriteString(" NULLS ")
+		w.WriteString(o.Nulls)
 	}
 
-	return args, nil
+	return nil
 }

--- a/clause/select.go
+++ b/clause/select.go
@@ -36,7 +36,6 @@ func (s *SelectList) AppendPreloadSelect(columns ...any) {
 
 func (s SelectList) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	var args []any
-
 	all := append(s.Columns, s.PreloadColumns...)
 	if len(all) > 0 {
 		colArgs, err := bob.ExpressSlice(ctx, w, d, start+len(args), all, "", ", ", "")

--- a/dialect/mysql/dialect/clone.go
+++ b/dialect/mysql/dialect/clone.go
@@ -1,0 +1,259 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedHints selectShared = 1 << iota
+	sharedModifiers
+	sharedWith
+	sharedSelect
+	sharedPreloadSelect
+	sharedPartitions
+	sharedIndexHints
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedCombinedOrder
+	sharedLocks
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedHints |
+	sharedModifiers |
+	sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedPartitions |
+	sharedIndexHints |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedCombinedOrder |
+	sharedLocks |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedHints:
+		s.hints.hints = slices.Clone(s.hints.hints)
+	case sharedModifiers:
+		s.modifiers.modifiers = slices.Clone(s.modifiers.modifiers)
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedPartitions:
+		s.TableRef.Partitions = slices.Clone(s.TableRef.Partitions)
+	case sharedIndexHints:
+		s.TableRef.IndexHints = slices.Clone(s.TableRef.IndexHints)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedCombinedOrder:
+		s.CombinedOrder.Expressions = slices.Clone(s.CombinedOrder.Expressions)
+	case sharedLocks:
+		s.Locks.Locks = slices.Clone(s.Locks.Locks)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendHint(hint string) {
+	s.cloneOnWrite(sharedHints)
+	s.hints.AppendHint(hint)
+}
+
+func (s *SelectQuery) AppendModifier(modifier any) {
+	s.cloneOnWrite(sharedModifiers)
+	s.modifiers.AppendModifier(modifier)
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPartition(partitions ...string) {
+	s.cloneOnWrite(sharedPartitions)
+	s.TableRef.AppendPartition(partitions...)
+}
+
+func (s *SelectQuery) AppendIndexHint(hint clause.IndexHint) {
+	s.cloneOnWrite(sharedIndexHints)
+	s.TableRef.AppendIndexHint(hint)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendCombinedOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedCombinedOrder)
+	s.CombinedOrder.AppendOrder(order)
+}
+
+func (s *SelectQuery) AppendLock(lock bob.Expression) {
+	s.cloneOnWrite(sharedLocks)
+	s.Locks.AppendLock(lock)
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/mysql/dialect/mods.go
+++ b/dialect/mysql/dialect/mods.go
@@ -260,7 +260,7 @@ func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
 type OrderCombined OrderBy[*SelectQuery]
 
 func (o OrderCombined) Apply(q *SelectQuery) {
-	q.CombinedOrder.AppendOrder(o())
+	q.AppendCombinedOrder(o())
 }
 
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef

--- a/dialect/mysql/dialect/select.go
+++ b/dialect/mysql/dialect/select.go
@@ -35,6 +35,8 @@ type SelectQuery struct {
 	CombinedOrder  clause.OrderBy
 	CombinedLimit  clause.Limit
 	CombinedOffset clause.Offset
+
+	shared selectShared
 }
 
 func (s *SelectQuery) SetInto(i any) {

--- a/dialect/mysql/dialect/select.go
+++ b/dialect/mysql/dialect/select.go
@@ -56,7 +56,7 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, withArgs...)
+	args = bob.MergeArgs(args, withArgs)
 
 	needsParens := false
 	if len(s.Combines.Queries) > 0 &&
@@ -88,48 +88,48 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, selArgs...)
+	args = bob.MergeArgs(args, selArgs)
 
 	fromArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.TableRef, s.TableRef.Expression != nil, "\nFROM ", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, fromArgs...)
+	args = bob.MergeArgs(args, fromArgs)
 
 	whereArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Where,
 		len(s.Where.Conditions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, whereArgs...)
+	args = bob.MergeArgs(args, whereArgs)
 
 	groupByArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.GroupBy,
 		len(s.GroupBy.Groups) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, groupByArgs...)
+	args = bob.MergeArgs(args, groupByArgs)
 
 	havingArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Having,
 		len(s.Having.Conditions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, havingArgs...)
+	args = bob.MergeArgs(args, havingArgs)
 
 	windowArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Windows,
 		len(s.Windows.Windows) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, windowArgs...)
+	args = bob.MergeArgs(args, windowArgs)
 
 	orderArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.OrderBy,
 		len(s.OrderBy.Expressions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, orderArgs...)
+	args = bob.MergeArgs(args, orderArgs)
 
 	_, err = bob.ExpressIf(ctx, w, d, start+len(args), s.Limit,
 		s.Limit.Count != nil, "\n", "")
@@ -148,7 +148,7 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, lockArgs...)
+	args = bob.MergeArgs(args, lockArgs)
 
 	if needsParens {
 		w.WriteString(")")
@@ -159,14 +159,14 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, combineArgs...)
+	args = bob.MergeArgs(args, combineArgs)
 
 	combinedOrderArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedOrder,
 		len(s.CombinedOrder.Expressions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, combinedOrderArgs...)
+	args = bob.MergeArgs(args, combinedOrderArgs)
 
 	_, err = bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedLimit,
 		s.CombinedLimit.Count != nil, "\n", "")
@@ -185,7 +185,7 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, intoArgs...)
+	args = bob.MergeArgs(args, intoArgs)
 
 	w.WriteString("\n")
 	return args, nil

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -95,6 +95,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/dialect/clone.go
+++ b/dialect/psql/dialect/clone.go
@@ -1,0 +1,227 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedWith selectShared = 1 << iota
+	sharedSelect
+	sharedPreloadSelect
+	sharedDistinctOn
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedCombinedOrder
+	sharedLocks
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedDistinctOn |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedCombinedOrder |
+	sharedLocks |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedDistinctOn:
+		s.Distinct.On = slices.Clone(s.Distinct.On)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedCombinedOrder:
+		s.CombinedOrder.Expressions = slices.Clone(s.CombinedOrder.Expressions)
+	case sharedLocks:
+		s.Locks.Locks = slices.Clone(s.Locks.Locks)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) AppendCombinedOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedCombinedOrder)
+	s.CombinedOrder.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendLock(lock bob.Expression) {
+	s.cloneOnWrite(sharedLocks)
+	s.Locks.AppendLock(lock)
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -37,15 +37,15 @@ type fromable interface {
 }
 
 func From[Q fromable](table any) FromChain[Q] {
-	return FromChain[Q](func() clause.TableRef {
-		return clause.TableRef{Expression: table}
-	})
+	return FromChain[Q]{ref: clause.TableRef{Expression: table}}
 }
 
-type FromChain[Q fromable] func() clause.TableRef
+type FromChain[Q fromable] struct {
+	ref clause.TableRef
+}
 
 func (f FromChain[Q]) Apply(q Q) {
-	from := f()
+	from := f.ref
 
 	q.SetTable(from.Expression)
 	if from.Alias != "" {
@@ -58,51 +58,41 @@ func (f FromChain[Q]) Apply(q Q) {
 }
 
 func (f FromChain[Q]) As(alias string, columns ...string) FromChain[Q] {
-	fr := f()
+	fr := f.ref
 	fr.Alias = alias
 	fr.Columns = columns
 
-	return FromChain[Q](func() clause.TableRef {
-		return fr
-	})
+	return FromChain[Q]{ref: fr}
 }
 
 func (f FromChain[Q]) Only() FromChain[Q] {
-	fr := f()
+	fr := f.ref
 	fr.Only = true
 
-	return FromChain[Q](func() clause.TableRef {
-		return fr
-	})
+	return FromChain[Q]{ref: fr}
 }
 
 func (f FromChain[Q]) Lateral() FromChain[Q] {
-	fr := f()
+	fr := f.ref
 	fr.Lateral = true
 
-	return FromChain[Q](func() clause.TableRef {
-		return fr
-	})
+	return FromChain[Q]{ref: fr}
 }
 
 func (f FromChain[Q]) WithOrdinality() FromChain[Q] {
-	fr := f()
+	fr := f.ref
 	fr.WithOrdinality = true
 
-	return FromChain[Q](func() clause.TableRef {
-		return fr
-	})
+	return FromChain[Q]{ref: fr}
 }
 
 type Joinable interface{ AppendJoin(clause.Join) }
 
 func Join[Q Joinable](typ string, e any) JoinChain[Q] {
-	return JoinChain[Q](func() clause.Join {
-		return clause.Join{
-			Type: typ,
-			To:   clause.TableRef{Expression: e},
-		}
-	})
+	return JoinChain[Q]{join: clause.Join{
+		Type: typ,
+		To:   clause.TableRef{Expression: e},
+	}}
 }
 
 func InnerJoin[Q Joinable](e any) JoinChain[Q] {
@@ -122,165 +112,139 @@ func FullJoin[Q Joinable](e any) JoinChain[Q] {
 }
 
 func CrossJoin[Q Joinable](e any) CrossJoinChain[Q] {
-	return CrossJoinChain[Q](func() clause.Join {
-		return clause.Join{
-			Type: clause.CrossJoin,
-			To:   clause.TableRef{Expression: e},
-		}
-	})
+	return CrossJoinChain[Q]{join: clause.Join{
+		Type: clause.CrossJoin,
+		To:   clause.TableRef{Expression: e},
+	}}
 }
 
-type JoinChain[Q Joinable] func() clause.Join
+type JoinChain[Q Joinable] struct {
+	join clause.Join
+}
 
 func (j JoinChain[Q]) Apply(q Q) {
-	q.AppendJoin(j())
+	q.AppendJoin(j.join)
 }
 
 func (j JoinChain[Q]) As(alias string, columns ...string) JoinChain[Q] {
-	jo := j()
+	jo := j.join
 	jo.To.Alias = alias
 	jo.To.Columns = columns
 
-	return JoinChain[Q](func() clause.Join {
-		return jo
-	})
+	return JoinChain[Q]{join: jo}
 }
 
 func (f JoinChain[Q]) Only() JoinChain[Q] {
-	jo := f()
+	jo := f.join
 	jo.To.Only = true
 
-	return JoinChain[Q](func() clause.Join {
-		return jo
-	})
+	return JoinChain[Q]{join: jo}
 }
 
 func (f JoinChain[Q]) Lateral() JoinChain[Q] {
-	jo := f()
+	jo := f.join
 	jo.To.Lateral = true
 
-	return JoinChain[Q](func() clause.Join {
-		return jo
-	})
+	return JoinChain[Q]{join: jo}
 }
 
 func (f JoinChain[Q]) WithOrdinality() JoinChain[Q] {
-	jo := f()
+	jo := f.join
 	jo.To.WithOrdinality = true
 
-	return JoinChain[Q](func() clause.Join {
-		return jo
-	})
+	return JoinChain[Q]{join: jo}
 }
 
 func (j JoinChain[Q]) Natural() bob.Mod[Q] {
-	jo := j()
+	jo := j.join
 	jo.Natural = true
 
 	return mods.Join[Q](jo)
 }
 
 func (j JoinChain[Q]) On(on ...bob.Expression) bob.Mod[Q] {
-	jo := j()
+	jo := j.join
 	jo.On = append(jo.On, on...)
 
 	return mods.Join[Q](jo)
 }
 
 func (j JoinChain[Q]) OnEQ(a, b bob.Expression) bob.Mod[Q] {
-	jo := j()
+	jo := j.join
 	jo.On = append(jo.On, expr.X[Expression, Expression](a).EQ(b))
 
 	return mods.Join[Q](jo)
 }
 
 func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
-	jo := j()
+	jo := j.join
 	jo.Using = using
 
 	return mods.Join[Q](jo)
 }
 
-type CrossJoinChain[Q Joinable] func() clause.Join
+type CrossJoinChain[Q Joinable] struct {
+	join clause.Join
+}
 
 func (j CrossJoinChain[Q]) Apply(q Q) {
-	q.AppendJoin(j())
+	q.AppendJoin(j.join)
 }
 
 func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
-	jo := j()
+	jo := j.join
 	jo.To.Alias = alias
 	jo.To.Columns = columns
 
-	return CrossJoinChain[Q](func() clause.Join {
-		return jo
-	})
+	return CrossJoinChain[Q]{join: jo}
 }
 
 type OrderCombined OrderBy[*SelectQuery]
 
 func (o OrderCombined) Apply(q *SelectQuery) {
-	q.AppendCombinedOrder(o())
+	q.AppendCombinedOrder(clause.OrderDef(o))
 }
 
-type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef
+type OrderBy[Q interface{ AppendOrder(bob.Expression) }] clause.OrderDef
 
 func (s OrderBy[Q]) Apply(q Q) {
-	q.AppendOrder(s())
+	q.AppendOrder(clause.OrderDef(s))
 }
 
 func (o OrderBy[Q]) Asc() OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Direction = "ASC"
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 func (o OrderBy[Q]) Desc() OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Direction = "DESC"
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 func (o OrderBy[Q]) Using(operator string) OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Direction = "USING " + operator
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 func (o OrderBy[Q]) NullsFirst() OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Nulls = "FIRST"
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 func (o OrderBy[Q]) NullsLast() OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Nulls = "LAST"
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 func (o OrderBy[Q]) Collate(collationName string) OrderBy[Q] {
-	order := o()
+	order := clause.OrderDef(o)
 	order.Collation = collationName
-
-	return OrderBy[Q](func() clause.OrderDef {
-		return order
-	})
+	return OrderBy[Q](order)
 }
 
 type CTEChain[Q interface{ AppendCTE(bob.Expression) }] func() clause.CTE

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -220,7 +220,7 @@ func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
 type OrderCombined OrderBy[*SelectQuery]
 
 func (o OrderCombined) Apply(q *SelectQuery) {
-	q.CombinedOrder.AppendOrder(o())
+	q.AppendCombinedOrder(o())
 }
 
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -2,6 +2,7 @@ package dialect
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/stephenafamo/bob"
@@ -39,19 +40,26 @@ type SelectQuery struct {
 }
 
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	var err error
 	var args []any
+	err := s.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (s SelectQuery) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
+	var err error
+	baseLen := len(*args)
+	nextStart := func() int {
+		return start + len(*args) - baseLen
+	}
 
 	if ctx, err = s.RunContextualMods(ctx, &s); err != nil {
-		return nil, err
+		return err
 	}
 
-	withArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.With,
-		len(s.With.CTEs) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.With,
+		len(s.With.CTEs) > 0, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, withArgs...)
 
 	needsParens := false
 	if len(s.Combines.Queries) > 0 &&
@@ -66,127 +74,345 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 
 	w.WriteString("SELECT ")
 
-	distinctArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Distinct,
-		s.Distinct.On != nil, "", " ")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.Distinct,
+		s.Distinct.On != nil, "", " ", args); err != nil {
+		return err
 	}
-	args = append(args, distinctArgs...)
 
-	selArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.SelectList, true, "\n", "")
-	if err != nil {
-		return nil, err
+	w.WriteString("\n")
+	if err := writeSelectListTo(ctx, w, d, nextStart(), s.SelectList, args); err != nil {
+		return err
 	}
-	args = append(args, selArgs...)
 
-	fromArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.TableRef, s.TableRef.Expression != nil, "\nFROM ", "")
-	if err != nil {
-		return nil, err
+	if s.TableRef.Expression != nil {
+		w.WriteString("\nFROM ")
+		if err := writeTableRefTo(ctx, w, d, nextStart(), s.TableRef, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, fromArgs...)
 
-	whereArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Where,
-		len(s.Where.Conditions) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if len(s.Where.Conditions) > 0 {
+		w.WriteString("\n")
+		if err := writeWhereTo(ctx, w, d, nextStart(), s.Where, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, whereArgs...)
 
-	groupByArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.GroupBy,
-		len(s.GroupBy.Groups) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.GroupBy,
+		len(s.GroupBy.Groups) > 0, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, groupByArgs...)
 
-	havingArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Having,
-		len(s.Having.Conditions) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.Having,
+		len(s.Having.Conditions) > 0, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, havingArgs...)
 
-	windowArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Windows,
-		len(s.Windows.Windows) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.Windows,
+		len(s.Windows.Windows) > 0, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, windowArgs...)
 
-	orderArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.OrderBy,
-		len(s.OrderBy.Expressions) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if len(s.OrderBy.Expressions) > 0 {
+		w.WriteString("\n")
+		if err := writeOrderByTo(ctx, w, d, nextStart(), s.OrderBy, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, orderArgs...)
 
-	limitArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Limit,
-		s.Limit.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if s.Limit.Count != nil {
+		w.WriteString("\n")
+		if err := writeLimitTo(ctx, w, d, nextStart(), s.Limit, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, limitArgs...)
 
-	offsetArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Offset,
-		s.Offset.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if s.Offset.Count != nil {
+		w.WriteString("\n")
+		if err := writeOffsetTo(ctx, w, d, nextStart(), s.Offset, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, offsetArgs...)
 
-	fetchArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Fetch,
-		s.Fetch.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.Fetch,
+		s.Fetch.Count != nil, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, fetchArgs...)
 
-	lockArgs, err := bob.ExpressSlice(ctx, w, d, start+len(args), s.Locks.Locks,
-		"\n", "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressSliceTo(ctx, w, d, nextStart(), s.Locks.Locks,
+		"\n", "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, lockArgs...)
 
 	if needsParens {
 		w.WriteString(")")
 	}
 
-	combineArgs, err := bob.ExpressSlice(ctx, w, d, start+len(args),
-		s.Combines.Queries, "\n", "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressSliceTo(ctx, w, d, nextStart(),
+		s.Combines.Queries, "\n", "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, combineArgs...)
 
-	combinedOrderArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedOrder,
-		len(s.CombinedOrder.Expressions) > 0, "\n", "")
-	if err != nil {
-		return nil, err
+	if len(s.CombinedOrder.Expressions) > 0 {
+		w.WriteString("\n")
+		if err := writeOrderByTo(ctx, w, d, nextStart(), s.CombinedOrder, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, combinedOrderArgs...)
 
-	combinedLimitArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedLimit,
-		s.CombinedLimit.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if s.CombinedLimit.Count != nil {
+		w.WriteString("\n")
+		if err := writeLimitTo(ctx, w, d, nextStart(), s.CombinedLimit, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, combinedLimitArgs...)
 
-	combinedOffsetArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedOffset,
-		s.CombinedOffset.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if s.CombinedOffset.Count != nil {
+		w.WriteString("\n")
+		if err := writeOffsetTo(ctx, w, d, nextStart(), s.CombinedOffset, args); err != nil {
+			return err
+		}
 	}
-	args = append(args, combinedOffsetArgs...)
 
-	combinedFetchArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.CombinedFetch,
-		s.CombinedFetch.Count != nil, "\n", "")
-	if err != nil {
-		return nil, err
+	if err := bob.ExpressIfTo(ctx, w, d, nextStart(), s.CombinedFetch,
+		s.CombinedFetch.Count != nil, "\n", "", args); err != nil {
+		return err
 	}
-	args = append(args, combinedFetchArgs...)
 
 	w.WriteString("\n")
-	return args, nil
+	return nil
+}
+
+func writeSelectListTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, s clause.SelectList, args *[]any) error {
+	baseLen := len(*args)
+	nextStart := func() int {
+		return start + len(*args) - baseLen
+	}
+
+	wrote := false
+	if len(s.Columns) > 0 {
+		if err := bob.ExpressSliceTo(ctx, w, d, nextStart(), s.Columns, "", ", ", "", args); err != nil {
+			return err
+		}
+		wrote = true
+	}
+
+	if len(s.PreloadColumns) > 0 {
+		if wrote {
+			w.WriteString(", ")
+		}
+		if err := bob.ExpressSliceTo(ctx, w, d, nextStart(), s.PreloadColumns, "", ", ", "", args); err != nil {
+			return err
+		}
+		wrote = true
+	}
+
+	if !wrote {
+		w.WriteString("*")
+	}
+
+	return nil
+}
+
+func writeWhereTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, wh clause.Where, args *[]any) error {
+	return bob.ExpressSliceTo(ctx, w, d, start, wh.Conditions, "WHERE ", " AND ", "", args)
+}
+
+func writeOrderByTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, order clause.OrderBy, args *[]any) error {
+	baseLen := len(*args)
+	nextStart := func() int {
+		return start + len(*args) - baseLen
+	}
+
+	w.WriteString("ORDER BY ")
+	for i, expression := range order.Expressions {
+		if i != 0 {
+			w.WriteString(", ")
+		}
+
+		switch o := any(expression).(type) {
+		case clause.OrderDef:
+			if err := writeOrderDefTo(ctx, w, d, nextStart(), o, args); err != nil {
+				return err
+			}
+		case *clause.OrderDef:
+			if err := writeOrderDefTo(ctx, w, d, nextStart(), *o, args); err != nil {
+				return err
+			}
+		default:
+			if err := bob.ExpressTo(ctx, w, d, nextStart(), expression, args); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeOrderDefTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, order clause.OrderDef, args *[]any) error {
+	if err := bob.ExpressTo(ctx, w, d, start, order.Expression, args); err != nil {
+		return err
+	}
+
+	if order.Collation != "" {
+		w.WriteString(" COLLATE ")
+		d.WriteQuoted(w, order.Collation)
+	}
+
+	if order.Direction != "" {
+		w.WriteString(" ")
+		w.WriteString(order.Direction)
+	}
+
+	if order.Nulls != "" {
+		w.WriteString(" NULLS ")
+		w.WriteString(order.Nulls)
+	}
+
+	return nil
+}
+
+func writeLimitTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, limit clause.Limit, args *[]any) error {
+	w.WriteString("LIMIT ")
+	return bob.ExpressTo(ctx, w, d, start, limit.Count, args)
+}
+
+func writeOffsetTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, offset clause.Offset, args *[]any) error {
+	w.WriteString("OFFSET ")
+	return bob.ExpressTo(ctx, w, d, start, offset.Count, args)
+}
+
+func writeTableRefTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, table clause.TableRef, args *[]any) error {
+	baseLen := len(*args)
+	nextStart := func() int {
+		return start + len(*args) - baseLen
+	}
+
+	if table.Only {
+		w.WriteString("ONLY ")
+	}
+
+	if table.Lateral {
+		w.WriteString("LATERAL ")
+	}
+
+	if err := bob.ExpressTo(ctx, w, d, nextStart(), table.Expression, args); err != nil {
+		return err
+	}
+
+	if table.WithOrdinality {
+		w.WriteString(" WITH ORDINALITY")
+	}
+
+	if len(table.Partitions) > 0 {
+		if err := bob.ExpressSliceTo(ctx, w, d, nextStart(), table.Partitions, " PARTITION (", ", ", ")", args); err != nil {
+			return err
+		}
+	}
+
+	if table.Alias != "" {
+		w.WriteString(" AS ")
+		d.WriteQuoted(w, table.Alias)
+	}
+
+	if len(table.Columns) > 0 {
+		w.WriteString("(")
+		for i, alias := range table.Columns {
+			if i != 0 {
+				w.WriteString(", ")
+			}
+			d.WriteQuoted(w, alias)
+		}
+		w.WriteString(")")
+	}
+
+	if len(table.IndexHints) > 0 {
+		for i, hint := range table.IndexHints {
+			if i == 0 {
+				w.WriteString("\n")
+			} else {
+				w.WriteString(" ")
+			}
+			writeIndexHint(w, d, hint)
+		}
+	}
+
+	switch {
+	case table.IndexedBy == nil:
+	case *table.IndexedBy == "":
+		w.WriteString(" NOT INDEXED")
+	default:
+		w.WriteString(fmt.Sprintf(" INDEXED BY %q", *table.IndexedBy))
+	}
+
+	for _, join := range table.Joins {
+		w.WriteString("\n")
+		if err := writeJoinTo(ctx, w, d, nextStart(), join, args); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeJoinTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, join clause.Join, args *[]any) error {
+	baseLen := len(*args)
+	nextStart := func() int {
+		return start + len(*args) - baseLen
+	}
+
+	if join.Natural {
+		w.WriteString("NATURAL ")
+	}
+
+	w.WriteString(join.Type)
+	w.WriteString(" ")
+
+	if err := writeTableRefTo(ctx, w, d, nextStart(), join.To, args); err != nil {
+		return err
+	}
+
+	if len(join.On) > 0 {
+		if err := bob.ExpressSliceTo(ctx, w, d, nextStart(), join.On, " ON ", " AND ", "", args); err != nil {
+			return err
+		}
+	}
+
+	for i, col := range join.Using {
+		if i == 0 {
+			w.WriteString(" USING(")
+		} else {
+			w.WriteString(", ")
+		}
+
+		d.WriteQuoted(w, col)
+
+		if i == len(join.Using)-1 {
+			w.WriteString(") ")
+		}
+	}
+
+	return nil
+}
+
+func writeIndexHint(w io.StringWriter, d bob.Dialect, hint clause.IndexHint) {
+	if hint.Type == "" {
+		return
+	}
+
+	w.WriteString(hint.Type)
+	w.WriteString(" INDEX ")
+	if hint.For != "" {
+		w.WriteString(" FOR ")
+		w.WriteString(hint.For)
+	}
+
+	w.WriteString(" (")
+	for i, index := range hint.Indexes {
+		if i != 0 {
+			w.WriteString(", ")
+		}
+		w.WriteString(index)
+	}
+	w.WriteString(")")
 }

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -34,6 +34,8 @@ type SelectQuery struct {
 	CombinedLimit  clause.Limit
 	CombinedFetch  clause.Fetch
 	CombinedOffset clause.Offset
+
+	shared selectShared
 }
 
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -230,43 +230,9 @@ func writeOrderByTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start
 			w.WriteString(", ")
 		}
 
-		switch o := any(expression).(type) {
-		case clause.OrderDef:
-			if err := writeOrderDefTo(ctx, w, d, nextStart(), o, args); err != nil {
-				return err
-			}
-		case *clause.OrderDef:
-			if err := writeOrderDefTo(ctx, w, d, nextStart(), *o, args); err != nil {
-				return err
-			}
-		default:
-			if err := bob.ExpressTo(ctx, w, d, nextStart(), expression, args); err != nil {
-				return err
-			}
+		if err := bob.ExpressTo(ctx, w, d, nextStart(), expression, args); err != nil {
+			return err
 		}
-	}
-
-	return nil
-}
-
-func writeOrderDefTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, order clause.OrderDef, args *[]any) error {
-	if err := bob.ExpressTo(ctx, w, d, start, order.Expression, args); err != nil {
-		return err
-	}
-
-	if order.Collation != "" {
-		w.WriteString(" COLLATE ")
-		d.WriteQuoted(w, order.Collation)
-	}
-
-	if order.Direction != "" {
-		w.WriteString(" ")
-		w.WriteString(order.Direction)
-	}
-
-	if order.Nulls != "" {
-		w.WriteString(" NULLS ")
-		w.WriteString(order.Nulls)
 	}
 
 	return nil

--- a/dialect/psql/fm/qm.go
+++ b/dialect/psql/fm/qm.go
@@ -14,11 +14,9 @@ func Distinct() bob.Mod[*dialect.Function] {
 }
 
 func OrderBy(e any) dialect.OrderBy[*dialect.Function] {
-	return dialect.OrderBy[*dialect.Function](func() clause.OrderDef {
-		return clause.OrderDef{
-			Expression: e,
-		}
-	})
+	return dialect.OrderBy[*dialect.Function]{
+		Expression: e,
+	}
 }
 
 func WithinGroup() bob.Mod[*dialect.Function] {

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -98,11 +98,9 @@ func Window(name string, winMods ...bob.Mod[*clause.Window]) bob.Mod[*dialect.Se
 }
 
 func OrderBy(e any) dialect.OrderBy[*dialect.SelectQuery] {
-	return dialect.OrderBy[*dialect.SelectQuery](func() clause.OrderDef {
-		return clause.OrderDef{
-			Expression: e,
-		}
-	})
+	return dialect.OrderBy[*dialect.SelectQuery]{
+		Expression: e,
+	}
 }
 
 func Limit(count any) bob.Mod[*dialect.SelectQuery] {
@@ -210,11 +208,9 @@ func ForKeyShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 
 // To apply order to the result of a UNION, INTERSECT, or EXCEPT query
 func OrderCombined(e any) dialect.OrderCombined {
-	return dialect.OrderCombined(func() clause.OrderDef {
-		return clause.OrderDef{
-			Expression: e,
-		}
-	})
+	return dialect.OrderCombined{
+		Expression: e,
+	}
 }
 
 // To apply limit to the result of a UNION, INTERSECT, or EXCEPT query

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -107,6 +107,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/dialect/psql/vm/qm.go
+++ b/dialect/psql/vm/qm.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/clause"
 	"github.com/stephenafamo/bob/dialect/psql/dialect"
 	"github.com/stephenafamo/bob/mods"
 )
@@ -12,11 +11,9 @@ func RowValue(clauses ...bob.Expression) bob.Mod[*dialect.ValuesQuery] {
 }
 
 func OrderBy(e any) dialect.OrderBy[*dialect.ValuesQuery] {
-	return dialect.OrderBy[*dialect.ValuesQuery](func() clause.OrderDef {
-		return clause.OrderDef{
-			Expression: e,
-		}
-	})
+	return dialect.OrderBy[*dialect.ValuesQuery]{
+		Expression: e,
+	}
 }
 
 func Limit(count any) bob.Mod[*dialect.ValuesQuery] {

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -83,7 +83,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkBaseQueryWithImmutableSpecializedSelectBuilders(b *testing.B) {
+func BenchmarkBaseQueryWithImmutableOrderWriterDispatch(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -130,7 +130,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkViewQueryCountThenPaginateImmutableSpecializedSelectBuilders(b *testing.B) {
+func BenchmarkViewQueryCountThenPaginateImmutableOrderWriterDispatch(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -83,7 +83,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkBaseQueryWithImmutableWithHelpers(b *testing.B) {
+func BenchmarkBaseQueryWithImmutableCopyOnWrite(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -130,7 +130,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkViewQueryCountThenPaginateImmutableWithHelpers(b *testing.B) {
+func BenchmarkViewQueryCountThenPaginateImmutableCopyOnWrite(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -83,7 +83,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkBaseQueryWithImmutableAppendStyleWriters(b *testing.B) {
+func BenchmarkBaseQueryWithImmutableSpecializedSelectBuilders(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -130,7 +130,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkViewQueryCountThenPaginateImmutableAppendStyleWriters(b *testing.B) {
+func BenchmarkViewQueryCountThenPaginateImmutableSpecializedSelectBuilders(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -83,7 +83,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkBaseQueryWithImmutableCopyOnWrite(b *testing.B) {
+func BenchmarkBaseQueryWithImmutableAppendStyleWriters(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -130,7 +130,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 	}
 }
 
-func BenchmarkViewQueryCountThenPaginateImmutableCopyOnWrite(b *testing.B) {
+func BenchmarkViewQueryCountThenPaginateImmutableAppendStyleWriters(b *testing.B) {
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/dialect/psql/with_test.go
+++ b/dialect/psql/with_test.go
@@ -1,0 +1,156 @@
+package psql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func TestBaseQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := Select(
+		sm.Columns("id"),
+		sm.From("users"),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Type() != bob.QueryTypeSelect {
+		t.Fatalf("expected derived query type %q, got %q", bob.QueryTypeSelect, derived.Type())
+	}
+
+	baseSQL := selectToString(t, base, 0)
+	if baseSQL != "SELECT \nid\nFROM users\n" {
+		t.Fatalf("base query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived, 0)
+	if derivedSQL != "SELECT \nid\nFROM users\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived query mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestViewQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := someStructView.Query(
+		sm.Where(Quote("id").GT(Arg(0))),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Scanner == nil {
+		t.Fatal("expected derived view query to preserve scanner")
+	}
+
+	baseSQL := selectToString(t, base.BaseQuery, 1)
+	if baseSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\n" {
+		t.Fatalf("base view query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL := selectToString(t, derived.BaseQuery, 1)
+	if derivedSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $0)\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived view query mismatch: %#v", derivedSQL)
+	}
+}
+
+func BenchmarkBaseQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBaseQueryWithImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateImmutableWithHelpers(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dialect/psql/wm/qm.go
+++ b/dialect/psql/wm/qm.go
@@ -22,11 +22,9 @@ func PartitionBy(condition any) bob.Mod[*clause.Window] {
 }
 
 func OrderBy(e any) dialect.OrderBy[*clause.Window] {
-	return dialect.OrderBy[*clause.Window](func() clause.OrderDef {
-		return clause.OrderDef{
-			Expression: e,
-		}
-	})
+	return dialect.OrderBy[*clause.Window]{
+		Expression: e,
+	}
 }
 
 func Range() bob.Mod[*clause.Window] {

--- a/dialect/sqlite/dialect/clone.go
+++ b/dialect/sqlite/dialect/clone.go
@@ -1,0 +1,205 @@
+package dialect
+
+import (
+	"context"
+	"slices"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	"github.com/stephenafamo/scan"
+)
+
+type selectShared uint32
+
+const (
+	sharedWith selectShared = 1 << iota
+	sharedSelect
+	sharedPreloadSelect
+	sharedJoins
+	sharedWhere
+	sharedGroups
+	sharedHaving
+	sharedWindows
+	sharedCombines
+	sharedOrderBy
+	sharedLoaders
+	sharedMapperMods
+	sharedHooks
+	sharedContextualMods
+)
+
+const sharedAll = sharedWith |
+	sharedSelect |
+	sharedPreloadSelect |
+	sharedJoins |
+	sharedWhere |
+	sharedGroups |
+	sharedHaving |
+	sharedWindows |
+	sharedCombines |
+	sharedOrderBy |
+	sharedLoaders |
+	sharedMapperMods |
+	sharedHooks |
+	sharedContextualMods
+
+func (s *SelectQuery) Clone() *SelectQuery {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	s.shared |= sharedAll
+	clone.shared |= sharedAll
+
+	return &clone
+}
+
+func (s *SelectQuery) cloneOnWrite(flag selectShared) {
+	if s.shared&flag == 0 {
+		return
+	}
+
+	switch flag {
+	case sharedWith:
+		s.With.CTEs = slices.Clone(s.With.CTEs)
+	case sharedSelect:
+		s.SelectList.Columns = slices.Clone(s.SelectList.Columns)
+	case sharedPreloadSelect:
+		s.SelectList.PreloadColumns = slices.Clone(s.SelectList.PreloadColumns)
+	case sharedJoins:
+		s.TableRef.Joins = slices.Clone(s.TableRef.Joins)
+	case sharedWhere:
+		s.Where.Conditions = slices.Clone(s.Where.Conditions)
+	case sharedGroups:
+		s.GroupBy.Groups = slices.Clone(s.GroupBy.Groups)
+	case sharedHaving:
+		s.Having.Conditions = slices.Clone(s.Having.Conditions)
+	case sharedWindows:
+		s.Windows.Windows = slices.Clone(s.Windows.Windows)
+	case sharedCombines:
+		s.Combines.Queries = slices.Clone(s.Combines.Queries)
+	case sharedOrderBy:
+		s.OrderBy.Expressions = slices.Clone(s.OrderBy.Expressions)
+	case sharedLoaders:
+		s.Load.SetLoaders(slices.Clone(s.Load.GetLoaders())...)
+	case sharedMapperMods:
+		s.Load.SetMapperMods(slices.Clone(s.Load.GetMapperMods())...)
+	case sharedHooks:
+		s.EmbeddedHook.SetHooks(slices.Clone(s.EmbeddedHook.Hooks)...)
+	case sharedContextualMods:
+		s.ContextualModdable.Mods = slices.Clone(s.ContextualModdable.Mods)
+	}
+
+	s.shared &^= flag
+}
+
+func (s *SelectQuery) AppendCTE(cte bob.Expression) {
+	s.cloneOnWrite(sharedWith)
+	s.With.AppendCTE(cte)
+}
+
+func (s *SelectQuery) AppendSelect(columns ...any) {
+	s.cloneOnWrite(sharedSelect)
+	s.SelectList.AppendSelect(columns...)
+}
+
+func (s *SelectQuery) SetSelect(columns ...any) {
+	s.shared &^= sharedSelect
+	s.SelectList.SetSelect(columns...)
+}
+
+func (s *SelectQuery) AppendPreloadSelect(columns ...any) {
+	s.cloneOnWrite(sharedPreloadSelect)
+	s.SelectList.AppendPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) SetPreloadSelect(columns ...any) {
+	s.shared &^= sharedPreloadSelect
+	s.SelectList.SetPreloadSelect(columns...)
+}
+
+func (s *SelectQuery) AppendJoin(join clause.Join) {
+	s.cloneOnWrite(sharedJoins)
+	s.TableRef.AppendJoin(join)
+}
+
+func (s *SelectQuery) AppendWhere(e ...any) {
+	s.cloneOnWrite(sharedWhere)
+	s.Where.AppendWhere(e...)
+}
+
+func (s *SelectQuery) AppendGroup(e any) {
+	s.cloneOnWrite(sharedGroups)
+	s.GroupBy.AppendGroup(e)
+}
+
+func (s *SelectQuery) SetGroups(groups ...any) {
+	s.shared &^= sharedGroups
+	s.GroupBy.SetGroups(groups...)
+}
+
+func (s *SelectQuery) AppendHaving(e ...any) {
+	s.cloneOnWrite(sharedHaving)
+	s.Having.AppendHaving(e...)
+}
+
+func (s *SelectQuery) AppendWindow(w bob.Expression) {
+	s.cloneOnWrite(sharedWindows)
+	s.Windows.AppendWindow(w)
+}
+
+func (s *SelectQuery) AppendCombine(combine clause.Combine) {
+	s.cloneOnWrite(sharedCombines)
+	s.Combines.AppendCombine(combine)
+}
+
+func (s *SelectQuery) AppendOrder(order bob.Expression) {
+	s.cloneOnWrite(sharedOrderBy)
+	s.OrderBy.AppendOrder(order)
+}
+
+func (s *SelectQuery) ClearOrderBy() {
+	s.shared &^= sharedOrderBy
+	s.OrderBy.ClearOrderBy()
+}
+
+func (s *SelectQuery) AppendLoader(loaders ...bob.Loader) {
+	s.cloneOnWrite(sharedLoaders)
+	s.Load.AppendLoader(loaders...)
+}
+
+func (s *SelectQuery) SetLoaders(loaders ...bob.Loader) {
+	s.shared &^= sharedLoaders
+	s.Load.SetLoaders(loaders...)
+}
+
+func (s *SelectQuery) AppendMapperMod(mod scan.MapperMod) {
+	s.cloneOnWrite(sharedMapperMods)
+	s.Load.AppendMapperMod(mod)
+}
+
+func (s *SelectQuery) SetMapperMods(mods ...scan.MapperMod) {
+	s.shared &^= sharedMapperMods
+	s.Load.SetMapperMods(mods...)
+}
+
+func (s *SelectQuery) AppendHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.cloneOnWrite(sharedHooks)
+	s.EmbeddedHook.AppendHooks(hooks...)
+}
+
+func (s *SelectQuery) SetHooks(hooks ...func(context.Context, bob.Executor) (context.Context, error)) {
+	s.shared &^= sharedHooks
+	s.EmbeddedHook.SetHooks(hooks...)
+}
+
+func (s *SelectQuery) AppendContextualMod(mods ...bob.ContextualMod[*SelectQuery]) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualMod(mods...)
+}
+
+func (s *SelectQuery) AppendContextualModFunc(f func(context.Context, *SelectQuery) (context.Context, error)) {
+	s.cloneOnWrite(sharedContextualMods)
+	s.ContextualModdable.AppendContextualModFunc(f)
+}

--- a/dialect/sqlite/dialect/select.go
+++ b/dialect/sqlite/dialect/select.go
@@ -27,6 +27,8 @@ type SelectQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*SelectQuery]
+
+	shared selectShared
 }
 
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {

--- a/dialect/sqlite/dialect/select.go
+++ b/dialect/sqlite/dialect/select.go
@@ -44,7 +44,7 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, withArgs...)
+	args = bob.MergeArgs(args, withArgs)
 
 	w.WriteString("SELECT ")
 
@@ -56,69 +56,69 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, selArgs...)
+	args = bob.MergeArgs(args, selArgs)
 
 	fromArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.TableRef, s.TableRef.Expression != nil, "\nFROM ", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, fromArgs...)
+	args = bob.MergeArgs(args, fromArgs)
 
 	whereArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Where,
 		len(s.Where.Conditions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, whereArgs...)
+	args = bob.MergeArgs(args, whereArgs)
 
 	groupByArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.GroupBy,
 		len(s.GroupBy.Groups) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, groupByArgs...)
+	args = bob.MergeArgs(args, groupByArgs)
 
 	havingArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Having,
 		len(s.Having.Conditions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, havingArgs...)
+	args = bob.MergeArgs(args, havingArgs)
 
 	windowArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Windows,
 		len(s.Windows.Windows) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, windowArgs...)
+	args = bob.MergeArgs(args, windowArgs)
 
 	combineArgs, err := bob.ExpressSlice(ctx, w, d, start+len(args),
 		s.Combines.Queries, "\n", "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, combineArgs...)
+	args = bob.MergeArgs(args, combineArgs)
 
 	orderArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.OrderBy,
 		len(s.OrderBy.Expressions) > 0, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, orderArgs...)
+	args = bob.MergeArgs(args, orderArgs)
 
 	limitArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Limit,
 		s.Limit.Count != nil, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, limitArgs...)
+	args = bob.MergeArgs(args, limitArgs)
 
 	offsetArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), s.Offset,
 		s.Offset.Count != nil, "\n", "")
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, offsetArgs...)
+	args = bob.MergeArgs(args, offsetArgs)
 
 	w.WriteString("\n")
 	return args, nil

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -117,6 +117,23 @@ type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
 }
 
+func (v *ViewQuery[T, Ts]) Clone() *ViewQuery[T, Ts] {
+	if v == nil {
+		return nil
+	}
+
+	return &ViewQuery[T, Ts]{
+		Query: v.Query.Clone(),
+	}
+}
+
+func (v *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Ts] {
+	clone := v.Clone()
+	clone.Apply(queryMods...)
+
+	return clone
+}
+
 // Count the number of matching rows
 func (v *ViewQuery[T, Tslice]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	ctx, err := v.RunHooks(ctx, exec)

--- a/expr/arg.go
+++ b/expr/arg.go
@@ -23,6 +23,12 @@ type args struct {
 }
 
 func (a args) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	var args []any
+	err := a.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (a args) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	if a.grouped {
 		w.WriteString(openPar)
 	}
@@ -43,7 +49,8 @@ func (a args) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, st
 		w.WriteString(closePar)
 	}
 
-	return a.vals, nil
+	*args = bob.MergeArgs(*args, a.vals)
+	return nil
 }
 
 func ToArgs[T any](vals ...T) bob.Expression {

--- a/expr/group.go
+++ b/expr/group.go
@@ -11,9 +11,15 @@ import (
 type group []bob.Expression
 
 func (g group) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	var args []any
+	err := g.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (g group) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	if len(g) == 0 {
-		return bob.ExpressIf(ctx, w, d, start, null, true, openPar, closePar)
+		return bob.ExpressIfTo(ctx, w, d, start, null, true, openPar, closePar, args)
 	}
 
-	return bob.ExpressSlice(ctx, w, d, start, g, openPar, commaSpace, closePar)
+	return bob.ExpressSliceTo(ctx, w, d, start, g, openPar, commaSpace, closePar, args)
 }

--- a/expr/operators.go
+++ b/expr/operators.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/stephenafamo/bob"
@@ -16,19 +15,22 @@ type leftRight struct {
 }
 
 func (lr leftRight) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	largs, err := bob.Express(ctx, w, d, start, lr.left)
-	if err != nil {
-		return nil, err
+	var args []any
+	err := lr.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (lr leftRight) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
+	baseLen := len(*args)
+	if err := bob.ExpressTo(ctx, w, d, start, lr.left, args); err != nil {
+		return err
 	}
 
-	w.WriteString(fmt.Sprintf(" %s ", lr.operator))
+	w.WriteString(" ")
+	w.WriteString(lr.operator)
+	w.WriteString(" ")
 
-	rargs, err := bob.Express(ctx, w, d, start+len(largs), lr.right)
-	if err != nil {
-		return nil, err
-	}
-
-	return append(largs, rargs...), nil
+	return bob.ExpressTo(ctx, w, d, start+len(*args)-baseLen, lr.right, args)
 }
 
 // Generic operator between a left and right val
@@ -47,10 +49,16 @@ type Join struct {
 }
 
 func (s Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	var args []any
+	err := s.WriteSQLTo(ctx, w, d, start, &args)
+	return args, err
+}
+
+func (s Join) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	sep := s.Sep
 	if sep == "" {
 		sep = " "
 	}
 
-	return bob.ExpressSlice(ctx, w, d, start, s.Exprs, "", sep, "")
+	return bob.ExpressSliceTo(ctx, w, d, start, s.Exprs, "", sep, "", args)
 }

--- a/expr/quote.go
+++ b/expr/quote.go
@@ -8,6 +8,18 @@ import (
 )
 
 func Quote(aa ...string) bob.Expression {
+	allNonEmpty := true
+	for _, v := range aa {
+		if v == "" {
+			allNonEmpty = false
+			break
+		}
+	}
+
+	if allNonEmpty {
+		return quoted(aa)
+	}
+
 	ss := make([]string, 0, len(aa))
 	for _, v := range aa {
 		if v == "" {
@@ -23,8 +35,12 @@ func Quote(aa ...string) bob.Expression {
 type quoted []string
 
 func (q quoted) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	return nil, q.WriteSQLTo(ctx, w, d, start, nil)
+}
+
+func (q quoted) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	if len(q) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// wrap in parenthesis and join with comma
@@ -42,5 +58,5 @@ func (q quoted) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, 
 		d.WriteQuoted(w, a)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/expr/raw.go
+++ b/expr/raw.go
@@ -13,8 +13,12 @@ import (
 type Raw string
 
 func (r Raw) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	return nil, r.WriteSQLTo(ctx, w, d, start, nil)
+}
+
+func (r Raw) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	w.WriteString(string(r))
-	return nil, nil
+	return nil
 }
 
 func RawQuery(d bob.Dialect, q string, args ...any) bob.BaseQuery[Clause] {
@@ -31,30 +35,53 @@ type Clause struct {
 }
 
 func (r Clause) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	// replace the args with positional args appropriately
-	total, args, err := r.convertQuestionMarks(ctx, w, d, start)
+	var args []any
+	total, err := r.writeSQLTo(ctx, w, d, start, &args)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(r.args) != total {
-		return r.args, &rawError{args: len(r.args), placeholders: total, clause: r.query}
+		return nil, &rawError{args: len(r.args), placeholders: total, clause: r.query}
 	}
 
 	return args, nil
 }
 
-// convertQuestionMarks converts each occurrence of ? with $<number>
-// where <number> is an incrementing digit starting at startAt.
-// If question-mark (?) is escaped using back-slash (\), it will be ignored.
-func (r Clause) convertQuestionMarks(ctx context.Context, w io.StringWriter, d bob.Dialect, startAt int) (int, []any, error) {
-	if startAt == 0 {
+func (r Clause) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
+	origLen := len(*args)
+	origNil := *args == nil
+	total, err := r.writeSQLTo(ctx, w, d, start, args)
+	if err != nil {
+		if origNil && origLen == 0 {
+			*args = nil
+		} else {
+			*args = (*args)[:origLen]
+		}
+		return err
+	}
+
+	if len(r.args) != total {
+		if origNil && origLen == 0 {
+			*args = nil
+		} else {
+			*args = (*args)[:origLen]
+		}
+		return &rawError{args: len(r.args), placeholders: total, clause: r.query}
+	}
+
+	return nil
+}
+
+func (r Clause) writeSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) (int, error) {
+	// replace the args with positional args appropriately
+	if start == 0 {
 		panic("Not a valid start number.")
 	}
 
+	baseLen := len(*args)
 	paramIndex := 0
 	total := 0
-	var args []any
 
 	clause := r.query
 	for paramIndex < len(clause) {
@@ -79,24 +106,21 @@ func (r Clause) convertQuestionMarks(ctx context.Context, w io.StringWriter, d b
 		if total < len(r.args) {
 			arg = r.args[total]
 		}
+
 		if ex, ok := arg.(bob.Expression); ok {
-			eargs, err := ex.WriteSQL(ctx, w, d, startAt)
-			if err != nil {
-				return total, nil, err
+			if err := bob.ExpressTo(ctx, w, d, start+len(*args)-baseLen, ex, args); err != nil {
+				return total, err
 			}
-			args = append(args, eargs...)
-			startAt += len(eargs)
 		} else {
-			d.WriteArg(w, startAt)
-			args = append(args, arg)
-			startAt++
+			d.WriteArg(w, start+len(*args)-baseLen)
+			*args = append(*args, arg)
 		}
 
 		total++
 		paramIndex++
 	}
 
-	return total, args, nil
+	return total, nil
 }
 
 type rawError struct {

--- a/expr/string.go
+++ b/expr/string.go
@@ -10,9 +10,13 @@ import (
 type rawString string
 
 func (s rawString) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	return nil, s.WriteSQLTo(ctx, w, d, start, nil)
+}
+
+func (s rawString) WriteSQLTo(ctx context.Context, w io.StringWriter, d bob.Dialect, start int, args *[]any) error {
 	w.WriteString("'")
 	w.WriteString(string(s))
 	w.WriteString("'")
 
-	return nil, nil
+	return nil
 }

--- a/expression.go
+++ b/expression.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 var ErrNoNamedArgs = errors.New("Dialect does not support named arguments")
@@ -41,53 +42,121 @@ func (e ExpressionFunc) WriteSQL(ctx context.Context, w io.StringWriter, d Diale
 	return e(ctx, w, d, start)
 }
 
+type sqlWriterTo interface {
+	WriteSQLTo(ctx context.Context, w io.StringWriter, d Dialect, start int, args *[]any) error
+}
+
 func Express(ctx context.Context, w io.StringWriter, d Dialect, start int, e any) ([]any, error) {
+	var args []any
+	err := ExpressTo(ctx, w, d, start, e, &args)
+	return args, err
+}
+
+func ExpressTo(ctx context.Context, w io.StringWriter, d Dialect, start int, e any, args *[]any) error {
 	switch v := e.(type) {
 	case string:
 		w.WriteString(v)
-		return nil, nil
+		return nil
 	case []byte:
 		w.WriteString(string(v))
-		return nil, nil
+		return nil
+	case bool:
+		w.WriteString(strconv.FormatBool(v))
+		return nil
+	case int:
+		w.WriteString(strconv.Itoa(v))
+		return nil
+	case int8:
+		w.WriteString(strconv.FormatInt(int64(v), 10))
+		return nil
+	case int16:
+		w.WriteString(strconv.FormatInt(int64(v), 10))
+		return nil
+	case int32:
+		w.WriteString(strconv.FormatInt(int64(v), 10))
+		return nil
+	case int64:
+		w.WriteString(strconv.FormatInt(v, 10))
+		return nil
+	case uint:
+		w.WriteString(strconv.FormatUint(uint64(v), 10))
+		return nil
+	case uint8:
+		w.WriteString(strconv.FormatUint(uint64(v), 10))
+		return nil
+	case uint16:
+		w.WriteString(strconv.FormatUint(uint64(v), 10))
+		return nil
+	case uint32:
+		w.WriteString(strconv.FormatUint(uint64(v), 10))
+		return nil
+	case uint64:
+		w.WriteString(strconv.FormatUint(v, 10))
+		return nil
+	case float32:
+		w.WriteString(strconv.FormatFloat(float64(v), 'g', -1, 32))
+		return nil
+	case float64:
+		w.WriteString(strconv.FormatFloat(v, 'g', -1, 64))
+		return nil
 	case sql.NamedArg:
 		dn, ok := d.(DialectWithNamed)
 		if !ok {
-			return nil, ErrNoNamedArgs
+			return ErrNoNamedArgs
 		}
 		dn.WriteNamedArg(w, v.Name)
-		return []any{v}, nil
+		*args = append(*args, v)
+		return nil
+	case sqlWriterTo:
+		return v.WriteSQLTo(ctx, w, d, start, args)
 	case Expression:
-		return v.WriteSQL(ctx, w, d, start)
+		newArgs, err := v.WriteSQL(ctx, w, d, start)
+		*args = MergeArgs(*args, newArgs)
+		return err
+	case interface{ String() string }:
+		w.WriteString(v.String())
+		return nil
 	default:
 		w.WriteString(fmt.Sprint(v))
-		return nil, nil
+		return nil
 	}
 }
 
 // ExpressIf expands an express if the condition evaluates to true
 // it can also add a prefix and suffix
 func ExpressIf(ctx context.Context, w io.StringWriter, d Dialect, start int, e any, cond bool, prefix, suffix string) ([]any, error) {
+	var args []any
+	err := ExpressIfTo(ctx, w, d, start, e, cond, prefix, suffix, &args)
+	return args, err
+}
+
+func ExpressIfTo(ctx context.Context, w io.StringWriter, d Dialect, start int, e any, cond bool, prefix, suffix string, args *[]any) error {
 	if !cond {
-		return nil, nil
+		return nil
 	}
 
 	w.WriteString(prefix)
-	args, err := Express(ctx, w, d, start, e)
-	if err != nil {
-		return nil, err
+	if err := ExpressTo(ctx, w, d, start, e, args); err != nil {
+		return err
 	}
 	w.WriteString(suffix)
 
-	return args, nil
+	return nil
 }
 
 // ExpressSlice is used to express a slice of expressions along with a prefix and suffix
 func ExpressSlice[T any](ctx context.Context, w io.StringWriter, d Dialect, start int, expressions []T, prefix, sep, suffix string) ([]any, error) {
+	var args []any
+	err := ExpressSliceTo(ctx, w, d, start, expressions, prefix, sep, suffix, &args)
+	return args, err
+}
+
+func ExpressSliceTo[T any](ctx context.Context, w io.StringWriter, d Dialect, start int, expressions []T, prefix, sep, suffix string, args *[]any) error {
 	if len(expressions) == 0 {
-		return nil, nil
+		return nil
 	}
 
-	var args []any
+	baseLen := len(*args)
 	w.WriteString(prefix)
 
 	for k, e := range expressions {
@@ -95,14 +164,22 @@ func ExpressSlice[T any](ctx context.Context, w io.StringWriter, d Dialect, star
 			w.WriteString(sep)
 		}
 
-		newArgs, err := Express(ctx, w, d, start+len(args), e)
-		if err != nil {
-			return args, err
+		if err := ExpressTo(ctx, w, d, start+len(*args)-baseLen, e, args); err != nil {
+			return err
 		}
-
-		args = append(args, newArgs...)
 	}
 	w.WriteString(suffix)
 
-	return args, nil
+	return nil
+}
+
+func MergeArgs(dst, src []any) []any {
+	switch {
+	case len(src) == 0:
+		return dst
+	case len(dst) == 0:
+		return src
+	default:
+		return append(dst, src...)
+	}
 }

--- a/hooks.go
+++ b/hooks.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 	"sync"
 )
 
@@ -84,6 +85,12 @@ func (h *Hooks[T, K]) RunHooks(ctx context.Context, exec Executor, o T) (context
 
 type EmbeddedHook struct {
 	Hooks []func(context.Context, Executor) (context.Context, error)
+}
+
+func (h EmbeddedHook) Clone() EmbeddedHook {
+	h.Hooks = slices.Clone(h.Hooks)
+
+	return h
 }
 
 func (h *EmbeddedHook) SetHooks(hooks ...func(context.Context, Executor) (context.Context, error)) {

--- a/load.go
+++ b/load.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 
 	"github.com/stephenafamo/scan"
 )
@@ -35,6 +36,13 @@ func (l LoaderFunc) Load(ctx context.Context, exec Executor, retrieved any) erro
 type Load struct {
 	loadFuncs         []Loader
 	preloadMapperMods []scan.MapperMod
+}
+
+func (l Load) Clone() Load {
+	l.loadFuncs = slices.Clone(l.loadFuncs)
+	l.preloadMapperMods = slices.Clone(l.preloadMapperMods)
+
+	return l
 }
 
 func (l *Load) SetMapperMods(mods ...scan.MapperMod) {

--- a/mods.go
+++ b/mods.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"context"
+	"slices"
 )
 
 // Mod is a generic interface for modifying a query
@@ -51,6 +52,12 @@ func (c ContextualModFunc[T]) Apply(ctx context.Context, o T) (context.Context, 
 
 type ContextualModdable[T any] struct {
 	Mods []ContextualMod[T]
+}
+
+func (h ContextualModdable[T]) Clone() ContextualModdable[T] {
+	h.Mods = slices.Clone(h.Mods)
+
+	return h
 }
 
 // AppendContextualMod a hook to the set

--- a/orm/query.go
+++ b/orm/query.go
@@ -22,6 +22,13 @@ func (q ExecQuery[Q]) Clone() ExecQuery[Q] {
 	}
 }
 
+func (q ExecQuery[Q]) With(mods ...bob.Mod[Q]) ExecQuery[Q] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
+}
+
 func (q ExecQuery[Q]) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
 	var err error
 
@@ -55,7 +62,15 @@ type Query[Q bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
 func (q Query[Q, T, Ts, Tr]) Clone() Query[Q, T, Ts, Tr] {
 	return Query[Q, T, Ts, Tr]{
 		ExecQuery: q.ExecQuery.Clone(),
+		Scanner:   q.Scanner,
 	}
+}
+
+func (q Query[Q, T, Ts, Tr]) With(mods ...bob.Mod[Q]) Query[Q, T, Ts, Tr] {
+	clone := q.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 // First matching row

--- a/query.go
+++ b/query.go
@@ -71,12 +71,14 @@ func (b BaseQuery[E]) Clone() BaseQuery[E] {
 		return BaseQuery[E]{
 			Expression: c.Clone(),
 			Dialect:    b.Dialect,
+			QueryType:  b.QueryType,
 		}
 	}
 
 	return BaseQuery[E]{
 		Expression: reprint.This(b.Expression).(E),
 		Dialect:    b.Dialect,
+		QueryType:  b.QueryType,
 	}
 }
 
@@ -116,6 +118,13 @@ func (b BaseQuery[E]) Apply(mods ...Mod[E]) {
 	for _, mod := range mods {
 		mod.Apply(b.Expression)
 	}
+}
+
+func (b BaseQuery[E]) With(mods ...Mod[E]) BaseQuery[E] {
+	clone := b.Clone()
+	clone.Apply(mods...)
+
+	return clone
 }
 
 func (b BaseQuery[E]) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {

--- a/query.go
+++ b/query.go
@@ -135,6 +135,14 @@ func (b BaseQuery[E]) WriteQuery(ctx context.Context, w io.StringWriter, start i
 		return e.WriteQuery(ctx, w, start)
 	}
 
+	if e, ok := any(b.Expression).(interface {
+		WriteSQLTo(context.Context, io.StringWriter, Dialect, int, *[]any) error
+	}); ok {
+		var args []any
+		err := e.WriteSQLTo(ctx, w, b.Dialect, start, &args)
+		return args, err
+	}
+
 	return b.Expression.WriteSQL(ctx, w, b.Dialect, start)
 }
 


### PR DESCRIPTION
Moves the order writer dispatch into the clause layer so the PostgreSQL specialization stays faster without keeping the extra switch-heavy logic inside the select builder.

This branch is intended to be reviewed after #654. GitHub requires this PR to target `main`, so the diff includes the earlier stack commits until they land.

Stack:
- 5/5
- branch: `psql-order-writer-dispatch`
- builds on: #654

Benchmarks

Upstream `main` baseline:
```text
BenchmarkBaseQueryApplyMain                     3039 ns/op   2865 B/op    48 allocs/op
BenchmarkViewQueryCountThenPaginateApplyMain  10070 ns/op   7424 B/op   130 allocs/op
```

This branch immutable path:
```text
BenchmarkBaseQueryWithImmutableOrderWriterDispatch                     5960 ns/op   3288 B/op    38 allocs/op
BenchmarkViewQueryCountThenPaginateImmutableOrderWriterDispatch      10063 ns/op   5688 B/op    63 allocs/op
```

Verification:
- `go test ./clause ./expr ./orm ./dialect/psql ./dialect/mysql ./dialect/sqlite`
- `go test ./dialect/psql -run '^$' -bench 'Benchmark(BaseQueryApplyMain|BaseQueryWithImmutableOrderWriterDispatch|ViewQueryCountThenPaginateApplyMain|ViewQueryCountThenPaginateImmutableOrderWriterDispatch)$' -benchmem`
