### PR TITLE
feat(psql): add native immutable with paths

### DIFF
--- a/dialect/psql/delete.go
+++ b/dialect/psql/delete.go
@@ -5,15 +5,25 @@ import (
 	"github.com/stephenafamo/bob/dialect/psql/dialect"
 )
 
-func Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) bob.BaseQuery[*dialect.DeleteQuery] {
+type DeleteQuery struct {
+	bob.BaseQuery[*dialect.DeleteQuery]
+}
+
+func (q DeleteQuery) With(queryMods ...bob.Mod[*dialect.DeleteQuery]) derivedDeleteQuery {
+	return asImmutableDelete(q.BaseQuery).With(queryMods...)
+}
+
+func Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) DeleteQuery {
 	q := &dialect.DeleteQuery{}
 	for _, mod := range queryMods {
 		mod.Apply(q)
 	}
 
-	return bob.BaseQuery[*dialect.DeleteQuery]{
-		Expression: q,
-		Dialect:    dialect.Dialect,
-		QueryType:  bob.QueryTypeDelete,
+	return DeleteQuery{
+		BaseQuery: bob.BaseQuery[*dialect.DeleteQuery]{
+			Expression: q,
+			Dialect:    dialect.Dialect,
+			QueryType:  bob.QueryTypeDelete,
+		},
 	}
 }

--- a/dialect/psql/immutable_select.go
+++ b/dialect/psql/immutable_select.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stephenafamo/scan"
 )
 
-type ImmutableSelectQuery struct {
+type derivedSelectQuery struct {
 	state immutableSelectState
 }
 
@@ -43,18 +43,18 @@ type immutableSelectState struct {
 	CombinedOffset clause.Offset
 }
 
-func asImmutable(q bob.BaseQuery[*psqldialect.SelectQuery]) ImmutableSelectQuery {
-	return ImmutableSelectQuery{state: immutableStateFromMutable(q.Expression)}
+func asImmutable(q bob.BaseQuery[*psqldialect.SelectQuery]) derivedSelectQuery {
+	return derivedSelectQuery{state: immutableStateFromMutable(q.Expression)}
 }
 
-func (q ImmutableSelectQuery) Type() bob.QueryType {
+func (q derivedSelectQuery) Type() bob.QueryType {
 	return bob.QueryTypeSelect
 }
 
-func (q ImmutableSelectQuery) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableSelectQuery {
+func (q derivedSelectQuery) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) derivedSelectQuery {
 	next, ok := q.state.withMods(queryMods...)
 	if ok {
-		return ImmutableSelectQuery{state: next}
+		return derivedSelectQuery{state: next}
 	}
 
 	mutable := q.state.toMutable()
@@ -62,10 +62,10 @@ func (q ImmutableSelectQuery) With(queryMods ...bob.Mod[*psqldialect.SelectQuery
 		mod.Apply(&mutable)
 	}
 
-	return ImmutableSelectQuery{state: immutableStateFromMutable(&mutable)}
+	return derivedSelectQuery{state: immutableStateFromMutable(&mutable)}
 }
 
-func (q ImmutableSelectQuery) AsCount() ImmutableSelectQuery {
+func (q derivedSelectQuery) AsCount() derivedSelectQuery {
 	next := q.state
 	next.SelectColumns = []any{"count(1)"}
 	next.PreloadColumns = nil
@@ -76,14 +76,14 @@ func (q ImmutableSelectQuery) AsCount() ImmutableSelectQuery {
 	next.Offset.Count = nil
 	next.Limit.Count = 1
 
-	return ImmutableSelectQuery{state: next}
+	return derivedSelectQuery{state: next}
 }
 
-func (q ImmutableSelectQuery) Build(ctx context.Context) (string, []any, error) {
+func (q derivedSelectQuery) Build(ctx context.Context) (string, []any, error) {
 	return q.BuildN(ctx, 1)
 }
 
-func (q ImmutableSelectQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
+func (q derivedSelectQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
 	var sb strings.Builder
 	args, err := q.WriteQuery(ctx, &sb, start)
 	if err != nil {
@@ -93,7 +93,7 @@ func (q ImmutableSelectQuery) BuildN(ctx context.Context, start int) (string, []
 	return sb.String(), args, nil
 }
 
-func (q ImmutableSelectQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+func (q derivedSelectQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
 	writer := immutableSelectWriter{
 		ctx:   ctx,
 		w:     w,
@@ -107,7 +107,7 @@ func (q ImmutableSelectQuery) WriteQuery(ctx context.Context, w io.StringWriter,
 	return writer.args, nil
 }
 
-func (q ImmutableSelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
+func (q derivedSelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
 	w.WriteString("(")
 	args, err := q.WriteQuery(ctx, w, start)
 	if err != nil {
@@ -117,47 +117,47 @@ func (q ImmutableSelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, _
 	return args, nil
 }
 
-type ImmutableViewQuery[T any, Ts ~[]T] struct {
-	Query   ImmutableSelectQuery
+type derivedViewQuery[T any, Ts ~[]T] struct {
+	Query   derivedSelectQuery
 	Scanner scan.Mapper[T]
 	Hooks   *bob.Hooks[*psqldialect.SelectQuery, bob.SkipQueryHooksKey]
 }
 
-func (q *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableViewQuery[T, Ts] {
+func (q *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) derivedViewQuery[T, Ts] {
 	state := immutableStateFromMutable(q.BaseQuery.Expression)
 	if len(state.SelectColumns) == 0 && q.defaultSelect != nil {
 		state.SelectColumns = append(state.SelectColumns, q.defaultSelect)
 	}
 
-	return ImmutableViewQuery[T, Ts]{
-		Query:   ImmutableSelectQuery{state: state}.With(queryMods...),
+	return derivedViewQuery[T, Ts]{
+		Query:   derivedSelectQuery{state: state}.With(queryMods...),
 		Scanner: q.Scanner,
 		Hooks:   q.Hooks,
 	}
 }
 
-func (q ImmutableViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableViewQuery[T, Ts] {
+func (q derivedViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) derivedViewQuery[T, Ts] {
 	q.Query = q.Query.With(queryMods...)
 	return q
 }
 
-func (q ImmutableViewQuery[T, Ts]) One(ctx context.Context, exec bob.Executor) (T, error) {
+func (q derivedViewQuery[T, Ts]) One(ctx context.Context, exec bob.Executor) (T, error) {
 	return q.mutable().One(ctx, exec)
 }
 
-func (q ImmutableViewQuery[T, Ts]) All(ctx context.Context, exec bob.Executor) (Ts, error) {
+func (q derivedViewQuery[T, Ts]) All(ctx context.Context, exec bob.Executor) (Ts, error) {
 	return q.mutable().All(ctx, exec)
 }
 
-func (q ImmutableViewQuery[T, Ts]) Cursor(ctx context.Context, exec bob.Executor) (scan.ICursor[T], error) {
+func (q derivedViewQuery[T, Ts]) Cursor(ctx context.Context, exec bob.Executor) (scan.ICursor[T], error) {
 	return q.mutable().Cursor(ctx, exec)
 }
 
-func (q ImmutableViewQuery[T, Ts]) Each(ctx context.Context, exec bob.Executor) (func(func(T, error) bool), error) {
+func (q derivedViewQuery[T, Ts]) Each(ctx context.Context, exec bob.Executor) (func(func(T, error) bool), error) {
 	return q.mutable().Each(ctx, exec)
 }
 
-func (q ImmutableViewQuery[T, Ts]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
+func (q derivedViewQuery[T, Ts]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
 	mq := q.mutable()
 	ctx, err := mq.RunHooks(ctx, exec)
 	if err != nil {
@@ -166,20 +166,16 @@ func (q ImmutableViewQuery[T, Ts]) Count(ctx context.Context, exec bob.Executor)
 	return bob.One(ctx, exec, asCountQuery(mq.BaseQuery), scan.SingleColumnMapper[int64])
 }
 
-func (q ImmutableViewQuery[T, Ts]) Exists(ctx context.Context, exec bob.Executor) (bool, error) {
+func (q derivedViewQuery[T, Ts]) Exists(ctx context.Context, exec bob.Executor) (bool, error) {
 	count, err := q.Count(ctx, exec)
 	return count > 0, err
 }
 
-func (q ImmutableViewQuery[T, Ts]) CountQuery() ImmutableSelectQuery {
-	return q.Query.AsCount()
-}
-
-func (q ImmutableViewQuery[T, Ts]) Build(ctx context.Context) (string, []any, error) {
+func (q derivedViewQuery[T, Ts]) Build(ctx context.Context) (string, []any, error) {
 	return q.Query.Build(ctx)
 }
 
-func (q ImmutableViewQuery[T, Ts]) mutable() orm.Query[*psqldialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]] {
+func (q derivedViewQuery[T, Ts]) mutable() orm.Query[*psqldialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]] {
 	mutable := q.Query.state.toMutable()
 	return orm.Query[*psqldialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]{
 		ExecQuery: orm.ExecQuery[*psqldialect.SelectQuery]{

--- a/dialect/psql/immutable_select.go
+++ b/dialect/psql/immutable_select.go
@@ -1,0 +1,587 @@
+package psql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	psqldialect "github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/mods"
+	"github.com/stephenafamo/bob/orm"
+	"github.com/stephenafamo/scan"
+)
+
+type ImmutableSelectQuery struct {
+	state immutableSelectState
+}
+
+type immutableSelectState struct {
+	With           clause.With
+	SelectColumns  []any
+	PreloadColumns []any
+	Distinct       psqldialect.Distinct
+	TableRef       clause.TableRef
+	Where          clause.Where
+	GroupBy        clause.GroupBy
+	Having         clause.Having
+	Windows        clause.Windows
+	Combines       clause.Combines
+	OrderBy        clause.OrderBy
+	Limit          clause.Limit
+	Offset         clause.Offset
+	Fetch          clause.Fetch
+	Locks          clause.Locks
+
+	CombinedOrder  clause.OrderBy
+	CombinedLimit  clause.Limit
+	CombinedFetch  clause.Fetch
+	CombinedOffset clause.Offset
+}
+
+func newImmutableSelect(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableSelectQuery {
+	mutable := Select(queryMods...)
+	return ImmutableSelectQuery{state: immutableStateFromMutable(mutable.Expression)}
+}
+
+func asImmutable(q bob.BaseQuery[*psqldialect.SelectQuery]) ImmutableSelectQuery {
+	return ImmutableSelectQuery{state: immutableStateFromMutable(q.Expression)}
+}
+
+func (q ImmutableSelectQuery) Type() bob.QueryType {
+	return bob.QueryTypeSelect
+}
+
+func (q ImmutableSelectQuery) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableSelectQuery {
+	next, ok := q.state.withMods(queryMods...)
+	if ok {
+		return ImmutableSelectQuery{state: next}
+	}
+
+	mutable := q.state.toMutable()
+	for _, mod := range queryMods {
+		mod.Apply(&mutable)
+	}
+
+	return ImmutableSelectQuery{state: immutableStateFromMutable(&mutable)}
+}
+
+func (q ImmutableSelectQuery) AsCount() ImmutableSelectQuery {
+	next := q.state
+	next.SelectColumns = []any{"count(1)"}
+	next.PreloadColumns = nil
+	next.OrderBy.Expressions = nil
+	next.GroupBy.Groups = nil
+	next.GroupBy.With = ""
+	next.GroupBy.Distinct = false
+	next.Offset.Count = nil
+	next.Limit.Count = 1
+
+	return ImmutableSelectQuery{state: next}
+}
+
+func (q ImmutableSelectQuery) Build(ctx context.Context) (string, []any, error) {
+	return q.BuildN(ctx, 1)
+}
+
+func (q ImmutableSelectQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
+	var sb strings.Builder
+	args, err := q.WriteQuery(ctx, &sb, start)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return sb.String(), args, nil
+}
+
+func (q ImmutableSelectQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	writer := immutableSelectWriter{
+		ctx:   ctx,
+		w:     w,
+		start: start,
+	}
+
+	if err := writer.writeQuery(q.state); err != nil {
+		return nil, err
+	}
+
+	return writer.args, nil
+}
+
+func (q ImmutableSelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
+	w.WriteString("(")
+	args, err := q.WriteQuery(ctx, w, start)
+	if err != nil {
+		return nil, err
+	}
+	w.WriteString(")")
+	return args, nil
+}
+
+type ImmutableViewQuery[T any, Ts ~[]T] struct {
+	Query   ImmutableSelectQuery
+	Scanner scan.Mapper[T]
+	Hooks   *bob.Hooks[*psqldialect.SelectQuery, bob.SkipQueryHooksKey]
+}
+
+func (q *ViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableViewQuery[T, Ts] {
+	state := immutableStateFromMutable(q.BaseQuery.Expression)
+	if len(state.SelectColumns) == 0 && q.defaultSelect != nil {
+		state.SelectColumns = append(state.SelectColumns, q.defaultSelect)
+	}
+
+	return ImmutableViewQuery[T, Ts]{
+		Query:   ImmutableSelectQuery{state: state}.With(queryMods...),
+		Scanner: q.Scanner,
+		Hooks:   q.Hooks,
+	}
+}
+
+func (q ImmutableViewQuery[T, Ts]) With(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableViewQuery[T, Ts] {
+	q.Query = q.Query.With(queryMods...)
+	return q
+}
+
+func (q ImmutableViewQuery[T, Ts]) One(ctx context.Context, exec bob.Executor) (T, error) {
+	return q.mutable().One(ctx, exec)
+}
+
+func (q ImmutableViewQuery[T, Ts]) All(ctx context.Context, exec bob.Executor) (Ts, error) {
+	return q.mutable().All(ctx, exec)
+}
+
+func (q ImmutableViewQuery[T, Ts]) Cursor(ctx context.Context, exec bob.Executor) (scan.ICursor[T], error) {
+	return q.mutable().Cursor(ctx, exec)
+}
+
+func (q ImmutableViewQuery[T, Ts]) Each(ctx context.Context, exec bob.Executor) (func(func(T, error) bool), error) {
+	return q.mutable().Each(ctx, exec)
+}
+
+func (q ImmutableViewQuery[T, Ts]) Count(ctx context.Context, exec bob.Executor) (int64, error) {
+	mq := q.mutable()
+	ctx, err := mq.RunHooks(ctx, exec)
+	if err != nil {
+		return 0, err
+	}
+	return bob.One(ctx, exec, asCountQuery(mq.BaseQuery), scan.SingleColumnMapper[int64])
+}
+
+func (q ImmutableViewQuery[T, Ts]) Exists(ctx context.Context, exec bob.Executor) (bool, error) {
+	count, err := q.Count(ctx, exec)
+	return count > 0, err
+}
+
+func (q ImmutableViewQuery[T, Ts]) CountQuery() ImmutableSelectQuery {
+	return q.Query.AsCount()
+}
+
+func (q ImmutableViewQuery[T, Ts]) Build(ctx context.Context) (string, []any, error) {
+	return q.Query.Build(ctx)
+}
+
+func (q ImmutableViewQuery[T, Ts]) mutable() orm.Query[*psqldialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]] {
+	mutable := q.Query.state.toMutable()
+	return orm.Query[*psqldialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]{
+		ExecQuery: orm.ExecQuery[*psqldialect.SelectQuery]{
+			BaseQuery: bob.BaseQuery[*psqldialect.SelectQuery]{
+				Expression: &mutable,
+				Dialect:    psqldialect.Dialect,
+				QueryType:  bob.QueryTypeSelect,
+			},
+			Hooks: q.Hooks,
+		},
+		Scanner: q.Scanner,
+	}
+}
+
+func immutableStateFromMutable(q *psqldialect.SelectQuery) immutableSelectState {
+	return immutableSelectState{
+		With: clause.With{
+			Recursive: q.With.Recursive,
+			CTEs:      append([]bob.Expression(nil), q.With.CTEs...),
+		},
+		SelectColumns:  append([]any(nil), q.SelectList.Columns...),
+		PreloadColumns: append([]any(nil), q.SelectList.PreloadColumns...),
+		Distinct:       psqldialect.Distinct{On: append([]any(nil), q.Distinct.On...)},
+		TableRef:       cloneTableRef(q.TableRef),
+		Where:          clause.Where{Conditions: append([]any(nil), q.Where.Conditions...)},
+		GroupBy: clause.GroupBy{
+			Groups:   append([]any(nil), q.GroupBy.Groups...),
+			Distinct: q.GroupBy.Distinct,
+			With:     q.GroupBy.With,
+		},
+		Having: clause.Having{
+			Conditions: append([]any(nil), q.Having.Conditions...),
+		},
+		Windows: clause.Windows{
+			Windows: append([]bob.Expression(nil), q.Windows.Windows...),
+		},
+		Combines: clause.Combines{
+			Queries: append([]clause.Combine(nil), q.Combines.Queries...),
+		},
+		OrderBy: clause.OrderBy{
+			Expressions: append([]bob.Expression(nil), q.OrderBy.Expressions...),
+		},
+		Limit: clause.Limit{Count: q.Limit.Count},
+		Offset: clause.Offset{
+			Count: q.Offset.Count,
+		},
+		Fetch: clause.Fetch{
+			Count:    q.Fetch.Count,
+			WithTies: q.Fetch.WithTies,
+		},
+		Locks: clause.Locks{
+			Locks: append([]bob.Expression(nil), q.Locks.Locks...),
+		},
+		CombinedOrder: clause.OrderBy{
+			Expressions: append([]bob.Expression(nil), q.CombinedOrder.Expressions...),
+		},
+		CombinedLimit: clause.Limit{Count: q.CombinedLimit.Count},
+		CombinedFetch: clause.Fetch{
+			Count:    q.CombinedFetch.Count,
+			WithTies: q.CombinedFetch.WithTies,
+		},
+		CombinedOffset: clause.Offset{Count: q.CombinedOffset.Count},
+	}
+}
+
+func (s immutableSelectState) toMutable() psqldialect.SelectQuery {
+	return psqldialect.SelectQuery{
+		With:           s.With,
+		SelectList:     clause.SelectList{Columns: s.SelectColumns, PreloadColumns: s.PreloadColumns},
+		Distinct:       s.Distinct,
+		TableRef:       s.TableRef,
+		Where:          s.Where,
+		GroupBy:        s.GroupBy,
+		Having:         s.Having,
+		Windows:        s.Windows,
+		Combines:       s.Combines,
+		OrderBy:        s.OrderBy,
+		Limit:          s.Limit,
+		Offset:         s.Offset,
+		Fetch:          s.Fetch,
+		Locks:          s.Locks,
+		CombinedOrder:  s.CombinedOrder,
+		CombinedLimit:  s.CombinedLimit,
+		CombinedFetch:  s.CombinedFetch,
+		CombinedOffset: s.CombinedOffset,
+	}
+}
+
+func (s immutableSelectState) withMods(queryMods ...bob.Mod[*psqldialect.SelectQuery]) (immutableSelectState, bool) {
+	next := s
+	var cloneSelect, cloneWhere, cloneGroup, cloneHaving, cloneOrder, cloneWindows, cloneLocks bool
+
+	for _, mod := range queryMods {
+		switch m := mod.(type) {
+		case mods.Select[*psqldialect.SelectQuery]:
+			if !cloneSelect {
+				next.SelectColumns = append([]any(nil), s.SelectColumns...)
+				cloneSelect = true
+			}
+			next.SelectColumns = append(next.SelectColumns, []any(m)...)
+		case mods.Where[*psqldialect.SelectQuery]:
+			if !cloneWhere {
+				next.Where.Conditions = append([]any(nil), s.Where.Conditions...)
+				cloneWhere = true
+			}
+			next.Where.Conditions = append(next.Where.Conditions, m.E)
+		case mods.GroupBy[*psqldialect.SelectQuery]:
+			if !cloneGroup {
+				next.GroupBy.Groups = append([]any(nil), s.GroupBy.Groups...)
+				cloneGroup = true
+			}
+			next.GroupBy.Groups = append(next.GroupBy.Groups, m.E)
+		case mods.Having[*psqldialect.SelectQuery]:
+			if !cloneHaving {
+				next.Having.Conditions = append([]any(nil), s.Having.Conditions...)
+				cloneHaving = true
+			}
+			next.Having.Conditions = append(next.Having.Conditions, []any(m)...)
+		case mods.Limit[*psqldialect.SelectQuery]:
+			next.Limit.Count = m.Count
+		case mods.Offset[*psqldialect.SelectQuery]:
+			next.Offset.Count = m.Count
+		case mods.Fetch[*psqldialect.SelectQuery]:
+			next.Fetch = clause.Fetch(m)
+		case psqldialect.OrderBy[*psqldialect.SelectQuery]:
+			if !cloneOrder {
+				next.OrderBy.Expressions = append([]bob.Expression(nil), s.OrderBy.Expressions...)
+				cloneOrder = true
+			}
+			next.OrderBy.Expressions = append(next.OrderBy.Expressions, m())
+		case mods.NamedWindow[*psqldialect.SelectQuery]:
+			if !cloneWindows {
+				next.Windows.Windows = append([]bob.Expression(nil), s.Windows.Windows...)
+				cloneWindows = true
+			}
+			next.Windows.Windows = append(next.Windows.Windows, clause.NamedWindow(m))
+		case psqldialect.LockChain[*psqldialect.SelectQuery]:
+			if !cloneLocks {
+				next.Locks.Locks = append([]bob.Expression(nil), s.Locks.Locks...)
+				cloneLocks = true
+			}
+			next.Locks.Locks = append(next.Locks.Locks, m())
+		case psqldialect.FromChain[*psqldialect.SelectQuery]:
+			next.TableRef = cloneTableRef(m())
+		default:
+			return next, false
+		}
+	}
+
+	return next, true
+}
+
+func cloneTableRef(from clause.TableRef) clause.TableRef {
+	from.Columns = append([]string(nil), from.Columns...)
+	from.Partitions = append([]string(nil), from.Partitions...)
+	from.IndexHints = append([]clause.IndexHint(nil), from.IndexHints...)
+	from.Joins = append([]clause.Join(nil), from.Joins...)
+	for i := range from.Joins {
+		from.Joins[i].On = append([]bob.Expression(nil), from.Joins[i].On...)
+		from.Joins[i].Using = append([]string(nil), from.Joins[i].Using...)
+		from.Joins[i].To = cloneTableRef(from.Joins[i].To)
+	}
+	return from
+}
+
+type immutableSelectWriter struct {
+	ctx   context.Context
+	w     io.StringWriter
+	args  []any
+	start int
+}
+
+func (w *immutableSelectWriter) writeQuery(q immutableSelectState) error {
+	if len(q.With.CTEs) > 0 {
+		if _, err := q.With.WriteSQL(w.ctx, w.w, psqldialect.Dialect, w.argPos()); err != nil {
+			return err
+		}
+		w.w.WriteString("\n")
+	}
+
+	w.w.WriteString("SELECT ")
+
+	if q.Distinct.On != nil {
+		w.w.WriteString("DISTINCT")
+		if len(q.Distinct.On) > 0 {
+			w.w.WriteString(" ON (")
+			if err := w.writeSliceAny(q.Distinct.On, ", "); err != nil {
+				return err
+			}
+			w.w.WriteString(")")
+		}
+		w.w.WriteString(" ")
+	}
+
+	w.w.WriteString("\n")
+	if len(q.SelectColumns) == 0 && len(q.PreloadColumns) == 0 {
+		w.w.WriteString("*")
+	} else {
+		allCols := append([]any(nil), q.SelectColumns...)
+		allCols = append(allCols, q.PreloadColumns...)
+		if err := w.writeSliceAny(allCols, ", "); err != nil {
+			return err
+		}
+	}
+
+	if q.TableRef.Expression != nil {
+		w.w.WriteString("\nFROM ")
+		args, err := q.TableRef.WriteSQL(w.ctx, w.w, psqldialect.Dialect, w.argPos())
+		if err != nil {
+			return err
+		}
+		w.args = append(w.args, args...)
+	}
+
+	if len(q.Where.Conditions) > 0 {
+		w.w.WriteString("\nWHERE ")
+		if err := w.writeSliceAny(q.Where.Conditions, " AND "); err != nil {
+			return err
+		}
+	}
+
+	if len(q.GroupBy.Groups) > 0 {
+		w.w.WriteString("\nGROUP BY ")
+		if q.GroupBy.Distinct {
+			w.w.WriteString("DISTINCT ")
+		}
+		if err := w.writeSliceAny(q.GroupBy.Groups, ", "); err != nil {
+			return err
+		}
+		if q.GroupBy.With != "" {
+			w.w.WriteString(" WITH ")
+			w.w.WriteString(q.GroupBy.With)
+		}
+	}
+
+	if len(q.Having.Conditions) > 0 {
+		w.w.WriteString("\nHAVING ")
+		if err := w.writeSliceAny(q.Having.Conditions, " AND "); err != nil {
+			return err
+		}
+	}
+
+	if len(q.Windows.Windows) > 0 {
+		w.w.WriteString("\nWINDOW ")
+		if err := w.writeSliceExpr(q.Windows.Windows, ", "); err != nil {
+			return err
+		}
+	}
+
+	if len(q.OrderBy.Expressions) > 0 {
+		w.w.WriteString("\nORDER BY ")
+		if err := w.writeOrderExprs(q.OrderBy.Expressions); err != nil {
+			return err
+		}
+	}
+
+	if q.Limit.Count != nil {
+		w.w.WriteString("\nLIMIT ")
+		if err := w.writeAny(q.Limit.Count); err != nil {
+			return err
+		}
+	}
+
+	if q.Offset.Count != nil {
+		w.w.WriteString("\nOFFSET ")
+		if err := w.writeAny(q.Offset.Count); err != nil {
+			return err
+		}
+	}
+
+	if q.Fetch.Count != nil {
+		w.w.WriteString("\nFETCH NEXT ")
+		if err := w.writeAny(q.Fetch.Count); err != nil {
+			return err
+		}
+		if q.Fetch.WithTies {
+			w.w.WriteString(" ROWS WITH TIES")
+		} else {
+			w.w.WriteString(" ROWS ONLY")
+		}
+	}
+
+	for _, lock := range q.Locks.Locks {
+		w.w.WriteString("\n")
+		if err := w.writeAny(lock); err != nil {
+			return err
+		}
+	}
+
+	w.w.WriteString("\n")
+	return nil
+}
+
+func (w *immutableSelectWriter) argPos() int {
+	return w.start + len(w.args)
+}
+
+func (w *immutableSelectWriter) writeSliceAny(values []any, sep string) error {
+	for i, value := range values {
+		if i > 0 {
+			w.w.WriteString(sep)
+		}
+		if err := w.writeAny(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *immutableSelectWriter) writeSliceExpr(values []bob.Expression, sep string) error {
+	for i, value := range values {
+		if i > 0 {
+			w.w.WriteString(sep)
+		}
+		if err := w.writeExpression(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *immutableSelectWriter) writeOrderExprs(values []bob.Expression) error {
+	for i, value := range values {
+		if i > 0 {
+			w.w.WriteString(", ")
+		}
+
+		switch order := value.(type) {
+		case clause.OrderDef:
+			if err := w.writeAny(order.Expression); err != nil {
+				return err
+			}
+			if order.Collation != "" {
+				w.w.WriteString(" COLLATE ")
+				psqldialect.Dialect.WriteQuoted(w.w, order.Collation)
+			}
+			if order.Direction != "" {
+				w.w.WriteString(" ")
+				w.w.WriteString(order.Direction)
+			}
+			if order.Nulls != "" {
+				w.w.WriteString(" NULLS ")
+				w.w.WriteString(order.Nulls)
+			}
+		default:
+			if err := w.writeExpression(value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *immutableSelectWriter) writeExpression(value bob.Expression) error {
+	args, err := value.WriteSQL(w.ctx, w.w, psqldialect.Dialect, w.argPos())
+	if err != nil {
+		return err
+	}
+	w.args = append(w.args, args...)
+	return nil
+}
+
+func (w *immutableSelectWriter) writeAny(value any) error {
+	switch v := value.(type) {
+	case nil:
+		w.w.WriteString("NULL")
+	case string:
+		w.w.WriteString(v)
+	case []byte:
+		w.w.WriteString(string(v))
+	case int:
+		w.w.WriteString(strconv.Itoa(v))
+	case int8:
+		w.w.WriteString(strconv.FormatInt(int64(v), 10))
+	case int16:
+		w.w.WriteString(strconv.FormatInt(int64(v), 10))
+	case int32:
+		w.w.WriteString(strconv.FormatInt(int64(v), 10))
+	case int64:
+		w.w.WriteString(strconv.FormatInt(v, 10))
+	case uint:
+		w.w.WriteString(strconv.FormatUint(uint64(v), 10))
+	case uint8:
+		w.w.WriteString(strconv.FormatUint(uint64(v), 10))
+	case uint16:
+		w.w.WriteString(strconv.FormatUint(uint64(v), 10))
+	case uint32:
+		w.w.WriteString(strconv.FormatUint(uint64(v), 10))
+	case uint64:
+		w.w.WriteString(strconv.FormatUint(v, 10))
+	case sql.NamedArg:
+		return fmt.Errorf("named args are not supported by psql dialect")
+	case bob.Expression:
+		return w.writeExpression(v)
+	default:
+		w.w.WriteString(fmt.Sprint(v))
+	}
+
+	return nil
+}

--- a/dialect/psql/immutable_select.go
+++ b/dialect/psql/immutable_select.go
@@ -43,11 +43,6 @@ type immutableSelectState struct {
 	CombinedOffset clause.Offset
 }
 
-func newImmutableSelect(queryMods ...bob.Mod[*psqldialect.SelectQuery]) ImmutableSelectQuery {
-	mutable := Select(queryMods...)
-	return ImmutableSelectQuery{state: immutableStateFromMutable(mutable.Expression)}
-}
-
 func asImmutable(q bob.BaseQuery[*psqldialect.SelectQuery]) ImmutableSelectQuery {
 	return ImmutableSelectQuery{state: immutableStateFromMutable(q.Expression)}
 }

--- a/dialect/psql/immutable_select_test.go
+++ b/dialect/psql/immutable_select_test.go
@@ -1,7 +1,6 @@
 package psql
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stephenafamo/bob"
@@ -24,7 +23,7 @@ func TestImmutableSelectQueryWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("expected derived query type %q, got %q", bob.QueryTypeSelect, derived.Type())
 	}
 
-	baseSQL, _, err := base.Build(context.Background())
+	baseSQL, _, err := base.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +31,7 @@ func TestImmutableSelectQueryWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("base query changed unexpectedly: %#v", baseSQL)
 	}
 
-	derivedSQL, _, err := derived.Build(context.Background())
+	derivedSQL, _, err := derived.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +55,7 @@ func TestImmutableViewQueryWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatal("expected derived view query to preserve scanner")
 	}
 
-	baseSQL, _, err := base.Build(context.Background())
+	baseSQL, _, err := base.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func TestImmutableViewQueryWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("base view query changed unexpectedly: %#v", baseSQL)
 	}
 
-	derivedSQL, _, err := derived.Build(context.Background())
+	derivedSQL, _, err := derived.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestImmutableViewQueryWithDoesNotMutateOriginal(t *testing.T) {
 }
 
 func BenchmarkBaseQueryApplyMain(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -96,7 +95,7 @@ func BenchmarkBaseQueryApplyMain(b *testing.B) {
 }
 
 func BenchmarkBaseQueryImmutableNativeHotPath(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -118,7 +117,7 @@ func BenchmarkBaseQueryImmutableNativeHotPath(b *testing.B) {
 }
 
 func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -143,7 +142,7 @@ func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
 }
 
 func BenchmarkViewQueryCountThenPaginateImmutableNativeHotPath(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/dialect/psql/immutable_select_test.go
+++ b/dialect/psql/immutable_select_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestImmutableSelectQueryWithDoesNotMutateOriginal(t *testing.T) {
-	base := newImmutableSelect(
+	base := Select(
 		sm.Columns("id"),
 		sm.From("users"),
-	)
+	).With()
 
 	derived := base.With(
 		sm.OrderBy("id").Desc(),
@@ -100,11 +100,11 @@ func BenchmarkBaseQueryImmutableNativeHotPath(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		q := asImmutable(Select(
+		q := Select(
 			sm.Columns("id", "name"),
 			sm.From("users"),
 			sm.Where(Quote("tenant_id").EQ(Arg(42))),
-		))
+		)
 		derived := q.With(
 			sm.OrderBy("id").Desc(),
 			sm.Limit(10),

--- a/dialect/psql/immutable_select_test.go
+++ b/dialect/psql/immutable_select_test.go
@@ -1,0 +1,168 @@
+package psql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func TestImmutableSelectQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := newImmutableSelect(
+		sm.Columns("id"),
+		sm.From("users"),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Type() != bob.QueryTypeSelect {
+		t.Fatalf("expected derived query type %q, got %q", bob.QueryTypeSelect, derived.Type())
+	}
+
+	baseSQL, _, err := base.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseSQL != "SELECT \nid\nFROM users\n" {
+		t.Fatalf("base query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL, _, err := derived.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivedSQL != "SELECT \nid\nFROM users\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived query mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestImmutableViewQueryWithDoesNotMutateOriginal(t *testing.T) {
+	base := someStructView.Query(
+		sm.Where(Quote("id").GT(Arg(0))),
+	).With()
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	if derived.Scanner == nil {
+		t.Fatal("expected derived view query to preserve scanner")
+	}
+
+	baseSQL, _, err := base.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $1)\n" {
+		t.Fatalf("base view query changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL, _, err := derived.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivedSQL != "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" > $1)\nORDER BY id DESC\nLIMIT 10\nOFFSET 20\n" {
+		t.Fatalf("derived view query mismatch: %#v", derivedSQL)
+	}
+}
+
+func BenchmarkBaseQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		)
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBaseQueryImmutableNativeHotPath(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := asImmutable(Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(Quote("tenant_id").EQ(Arg(42))),
+		))
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		q.Apply(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkViewQueryCountThenPaginateImmutableNativeHotPath(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := someStructView.Query(
+			sm.Where(Quote("id").GT(Arg(0))),
+		)
+
+		if _, _, err := asCountQuery(q.BaseQuery).Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+
+		derived := q.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dialect/psql/immutable_write.go
+++ b/dialect/psql/immutable_write.go
@@ -1,0 +1,618 @@
+package psql
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"strings"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+	psqldialect "github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/mods"
+	"github.com/stephenafamo/scan"
+)
+
+type derivedUpdateQuery struct {
+	state          immutableUpdateState
+	load           bob.Load
+	hooks          bob.EmbeddedHook
+	contextualMods []bob.ContextualMod[*psqldialect.UpdateQuery]
+}
+
+type immutableUpdateState struct {
+	With      clause.With
+	Only      bool
+	Table     clause.TableRef
+	From      clause.TableRef
+	Set       clause.Set
+	Where     clause.Where
+	Returning clause.Returning
+}
+
+func asImmutableUpdate(q bob.BaseQuery[*psqldialect.UpdateQuery]) derivedUpdateQuery {
+	return derivedUpdateQuery{
+		state: immutableUpdateState{
+			With: clause.With{
+				Recursive: q.Expression.With.Recursive,
+				CTEs:      append([]bob.Expression(nil), q.Expression.With.CTEs...),
+			},
+			Only:  q.Expression.Only,
+			Table: cloneTableRef(q.Expression.Table),
+			From:  cloneTableRef(q.Expression.TableRef),
+			Set: clause.Set{
+				Set: append([]any(nil), q.Expression.Set.Set...),
+			},
+			Where: clause.Where{
+				Conditions: append([]any(nil), q.Expression.Where.Conditions...),
+			},
+			Returning: clause.Returning{
+				Expressions: append([]any(nil), q.Expression.Returning.Expressions...),
+			},
+		},
+		load:           q.Expression.Load,
+		hooks:          q.Expression.EmbeddedHook,
+		contextualMods: append([]bob.ContextualMod[*psqldialect.UpdateQuery](nil), q.Expression.ContextualModdable.Mods...),
+	}
+}
+
+func (q derivedUpdateQuery) Type() bob.QueryType { return bob.QueryTypeUpdate }
+
+func (q derivedUpdateQuery) With(queryMods ...bob.Mod[*psqldialect.UpdateQuery]) derivedUpdateQuery {
+	next, ok := q.state.withMods(queryMods...)
+	if ok {
+		q.state = next
+		return q
+	}
+
+	base := q.mutableBase()
+	mutable := base.Expression
+	for _, mod := range queryMods {
+		mod.Apply(mutable)
+	}
+
+	return asImmutableUpdate(base)
+}
+
+func (q derivedUpdateQuery) Exec(ctx context.Context, exec bob.Executor) (sql.Result, error) {
+	return bob.Exec(ctx, exec, q)
+}
+
+func (q derivedUpdateQuery) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
+	return q.hooks.RunHooks(ctx, exec)
+}
+
+func (q derivedUpdateQuery) GetLoaders() []bob.Loader {
+	return q.load.GetLoaders()
+}
+
+func (q derivedUpdateQuery) GetMapperMods() []scan.MapperMod {
+	return q.load.GetMapperMods()
+}
+
+func (q derivedUpdateQuery) Build(ctx context.Context) (string, []any, error) {
+	return q.BuildN(ctx, 1)
+}
+
+func (q derivedUpdateQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
+	var sb strings.Builder
+	args, err := q.WriteQuery(ctx, &sb, start)
+	if err != nil {
+		return "", nil, err
+	}
+	return sb.String(), args, nil
+}
+
+func (q derivedUpdateQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	if len(q.contextualMods) > 0 {
+		return q.mutableBase().WriteQuery(ctx, w, start)
+	}
+
+	var args []any
+
+	if len(q.state.With.CTEs) > 0 {
+		withArgs, err := q.state.With.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, withArgs...)
+		w.WriteString("\n")
+	}
+
+	w.WriteString("UPDATE ")
+	if q.state.Only {
+		w.WriteString("ONLY ")
+	}
+
+	tableArgs, err := q.state.Table.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, tableArgs...)
+
+	w.WriteString(" SET\n")
+	setArgs, err := q.state.Set.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, setArgs...)
+
+	if q.state.From.Expression != nil {
+		w.WriteString("\nFROM ")
+		fromArgs, err := q.state.From.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, fromArgs...)
+	}
+
+	if len(q.state.Where.Conditions) > 0 {
+		w.WriteString("\n")
+		whereArgs, err := q.state.Where.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, whereArgs...)
+	}
+
+	if len(q.state.Returning.Expressions) > 0 {
+		w.WriteString("\n")
+		retArgs, err := q.state.Returning.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, retArgs...)
+	}
+
+	return args, nil
+}
+
+func (q derivedUpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
+	return q.WriteQuery(ctx, w, start)
+}
+
+func (q derivedUpdateQuery) mutableBase() bob.BaseQuery[*psqldialect.UpdateQuery] {
+	mutable := &psqldialect.UpdateQuery{
+		With:         q.state.With,
+		Only:         q.state.Only,
+		Table:        q.state.Table,
+		Set:          q.state.Set,
+		TableRef:     q.state.From,
+		Where:        q.state.Where,
+		Returning:    q.state.Returning,
+		Load:         q.load,
+		EmbeddedHook: q.hooks,
+		ContextualModdable: bob.ContextualModdable[*psqldialect.UpdateQuery]{
+			Mods: append([]bob.ContextualMod[*psqldialect.UpdateQuery](nil), q.contextualMods...),
+		},
+	}
+
+	return bob.BaseQuery[*psqldialect.UpdateQuery]{
+		Expression: mutable,
+		Dialect:    psqldialect.Dialect,
+		QueryType:  bob.QueryTypeUpdate,
+	}
+}
+
+func (s immutableUpdateState) withMods(queryMods ...bob.Mod[*psqldialect.UpdateQuery]) (immutableUpdateState, bool) {
+	next := s
+	var cloneWhere, cloneReturning bool
+
+	for _, mod := range queryMods {
+		switch m := mod.(type) {
+		case mods.Where[*psqldialect.UpdateQuery]:
+			if !cloneWhere {
+				next.Where.Conditions = append([]any(nil), s.Where.Conditions...)
+				cloneWhere = true
+			}
+			next.Where.Conditions = append(next.Where.Conditions, m.E)
+		case mods.Returning[*psqldialect.UpdateQuery]:
+			if !cloneReturning {
+				next.Returning.Expressions = append([]any(nil), s.Returning.Expressions...)
+				cloneReturning = true
+			}
+			next.Returning.Expressions = append(next.Returning.Expressions, []any(m)...)
+		case psqldialect.FromChain[*psqldialect.UpdateQuery]:
+			next.From = cloneTableRef(m())
+		default:
+			return next, false
+		}
+	}
+
+	return next, true
+}
+
+type derivedDeleteQuery struct {
+	state          immutableDeleteState
+	load           bob.Load
+	hooks          bob.EmbeddedHook
+	contextualMods []bob.ContextualMod[*psqldialect.DeleteQuery]
+}
+
+type immutableDeleteState struct {
+	With      clause.With
+	Only      bool
+	Table     clause.TableRef
+	Using     clause.TableRef
+	Where     clause.Where
+	Returning clause.Returning
+}
+
+func asImmutableDelete(q bob.BaseQuery[*psqldialect.DeleteQuery]) derivedDeleteQuery {
+	return derivedDeleteQuery{
+		state: immutableDeleteState{
+			With: clause.With{
+				Recursive: q.Expression.With.Recursive,
+				CTEs:      append([]bob.Expression(nil), q.Expression.With.CTEs...),
+			},
+			Only:  q.Expression.Only,
+			Table: cloneTableRef(q.Expression.Table),
+			Using: cloneTableRef(q.Expression.TableRef),
+			Where: clause.Where{Conditions: append([]any(nil), q.Expression.Where.Conditions...)},
+			Returning: clause.Returning{
+				Expressions: append([]any(nil), q.Expression.Returning.Expressions...),
+			},
+		},
+		load:           q.Expression.Load,
+		hooks:          q.Expression.EmbeddedHook,
+		contextualMods: append([]bob.ContextualMod[*psqldialect.DeleteQuery](nil), q.Expression.ContextualModdable.Mods...),
+	}
+}
+
+func (q derivedDeleteQuery) Type() bob.QueryType { return bob.QueryTypeDelete }
+
+func (q derivedDeleteQuery) With(queryMods ...bob.Mod[*psqldialect.DeleteQuery]) derivedDeleteQuery {
+	next, ok := q.state.withMods(queryMods...)
+	if ok {
+		q.state = next
+		return q
+	}
+
+	base := q.mutableBase()
+	mutable := base.Expression
+	for _, mod := range queryMods {
+		mod.Apply(mutable)
+	}
+
+	return asImmutableDelete(base)
+}
+
+func (q derivedDeleteQuery) Exec(ctx context.Context, exec bob.Executor) (sql.Result, error) {
+	return bob.Exec(ctx, exec, q)
+}
+
+func (q derivedDeleteQuery) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
+	return q.hooks.RunHooks(ctx, exec)
+}
+
+func (q derivedDeleteQuery) GetLoaders() []bob.Loader { return q.load.GetLoaders() }
+
+func (q derivedDeleteQuery) GetMapperMods() []scan.MapperMod { return q.load.GetMapperMods() }
+
+func (q derivedDeleteQuery) Build(ctx context.Context) (string, []any, error) {
+	return q.BuildN(ctx, 1)
+}
+
+func (q derivedDeleteQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
+	var sb strings.Builder
+	args, err := q.WriteQuery(ctx, &sb, start)
+	if err != nil {
+		return "", nil, err
+	}
+	return sb.String(), args, nil
+}
+
+func (q derivedDeleteQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	if len(q.contextualMods) > 0 {
+		return q.mutableBase().WriteQuery(ctx, w, start)
+	}
+
+	var args []any
+	if len(q.state.With.CTEs) > 0 {
+		withArgs, err := q.state.With.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, withArgs...)
+		w.WriteString("\n")
+	}
+
+	w.WriteString("DELETE FROM ")
+	if q.state.Only {
+		w.WriteString("ONLY ")
+	}
+
+	tableArgs, err := q.state.Table.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, tableArgs...)
+
+	if q.state.Using.Expression != nil {
+		w.WriteString("\nUSING ")
+		usingArgs, err := q.state.Using.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, usingArgs...)
+	}
+
+	if len(q.state.Where.Conditions) > 0 {
+		w.WriteString("\n")
+		whereArgs, err := q.state.Where.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, whereArgs...)
+	}
+
+	if len(q.state.Returning.Expressions) > 0 {
+		w.WriteString("\n")
+		retArgs, err := q.state.Returning.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, retArgs...)
+	}
+
+	return args, nil
+}
+
+func (q derivedDeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
+	return q.WriteQuery(ctx, w, start)
+}
+
+func (q derivedDeleteQuery) mutableBase() bob.BaseQuery[*psqldialect.DeleteQuery] {
+	mutable := &psqldialect.DeleteQuery{
+		With:         q.state.With,
+		Only:         q.state.Only,
+		Table:        q.state.Table,
+		TableRef:     q.state.Using,
+		Where:        q.state.Where,
+		Returning:    q.state.Returning,
+		Load:         q.load,
+		EmbeddedHook: q.hooks,
+		ContextualModdable: bob.ContextualModdable[*psqldialect.DeleteQuery]{
+			Mods: append([]bob.ContextualMod[*psqldialect.DeleteQuery](nil), q.contextualMods...),
+		},
+	}
+
+	return bob.BaseQuery[*psqldialect.DeleteQuery]{
+		Expression: mutable,
+		Dialect:    psqldialect.Dialect,
+		QueryType:  bob.QueryTypeDelete,
+	}
+}
+
+func (s immutableDeleteState) withMods(queryMods ...bob.Mod[*psqldialect.DeleteQuery]) (immutableDeleteState, bool) {
+	next := s
+	var cloneWhere, cloneReturning bool
+
+	for _, mod := range queryMods {
+		switch m := mod.(type) {
+		case mods.Where[*psqldialect.DeleteQuery]:
+			if !cloneWhere {
+				next.Where.Conditions = append([]any(nil), s.Where.Conditions...)
+				cloneWhere = true
+			}
+			next.Where.Conditions = append(next.Where.Conditions, m.E)
+		case mods.Returning[*psqldialect.DeleteQuery]:
+			if !cloneReturning {
+				next.Returning.Expressions = append([]any(nil), s.Returning.Expressions...)
+				cloneReturning = true
+			}
+			next.Returning.Expressions = append(next.Returning.Expressions, []any(m)...)
+		case psqldialect.FromChain[*psqldialect.DeleteQuery]:
+			next.Using = cloneTableRef(m())
+		default:
+			return next, false
+		}
+	}
+
+	return next, true
+}
+
+type derivedInsertQuery struct {
+	state          immutableInsertState
+	load           bob.Load
+	hooks          bob.EmbeddedHook
+	contextualMods []bob.ContextualMod[*psqldialect.InsertQuery]
+}
+
+type immutableInsertState struct {
+	With       clause.With
+	Overriding string
+	Table      clause.TableRef
+	Values     clause.Values
+	Conflict   clause.Conflict
+	Returning  clause.Returning
+}
+
+func asImmutableInsert(q bob.BaseQuery[*psqldialect.InsertQuery]) derivedInsertQuery {
+	return derivedInsertQuery{
+		state: immutableInsertState{
+			With: clause.With{
+				Recursive: q.Expression.With.Recursive,
+				CTEs:      append([]bob.Expression(nil), q.Expression.With.CTEs...),
+			},
+			Overriding: q.Expression.Overriding,
+			Table:      cloneTableRef(q.Expression.TableRef),
+			Values: clause.Values{
+				Query: q.Expression.Values.Query,
+				Vals:  append([]clause.Value(nil), q.Expression.Values.Vals...),
+			},
+			Conflict: clause.Conflict{Expression: q.Expression.Conflict.Expression},
+			Returning: clause.Returning{
+				Expressions: append([]any(nil), q.Expression.Returning.Expressions...),
+			},
+		},
+		load:           q.Expression.Load,
+		hooks:          q.Expression.EmbeddedHook,
+		contextualMods: append([]bob.ContextualMod[*psqldialect.InsertQuery](nil), q.Expression.ContextualModdable.Mods...),
+	}
+}
+
+func (q derivedInsertQuery) Type() bob.QueryType { return bob.QueryTypeInsert }
+
+func (q derivedInsertQuery) With(queryMods ...bob.Mod[*psqldialect.InsertQuery]) derivedInsertQuery {
+	next, ok := q.state.withMods(queryMods...)
+	if ok {
+		q.state = next
+		return q
+	}
+
+	base := q.mutableBase()
+	mutable := base.Expression
+	for _, mod := range queryMods {
+		mod.Apply(mutable)
+	}
+
+	return asImmutableInsert(base)
+}
+
+func (q derivedInsertQuery) Exec(ctx context.Context, exec bob.Executor) (sql.Result, error) {
+	return bob.Exec(ctx, exec, q)
+}
+
+func (q derivedInsertQuery) RunHooks(ctx context.Context, exec bob.Executor) (context.Context, error) {
+	return q.hooks.RunHooks(ctx, exec)
+}
+
+func (q derivedInsertQuery) GetLoaders() []bob.Loader { return q.load.GetLoaders() }
+
+func (q derivedInsertQuery) GetMapperMods() []scan.MapperMod { return q.load.GetMapperMods() }
+
+func (q derivedInsertQuery) Build(ctx context.Context) (string, []any, error) {
+	return q.BuildN(ctx, 1)
+}
+
+func (q derivedInsertQuery) BuildN(ctx context.Context, start int) (string, []any, error) {
+	var sb strings.Builder
+	args, err := q.WriteQuery(ctx, &sb, start)
+	if err != nil {
+		return "", nil, err
+	}
+	return sb.String(), args, nil
+}
+
+func (q derivedInsertQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	if len(q.contextualMods) > 0 {
+		return q.mutableBase().WriteQuery(ctx, w, start)
+	}
+
+	var args []any
+	if len(q.state.With.CTEs) > 0 {
+		withArgs, err := q.state.With.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, withArgs...)
+		w.WriteString("\n")
+	}
+
+	w.WriteString("INSERT INTO ")
+	tableArgs, err := q.state.Table.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, tableArgs...)
+
+	if q.state.Overriding != "" {
+		w.WriteString("\nOVERRIDING ")
+		w.WriteString(q.state.Overriding)
+		w.WriteString(" VALUE")
+	}
+
+	w.WriteString("\n")
+	valArgs, err := q.state.Values.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, valArgs...)
+
+	if q.state.Conflict.Expression != nil {
+		w.WriteString("\n")
+		conflictArgs, err := q.state.Conflict.Expression.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, conflictArgs...)
+	}
+
+	if len(q.state.Returning.Expressions) > 0 {
+		w.WriteString("\n")
+		retArgs, err := q.state.Returning.WriteSQL(ctx, w, psqldialect.Dialect, start+len(args))
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, retArgs...)
+	}
+
+	w.WriteString("\n")
+	return args, nil
+}
+
+func (q derivedInsertQuery) WriteSQL(ctx context.Context, w io.StringWriter, _ bob.Dialect, start int) ([]any, error) {
+	return q.WriteQuery(ctx, w, start)
+}
+
+func (q derivedInsertQuery) mutableBase() bob.BaseQuery[*psqldialect.InsertQuery] {
+	values := clause.Values{
+		Query: q.state.Values.Query,
+		Vals:  append([]clause.Value(nil), q.state.Values.Vals...),
+	}
+
+	mutable := &psqldialect.InsertQuery{
+		With:         q.state.With,
+		Overriding:   q.state.Overriding,
+		TableRef:     q.state.Table,
+		Values:       values,
+		Conflict:     q.state.Conflict,
+		Returning:    q.state.Returning,
+		Load:         q.load,
+		EmbeddedHook: q.hooks,
+		ContextualModdable: bob.ContextualModdable[*psqldialect.InsertQuery]{
+			Mods: append([]bob.ContextualMod[*psqldialect.InsertQuery](nil), q.contextualMods...),
+		},
+	}
+
+	return bob.BaseQuery[*psqldialect.InsertQuery]{
+		Expression: mutable,
+		Dialect:    psqldialect.Dialect,
+		QueryType:  bob.QueryTypeInsert,
+	}
+}
+
+func (s immutableInsertState) withMods(queryMods ...bob.Mod[*psqldialect.InsertQuery]) (immutableInsertState, bool) {
+	next := s
+	var cloneReturning, cloneVals bool
+
+	for _, mod := range queryMods {
+		switch m := mod.(type) {
+		case mods.Returning[*psqldialect.InsertQuery]:
+			if !cloneReturning {
+				next.Returning.Expressions = append([]any(nil), s.Returning.Expressions...)
+				cloneReturning = true
+			}
+			next.Returning.Expressions = append(next.Returning.Expressions, []any(m)...)
+		case mods.Values[*psqldialect.InsertQuery]:
+			if !cloneVals {
+				next.Values.Vals = append([]clause.Value(nil), s.Values.Vals...)
+				cloneVals = true
+			}
+			next.Values.Vals = append(next.Values.Vals, clause.Value(m))
+		case mods.Rows[*psqldialect.InsertQuery]:
+			if !cloneVals {
+				next.Values.Vals = append([]clause.Value(nil), s.Values.Vals...)
+				cloneVals = true
+			}
+			for _, row := range m {
+				next.Values.Vals = append(next.Values.Vals, clause.Value(row))
+			}
+		default:
+			return next, false
+		}
+	}
+
+	return next, true
+}

--- a/dialect/psql/immutable_write_test.go
+++ b/dialect/psql/immutable_write_test.go
@@ -1,7 +1,6 @@
 package psql
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stephenafamo/bob/dialect/psql/dm"
@@ -20,7 +19,7 @@ func TestUpdateWithDoesNotMutateOriginal(t *testing.T) {
 		um.Returning("id"),
 	)
 
-	baseSQL, _, err := base.Build(context.Background())
+	baseSQL, _, err := base.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +27,7 @@ func TestUpdateWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("base update changed unexpectedly: %#v", baseSQL)
 	}
 
-	derivedSQL, _, err := derived.Build(context.Background())
+	derivedSQL, _, err := derived.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +46,7 @@ func TestDeleteWithDoesNotMutateOriginal(t *testing.T) {
 		dm.Returning("id"),
 	)
 
-	baseSQL, _, err := base.Build(context.Background())
+	baseSQL, _, err := base.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +54,7 @@ func TestDeleteWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("base delete changed unexpectedly: %#v", baseSQL)
 	}
 
-	derivedSQL, _, err := derived.Build(context.Background())
+	derivedSQL, _, err := derived.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestInsertWithDoesNotMutateOriginal(t *testing.T) {
 		im.Returning("id"),
 	)
 
-	baseSQL, _, err := base.Build(context.Background())
+	baseSQL, _, err := base.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func TestInsertWithDoesNotMutateOriginal(t *testing.T) {
 		t.Fatalf("base insert changed unexpectedly: %#v", baseSQL)
 	}
 
-	derivedSQL, _, err := derived.Build(context.Background())
+	derivedSQL, _, err := derived.Build(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +91,7 @@ func TestInsertWithDoesNotMutateOriginal(t *testing.T) {
 }
 
 func BenchmarkUpdateQueryApplyMain(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -112,7 +111,7 @@ func BenchmarkUpdateQueryApplyMain(b *testing.B) {
 }
 
 func BenchmarkUpdateQueryImmutableNativeHotPath(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -132,7 +131,7 @@ func BenchmarkUpdateQueryImmutableNativeHotPath(b *testing.B) {
 }
 
 func BenchmarkDeleteQueryApplyMain(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -151,7 +150,7 @@ func BenchmarkDeleteQueryApplyMain(b *testing.B) {
 }
 
 func BenchmarkDeleteQueryImmutableNativeHotPath(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -170,7 +169,7 @@ func BenchmarkDeleteQueryImmutableNativeHotPath(b *testing.B) {
 }
 
 func BenchmarkInsertQueryApplyMain(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -189,7 +188,7 @@ func BenchmarkInsertQueryApplyMain(b *testing.B) {
 }
 
 func BenchmarkInsertQueryImmutableNativeHotPath(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/dialect/psql/immutable_write_test.go
+++ b/dialect/psql/immutable_write_test.go
@@ -1,0 +1,208 @@
+package psql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/im"
+	"github.com/stephenafamo/bob/dialect/psql/um"
+)
+
+func TestUpdateWithDoesNotMutateOriginal(t *testing.T) {
+	base := Update(
+		um.Table("films"),
+		um.SetCol("kind").ToArg("Dramatic"),
+	)
+
+	derived := base.With(
+		um.Where(Quote("kind").EQ(Arg("Drama"))),
+		um.Returning("id"),
+	)
+
+	baseSQL, _, err := base.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseSQL != "UPDATE films SET\n\"kind\" = $1" {
+		t.Fatalf("base update changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL, _, err := derived.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivedSQL != "UPDATE films SET\n\"kind\" = $1\nWHERE (\"kind\" = $2)\nRETURNING id" {
+		t.Fatalf("derived update mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestDeleteWithDoesNotMutateOriginal(t *testing.T) {
+	base := Delete(
+		dm.From("films"),
+	)
+
+	derived := base.With(
+		dm.Where(Quote("kind").EQ(Arg("Drama"))),
+		dm.Returning("id"),
+	)
+
+	baseSQL, _, err := base.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseSQL != "DELETE FROM films" {
+		t.Fatalf("base delete changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL, _, err := derived.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivedSQL != "DELETE FROM films\nWHERE (\"kind\" = $1)\nRETURNING id" {
+		t.Fatalf("derived delete mismatch: %#v", derivedSQL)
+	}
+}
+
+func TestInsertWithDoesNotMutateOriginal(t *testing.T) {
+	base := Insert(
+		im.Into("films"),
+		im.Values(Arg("UA502", "Bananas")),
+	)
+
+	derived := base.With(
+		im.Returning("id"),
+	)
+
+	baseSQL, _, err := base.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseSQL != "INSERT INTO films\nVALUES ($1, $2)\n" {
+		t.Fatalf("base insert changed unexpectedly: %#v", baseSQL)
+	}
+
+	derivedSQL, _, err := derived.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivedSQL != "INSERT INTO films\nVALUES ($1, $2)\nRETURNING id\n" {
+		t.Fatalf("derived insert mismatch: %#v", derivedSQL)
+	}
+}
+
+func BenchmarkUpdateQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Update(
+			um.Table("films"),
+			um.SetCol("kind").ToArg("Dramatic"),
+		)
+		q.Apply(
+			um.Where(Quote("kind").EQ(Arg("Drama"))),
+			um.Returning("id"),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUpdateQueryImmutableNativeHotPath(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Update(
+			um.Table("films"),
+			um.SetCol("kind").ToArg("Dramatic"),
+		)
+		derived := q.With(
+			um.Where(Quote("kind").EQ(Arg("Drama"))),
+			um.Returning("id"),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDeleteQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Delete(
+			dm.From("films"),
+		)
+		q.Apply(
+			dm.Where(Quote("kind").EQ(Arg("Drama"))),
+			dm.Returning("id"),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDeleteQueryImmutableNativeHotPath(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Delete(
+			dm.From("films"),
+		)
+		derived := q.With(
+			dm.Where(Quote("kind").EQ(Arg("Drama"))),
+			dm.Returning("id"),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkInsertQueryApplyMain(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Insert(
+			im.Into("films"),
+			im.Values(Arg("UA502", "Bananas")),
+		)
+		q.Apply(
+			im.Returning("id"),
+		)
+
+		if _, _, err := q.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkInsertQueryImmutableNativeHotPath(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		q := Insert(
+			im.Into("films"),
+			im.Values(Arg("UA502", "Bananas")),
+		)
+		derived := q.With(
+			im.Returning("id"),
+		)
+
+		if _, _, err := derived.Build(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/dialect/psql/insert.go
+++ b/dialect/psql/insert.go
@@ -5,15 +5,25 @@ import (
 	"github.com/stephenafamo/bob/dialect/psql/dialect"
 )
 
-func Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) bob.BaseQuery[*dialect.InsertQuery] {
+type InsertQuery struct {
+	bob.BaseQuery[*dialect.InsertQuery]
+}
+
+func (q InsertQuery) With(queryMods ...bob.Mod[*dialect.InsertQuery]) derivedInsertQuery {
+	return asImmutableInsert(q.BaseQuery).With(queryMods...)
+}
+
+func Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) InsertQuery {
 	q := &dialect.InsertQuery{}
 	for _, mod := range queryMods {
 		mod.Apply(q)
 	}
 
-	return bob.BaseQuery[*dialect.InsertQuery]{
-		Expression: q,
-		Dialect:    dialect.Dialect,
-		QueryType:  bob.QueryTypeInsert,
+	return InsertQuery{
+		BaseQuery: bob.BaseQuery[*dialect.InsertQuery]{
+			Expression: q,
+			Dialect:    dialect.Dialect,
+			QueryType:  bob.QueryTypeInsert,
+		},
 	}
 }

--- a/dialect/psql/select.go
+++ b/dialect/psql/select.go
@@ -5,15 +5,25 @@ import (
 	"github.com/stephenafamo/bob/dialect/psql/dialect"
 )
 
-func Select(queryMods ...bob.Mod[*dialect.SelectQuery]) bob.BaseQuery[*dialect.SelectQuery] {
+type SelectQuery struct {
+	bob.BaseQuery[*dialect.SelectQuery]
+}
+
+func (q SelectQuery) With(queryMods ...bob.Mod[*dialect.SelectQuery]) ImmutableSelectQuery {
+	return asImmutable(q.BaseQuery).With(queryMods...)
+}
+
+func Select(queryMods ...bob.Mod[*dialect.SelectQuery]) SelectQuery {
 	q := &dialect.SelectQuery{}
 	for _, mod := range queryMods {
 		mod.Apply(q)
 	}
 
-	return bob.BaseQuery[*dialect.SelectQuery]{
-		Expression: q,
-		Dialect:    dialect.Dialect,
-		QueryType:  bob.QueryTypeSelect,
+	return SelectQuery{
+		BaseQuery: bob.BaseQuery[*dialect.SelectQuery]{
+			Expression: q,
+			Dialect:    dialect.Dialect,
+			QueryType:  bob.QueryTypeSelect,
+		},
 	}
 }

--- a/dialect/psql/select.go
+++ b/dialect/psql/select.go
@@ -9,7 +9,7 @@ type SelectQuery struct {
 	bob.BaseQuery[*dialect.SelectQuery]
 }
 
-func (q SelectQuery) With(queryMods ...bob.Mod[*dialect.SelectQuery]) ImmutableSelectQuery {
+func (q SelectQuery) With(queryMods ...bob.Mod[*dialect.SelectQuery]) derivedSelectQuery {
 	return asImmutable(q.BaseQuery).With(queryMods...)
 }
 

--- a/dialect/psql/table.go
+++ b/dialect/psql/table.go
@@ -70,7 +70,7 @@ func (t *Table[T, Tslice, Tset, C]) PrimaryKey() expr.ColumnsExpr {
 func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) *ormInsertQuery[T, Tslice] {
 	q := &ormInsertQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.InsertQuery]{
-			BaseQuery: Insert(im.Into(t.NameAs(), t.nonGeneratedCols...)),
+			BaseQuery: Insert(im.Into(t.NameAs(), t.nonGeneratedCols...)).BaseQuery,
 			Hooks:     &t.InsertQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -94,7 +94,7 @@ func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQ
 func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) *ormUpdateQuery[T, Tslice] {
 	q := &ormUpdateQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.UpdateQuery]{
-			BaseQuery: Update(um.Table(t.NameAs())),
+			BaseQuery: Update(um.Table(t.NameAs())).BaseQuery,
 			Hooks:     &t.UpdateQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -118,7 +118,7 @@ func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQ
 func (t *Table[T, Tslice, Tset, C]) Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) *ormDeleteQuery[T, Tslice] {
 	q := &ormDeleteQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.DeleteQuery]{
-			BaseQuery: Delete(dm.From(t.NameAs())),
+			BaseQuery: Delete(dm.From(t.NameAs())).BaseQuery,
 			Hooks:     &t.DeleteQueryHooks,
 		},
 		Scanner: t.scanner,

--- a/dialect/psql/update.go
+++ b/dialect/psql/update.go
@@ -5,15 +5,25 @@ import (
 	"github.com/stephenafamo/bob/dialect/psql/dialect"
 )
 
-func Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) bob.BaseQuery[*dialect.UpdateQuery] {
+type UpdateQuery struct {
+	bob.BaseQuery[*dialect.UpdateQuery]
+}
+
+func (q UpdateQuery) With(queryMods ...bob.Mod[*dialect.UpdateQuery]) derivedUpdateQuery {
+	return asImmutableUpdate(q.BaseQuery).With(queryMods...)
+}
+
+func Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) UpdateQuery {
 	q := &dialect.UpdateQuery{}
 	for _, mod := range queryMods {
 		mod.Apply(q)
 	}
 
-	return bob.BaseQuery[*dialect.UpdateQuery]{
-		Expression: q,
-		Dialect:    dialect.Dialect,
-		QueryType:  bob.QueryTypeUpdate,
+	return UpdateQuery{
+		BaseQuery: bob.BaseQuery[*dialect.UpdateQuery]{
+			Expression: q,
+			Dialect:    dialect.Dialect,
+			QueryType:  bob.QueryTypeUpdate,
+		},
 	}
 }

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -82,7 +82,7 @@ func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *
 	q := &ViewQuery[T, Tslice]{
 		Query: orm.Query[*dialect.SelectQuery, T, Tslice, bob.SliceTransformer[T, Tslice]]{
 			ExecQuery: orm.ExecQuery[*dialect.SelectQuery]{
-				BaseQuery: Select(sm.From(v.NameAs())),
+				BaseQuery: Select(sm.From(v.NameAs())).BaseQuery,
 				Hooks:     &v.SelectQueryHooks,
 			},
 			Scanner: v.scanner,

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -87,6 +87,7 @@ func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *
 			},
 			Scanner: v.scanner,
 		},
+		defaultSelect: v.Columns,
 	}
 
 	q.Expression.AppendContextualModFunc(
@@ -105,6 +106,7 @@ func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *
 
 type ViewQuery[T any, Ts ~[]T] struct {
 	orm.Query[*dialect.SelectQuery, T, Ts, bob.SliceTransformer[T, Ts]]
+	defaultSelect bob.Expression
 }
 
 // Count the number of matching rows

--- a/dialect/psql/view_test.go
+++ b/dialect/psql/view_test.go
@@ -2,7 +2,6 @@ package psql
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -57,7 +56,7 @@ func TestSomeViewQuery(t *testing.T) {
 
 func selectToString(t *testing.T, query bob.Query, argsLen int) string {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	buf := new(bytes.Buffer)
 	args, err := query.WriteQuery(ctx, buf, 0)
 	if err != nil {

--- a/dialect/psql/view_test.go
+++ b/dialect/psql/view_test.go
@@ -7,7 +7,6 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
 	"github.com/stephenafamo/bob/dialect/psql/sm"
 	"github.com/stephenafamo/bob/expr"
 )
@@ -56,7 +55,7 @@ func TestSomeViewQuery(t *testing.T) {
 	}
 }
 
-func selectToString(t *testing.T, query bob.BaseQuery[*dialect.SelectQuery], argsLen int) string {
+func selectToString(t *testing.T, query bob.Query, argsLen int) string {
 	t.Helper()
 	ctx := context.Background()
 	buf := new(bytes.Buffer)

--- a/dialect/psql/with_regression_test.go
+++ b/dialect/psql/with_regression_test.go
@@ -1,7 +1,6 @@
 package psql_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stephenafamo/bob"
@@ -203,12 +202,12 @@ func TestInsertWithRegression(t *testing.T) {
 func assertQueriesEqual(t *testing.T, got bob.Query, want bob.Query) {
 	t.Helper()
 
-	gotSQL, gotArgs, err := bob.Build(context.Background(), got)
+	gotSQL, gotArgs, err := bob.Build(t.Context(), got)
 	if err != nil {
 		t.Fatalf("build got: %v", err)
 	}
 
-	wantSQL, wantArgs, err := bob.Build(context.Background(), want)
+	wantSQL, wantArgs, err := bob.Build(t.Context(), want)
 	if err != nil {
 		t.Fatalf("build want: %v", err)
 	}

--- a/dialect/psql/with_regression_test.go
+++ b/dialect/psql/with_regression_test.go
@@ -1,0 +1,227 @@
+package psql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/im"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+	"github.com/stephenafamo/bob/dialect/psql/um"
+	"github.com/stephenafamo/bob/expr"
+	testutils "github.com/stephenafamo/bob/test/utils"
+)
+
+type withTestStruct struct {
+	ID    int64  `db:"id,pk"`
+	Name  string `db:"name"`
+	Email string `db:"email"`
+}
+
+var withTestStructView = psql.NewView[*withTestStruct, bob.Expression](
+	"public",
+	"with_test_struct",
+	expr.ColsForStruct[withTestStruct]("with_test_struct"),
+)
+
+func TestSelectWithRegression(t *testing.T) {
+	t.Run("native path matches direct construction", func(t *testing.T) {
+		base := psql.Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(psql.Quote("tenant_id").EQ(psql.Arg(42))),
+		)
+
+		derived := base.With(
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		)
+
+		assertQueriesEqual(t, base, psql.Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(psql.Quote("tenant_id").EQ(psql.Arg(42))),
+		))
+		assertQueriesEqual(t, derived, psql.Select(
+			sm.Columns("id", "name"),
+			sm.From("users"),
+			sm.Where(psql.Quote("tenant_id").EQ(psql.Arg(42))),
+			sm.OrderBy("id").Desc(),
+			sm.Limit(10),
+			sm.Offset(20),
+		))
+	})
+
+	t.Run("fallback path matches direct construction", func(t *testing.T) {
+		base := psql.Select(
+			sm.Columns("users.id", "users.name"),
+			sm.From("users"),
+		)
+
+		derived := base.With(
+			sm.LeftJoin("teams").Using("id"),
+			sm.ForUpdate("users").SkipLocked(),
+		)
+
+		assertQueriesEqual(t, base, psql.Select(
+			sm.Columns("users.id", "users.name"),
+			sm.From("users"),
+		))
+		assertQueriesEqual(t, derived, psql.Select(
+			sm.Columns("users.id", "users.name"),
+			sm.From("users"),
+			sm.LeftJoin("teams").Using("id"),
+			sm.ForUpdate("users").SkipLocked(),
+		))
+	})
+}
+
+func TestViewQueryWithRegression(t *testing.T) {
+	base := withTestStructView.Query(
+		sm.Where(psql.Quote("id").GT(psql.Arg(0))),
+	)
+
+	derived := base.With(
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	)
+
+	assertQueriesEqual(t, base, withTestStructView.Query(
+		sm.Where(psql.Quote("id").GT(psql.Arg(0))),
+	))
+	assertQueriesEqual(t, derived.Query, withTestStructView.Query(
+		sm.Where(psql.Quote("id").GT(psql.Arg(0))),
+		sm.OrderBy("id").Desc(),
+		sm.Limit(10),
+		sm.Offset(20),
+	))
+}
+
+func TestUpdateWithRegression(t *testing.T) {
+	base := psql.Update(
+		um.Table("films"),
+		um.SetCol("kind").ToArg("Dramatic"),
+	)
+
+	derived := base.With(
+		um.SetCol("updated_at").To("NOW()"),
+		um.Where(psql.Quote("kind").EQ(psql.Arg("Drama"))),
+		um.Returning("id"),
+	)
+
+	assertQueriesEqual(t, base, psql.Update(
+		um.Table("films"),
+		um.SetCol("kind").ToArg("Dramatic"),
+	))
+	assertQueriesEqual(t, derived, psql.Update(
+		um.Table("films"),
+		um.SetCol("kind").ToArg("Dramatic"),
+		um.SetCol("updated_at").To("NOW()"),
+		um.Where(psql.Quote("kind").EQ(psql.Arg("Drama"))),
+		um.Returning("id"),
+	))
+}
+
+func TestDeleteWithRegression(t *testing.T) {
+	base := psql.Delete(
+		dm.From("employees"),
+	)
+
+	derived := base.With(
+		dm.Using("accounts"),
+		dm.Where(psql.Quote("accounts", "name").EQ(psql.Arg("Acme Corporation"))),
+		dm.Where(psql.Quote("employees", "id").EQ(psql.Quote("accounts", "sales_person"))),
+		dm.Returning("id"),
+	)
+
+	assertQueriesEqual(t, base, psql.Delete(
+		dm.From("employees"),
+	))
+	assertQueriesEqual(t, derived, psql.Delete(
+		dm.From("employees"),
+		dm.Using("accounts"),
+		dm.Where(psql.Quote("accounts", "name").EQ(psql.Arg("Acme Corporation"))),
+		dm.Where(psql.Quote("employees", "id").EQ(psql.Quote("accounts", "sales_person"))),
+		dm.Returning("id"),
+	))
+}
+
+func TestInsertWithRegression(t *testing.T) {
+	t.Run("native path matches direct construction", func(t *testing.T) {
+		base := psql.Insert(
+			im.Into("films"),
+			im.Values(psql.Arg("UA502", "Bananas")),
+		)
+
+		derived := base.With(
+			im.Returning("id"),
+		)
+
+		assertQueriesEqual(t, base, psql.Insert(
+			im.Into("films"),
+			im.Values(psql.Arg("UA502", "Bananas")),
+		))
+		assertQueriesEqual(t, derived, psql.Insert(
+			im.Into("films"),
+			im.Values(psql.Arg("UA502", "Bananas")),
+			im.Returning("id"),
+		))
+	})
+
+	t.Run("fallback path matches direct construction", func(t *testing.T) {
+		base := psql.Insert(
+			im.IntoAs("distributors", "d", "did", "dname"),
+			im.Values(psql.Arg(8, "Anvil Distribution")),
+		)
+
+		derived := base.With(
+			im.OnConflict("did").DoUpdate(
+				im.SetExcluded("dname"),
+				im.Where(psql.Quote("d", "zipcode").NE(psql.S("21201"))),
+			),
+		)
+
+		assertQueriesEqual(t, base, psql.Insert(
+			im.IntoAs("distributors", "d", "did", "dname"),
+			im.Values(psql.Arg(8, "Anvil Distribution")),
+		))
+		assertQueriesEqual(t, derived, psql.Insert(
+			im.IntoAs("distributors", "d", "did", "dname"),
+			im.Values(psql.Arg(8, "Anvil Distribution")),
+			im.OnConflict("did").DoUpdate(
+				im.SetExcluded("dname"),
+				im.Where(psql.Quote("d", "zipcode").NE(psql.S("21201"))),
+			),
+		))
+	})
+}
+
+func assertQueriesEqual(t *testing.T, got bob.Query, want bob.Query) {
+	t.Helper()
+
+	gotSQL, gotArgs, err := bob.Build(context.Background(), got)
+	if err != nil {
+		t.Fatalf("build got: %v", err)
+	}
+
+	wantSQL, wantArgs, err := bob.Build(context.Background(), want)
+	if err != nil {
+		t.Fatalf("build want: %v", err)
+	}
+
+	diff, err := testutils.QueryDiff(wantSQL, gotSQL, formatter)
+	if err != nil {
+		t.Fatalf("query diff error: %v", err)
+	}
+	if diff != "" {
+		t.Fatalf("sql diff: %s", diff)
+	}
+
+	if diff := testutils.ArgsDiff(wantArgs, gotArgs); diff != "" {
+		t.Fatalf("args diff: %s", diff)
+	}
+}


### PR DESCRIPTION
Adds native immutable `With(...)` paths for PostgreSQL `Select`, `ViewQuery`, `Update`, `Delete`, and `Insert` derivations while keeping existing mutable `Apply(...)` behavior unchanged.

The user-facing constructors stay the same:
- `psql.Select(...)`
- `view.Query(...)`
- `psql.Update(...)`
- `psql.Delete(...)`
- `psql.Insert(...)`

The behavior change is opt-in at the call site: callers only see the new immutable behavior and perf gains when they use `With(...)` and keep the returned query.

What changed:
- `Select(...).With(...)` and `ViewQuery.With(...)` now use a native immutable path instead of clone-plus-mutate.
- `Update(...).With(...)`, `Delete(...).With(...)`, and `Insert(...).With(...)` now follow the same pattern.
- common derivation cases use specialized immutable state updates
- unsupported/fallback cases still work by materializing the mutable query internally
- added regression coverage to verify `With(...)` does not mutate the base query and matches direct construction for native and fallback cases

Benchmarks:
```text
BenchmarkBaseQueryApplyMain                               2990 ns/op   2865 B/op    48 allocs/op
BenchmarkBaseQueryImmutableNativeHotPath                  2143 ns/op   1705 B/op    36 allocs/op
BenchmarkViewQueryCountThenPaginateApplyMain            10084 ns/op   7440 B/op   130 allocs/op
BenchmarkViewQueryCountThenPaginateImmutableNativeHotPath 9153 ns/op   6115 B/op   117 allocs/op
BenchmarkUpdateQueryApplyMain                             2433 ns/op   2319 B/op    47 allocs/op
BenchmarkUpdateQueryImmutableNativeHotPath                1966 ns/op   1360 B/op    41 allocs/op
BenchmarkDeleteQueryApplyMain                             1879 ns/op   1956 B/op    33 allocs/op
BenchmarkDeleteQueryImmutableNativeHotPath                1383 ns/op   1027 B/op    26 allocs/op
BenchmarkInsertQueryApplyMain                             1543 ns/op   1576 B/op    24 allocs/op
BenchmarkInsertQueryImmutableNativeHotPath                1157 ns/op    920 B/op    20 allocs/op
```

Verification:
- `go test ./dialect/psql`
- `go test ./dialect/psql ./orm ./mods ./clause`
- `go test ./dialect/psql -run '^$' -bench 'Benchmark(BaseQuery|ViewQueryCountThenPaginate|UpdateQuery|DeleteQuery|InsertQuery)' -benchmem`

Regression coverage added:
- `Select` native path
- `Select` fallback path
- `View.Query(...).With(...)`
- `Update`
- `Delete`
- `Insert` native path
- `Insert` fallback path
