### PR TITLE
refactor(psql/mm): replace WHEN clause mods with fluent chain API

### DIFF
--- a/dialect/psql/merge_test.go
+++ b/dialect/psql/merge_test.go
@@ -17,18 +17,14 @@ func TestMerge(t *testing.T) {
 				mm.Using("recent_transactions").As("t").On(
 					psql.Quote("t", "customer_id").EQ(psql.Quote("customer_account", "customer_id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("balance").ToExpr(
-							psql.Raw("balance + ?", psql.Quote("t", "transaction_value")),
-						),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("balance").ToExpr(
+						psql.Raw("balance + ?", psql.Quote("t", "transaction_value")),
 					),
 				),
-				mm.WhenNotMatched(
-					mm.ThenInsert(
-						mm.Columns("customer_id", "balance"),
-						mm.Values(psql.Quote("t", "customer_id"), psql.Quote("t", "transaction_value")),
-					),
+				mm.WhenNotMatched().ThenInsert(
+					mm.Columns("customer_id", "balance"),
+					mm.Values(psql.Quote("t", "customer_id"), psql.Quote("t", "transaction_value")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO customer_account
@@ -42,21 +38,13 @@ func TestMerge(t *testing.T) {
 				mm.Using("wine_stock_changes").As("s").On(
 					psql.Quote("s", "winename").EQ(psql.Quote("wines", "winename")),
 				),
-				mm.WhenNotMatched(
-					mm.And(psql.Quote("s", "stock_delta").GT(psql.Arg(0))),
-					mm.ThenInsert(
-						mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock_delta")),
-					),
+				mm.WhenNotMatched().And(psql.Quote("s", "stock_delta").GT(psql.Arg(0))).ThenInsert(
+					mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock_delta")),
 				),
-				mm.WhenMatched(
-					mm.And(psql.Raw("w.stock + s.stock_delta > 0")),
-					mm.ThenUpdate(
-						mm.SetCol("stock").ToExpr(psql.Raw("w.stock + s.stock_delta")),
-					),
+				mm.WhenMatched().And(psql.Raw("w.stock + s.stock_delta > 0")).ThenUpdate(
+					mm.SetCol("stock").ToExpr(psql.Raw("w.stock + s.stock_delta")),
 				),
-				mm.WhenMatched(
-					mm.ThenDelete(),
-				),
+				mm.WhenMatched().ThenDelete(),
 			),
 			ExpectedSQL: `MERGE INTO wines
 				USING wine_stock_changes AS "s" ON "s"."winename" = "wines"."winename"
@@ -71,12 +59,8 @@ func TestMerge(t *testing.T) {
 				mm.Using("source").As("s").On(
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenDoNothing(),
-				),
-				mm.WhenNotMatched(
-					mm.ThenDoNothing(),
-				),
+				mm.WhenMatched().ThenDoNothing(),
+				mm.WhenNotMatched().ThenDoNothing(),
 			),
 			ExpectedSQL: `MERGE INTO target
 				USING source AS "s" ON "s"."id" = "target"."id"
@@ -89,20 +73,13 @@ func TestMerge(t *testing.T) {
 				mm.Using("new_wine_list").As("s").On(
 					psql.Quote("s", "winename").EQ(psql.Quote("w", "winename")),
 				),
-				mm.WhenNotMatchedByTarget(
-					mm.ThenInsert(
-						mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock")),
-					),
+				mm.WhenNotMatchedByTarget().ThenInsert(
+					mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock")),
 				),
-				mm.WhenMatched(
-					mm.And(psql.Quote("w", "stock").NE(psql.Quote("s", "stock"))),
-					mm.ThenUpdate(
-						mm.SetCol("stock").ToExpr(psql.Quote("s", "stock")),
-					),
+				mm.WhenMatched().And(psql.Quote("w", "stock").NE(psql.Quote("s", "stock"))).ThenUpdate(
+					mm.SetCol("stock").ToExpr(psql.Quote("s", "stock")),
 				),
-				mm.WhenNotMatchedBySource(
-					mm.ThenDelete(),
-				),
+				mm.WhenNotMatchedBySource().ThenDelete(),
 			),
 			ExpectedSQL: `MERGE INTO wines AS "w"
 				USING new_wine_list AS "s" ON "s"."winename" = "w"."winename"
@@ -116,16 +93,12 @@ func TestMerge(t *testing.T) {
 				mm.Using("product_updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("price").ToExpr(psql.Quote("u", "price")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("price").ToExpr(psql.Quote("u", "price")),
 				),
-				mm.WhenNotMatched(
-					mm.ThenInsert(
-						mm.Columns("id", "name", "price"),
-						mm.Values(psql.Quote("u", "id"), psql.Quote("u", "name"), psql.Quote("u", "price")),
-					),
+				mm.WhenNotMatched().ThenInsert(
+					mm.Columns("id", "name", "price"),
+					mm.Values(psql.Quote("u", "id"), psql.Quote("u", "name"), psql.Quote("u", "price")),
 				),
 				mm.Returning("*"),
 			),
@@ -141,10 +114,8 @@ func TestMerge(t *testing.T) {
 				mm.Using(psql.Select()).As("src").On(
 					psql.Quote("src", "id").EQ(psql.Quote("target_table", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("value").ToExpr(psql.Quote("src", "value")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("value").ToExpr(psql.Quote("src", "value")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO target_table
@@ -157,12 +128,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("employee_updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("employees", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
-						mm.SetCol("salary").ToExpr(psql.Quote("u", "salary")),
-						mm.SetCol("department").ToExpr(psql.Quote("u", "department")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
+					mm.SetCol("salary").ToExpr(psql.Quote("u", "salary")),
+					mm.SetCol("department").ToExpr(psql.Quote("u", "department")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO employees
@@ -175,11 +144,9 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("updated_at").ToDefault(),
-						mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("updated_at").ToDefault(),
+					mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -192,12 +159,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCols("name", "price").ToRow(
-							psql.Quote("u", "name"),
-							psql.Quote("u", "price"),
-						),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCols("name", "price").ToRow(
+						psql.Quote("u", "name"),
+						psql.Quote("u", "price"),
 					),
 				),
 			),
@@ -211,14 +176,12 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCols("name", "price").ToQuery(
-							psql.Select(
-								sm.Columns("name", "price"),
-								sm.From("default_values"),
-								sm.Where(psql.Quote("category").EQ(psql.Quote("u", "category"))),
-							),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCols("name", "price").ToQuery(
+						psql.Select(
+							sm.Columns("name", "price"),
+							sm.From("default_values"),
+							sm.Where(psql.Quote("category").EQ(psql.Quote("u", "category"))),
 						),
 					),
 				),
@@ -237,10 +200,8 @@ func TestMerge(t *testing.T) {
 				mm.Using("source_data").As("s").On(
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `WITH source_data AS (SELECT "id", "value" FROM temp_table)
@@ -254,9 +215,7 @@ func TestMerge(t *testing.T) {
 				mm.Using("events").As("e").On(
 					psql.Quote("e", "id").EQ(psql.Quote("audit_log", "event_id")),
 				),
-				mm.WhenNotMatched(
-					mm.ThenInsertDefaultValues(),
-				),
+				mm.WhenNotMatched().ThenInsertDefaultValues(),
 			),
 			ExpectedSQL: `MERGE INTO audit_log
 				USING events AS "e" ON "e"."id" = "audit_log"."event_id"
@@ -268,12 +227,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("new_products").As("n").On(
 					psql.Quote("n", "sku").EQ(psql.Quote("products", "sku")),
 				),
-				mm.WhenNotMatched(
-					mm.ThenInsert(
-						mm.Columns("id", "sku", "name"),
-						mm.OverridingSystem(),
-						mm.Values(psql.Quote("n", "id"), psql.Quote("n", "sku"), psql.Quote("n", "name")),
-					),
+				mm.WhenNotMatched().ThenInsert(
+					mm.Columns("id", "sku", "name"),
+					mm.OverridingSystem(),
+					mm.Values(psql.Quote("n", "id"), psql.Quote("n", "sku"), psql.Quote("n", "name")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -286,12 +243,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("new_products").As("n").On(
 					psql.Quote("n", "sku").EQ(psql.Quote("products", "sku")),
 				),
-				mm.WhenNotMatched(
-					mm.ThenInsert(
-						mm.Columns("id", "sku", "name"),
-						mm.OverridingUser(),
-						mm.Values(psql.Quote("n", "id"), psql.Quote("n", "sku"), psql.Quote("n", "name")),
-					),
+				mm.WhenNotMatched().ThenInsert(
+					mm.Columns("id", "sku", "name"),
+					mm.OverridingUser(),
+					mm.Values(psql.Quote("n", "id"), psql.Quote("n", "sku"), psql.Quote("n", "name")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -309,10 +264,8 @@ func TestMerge(t *testing.T) {
 				mm.Using("hierarchy").As("h").On(
 					psql.Quote("h", "id").EQ(psql.Quote("target", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("name").ToExpr(psql.Quote("h", "name")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("name").ToExpr(psql.Quote("h", "name")),
 				),
 			),
 			ExpectedSQL: `WITH RECURSIVE hierarchy AS (SELECT "id", "parent_id", "name" FROM categories)
@@ -327,10 +280,8 @@ func TestMerge(t *testing.T) {
 				mm.Using("source").As("s").On(
 					psql.Quote("s", "id").EQ(psql.Quote("parent_table", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO ONLY parent_table
@@ -343,9 +294,7 @@ func TestMerge(t *testing.T) {
 				mm.Using("parent_source").Only().As("s").On(
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenDelete(),
-				),
+				mm.WhenMatched().ThenDelete(),
 			),
 			ExpectedSQL: `MERGE INTO target
 				USING ONLY parent_source AS "s" ON "s"."id" = "target"."id"
@@ -358,9 +307,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("s", "id"),
 					psql.Quote("target", "id"),
 				),
-				mm.WhenMatched(
-					mm.ThenDoNothing(),
-				),
+				mm.WhenMatched().ThenDoNothing(),
 			),
 			ExpectedSQL: `MERGE INTO target
 				USING source AS "s" ON "s"."id" = "target"."id"
@@ -372,11 +319,9 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("status").To(psql.Raw("'active'")),
-						mm.SetCol("counter").To(psql.Raw("counter + 1")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("status").To(psql.Raw("'active'")),
+					mm.SetCol("counter").To(psql.Raw("counter + 1")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -389,11 +334,9 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("status").ToArg("active"),
-						mm.SetCol("quantity").ToArg(100),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("status").ToArg("active"),
+					mm.SetCol("quantity").ToArg(100),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -407,12 +350,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.Set(
-							psql.Raw(`"name" = "u"."name"`),
-							psql.Raw(`"price" = "u"."price" * 1.1`),
-						),
+				mm.WhenMatched().ThenUpdate(
+					mm.Set(
+						psql.Raw(`"name" = "u"."name"`),
+						psql.Raw(`"price" = "u"."price" * 1.1`),
 					),
 				),
 			),
@@ -426,12 +367,10 @@ func TestMerge(t *testing.T) {
 				mm.Using("updates").As("u").On(
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCols("name", "price").ToExprs(
-							psql.Quote("u", "name"),
-							psql.Quote("u", "price"),
-						),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCols("name", "price").ToExprs(
+						psql.Quote("u", "name"),
+						psql.Quote("u", "price"),
 					),
 				),
 			),
@@ -445,28 +384,17 @@ func TestMerge(t *testing.T) {
 				mm.Using("stock_updates").As("s").On(
 					psql.Quote("s", "product_id").EQ(psql.Quote("inventory", "product_id")),
 				),
-				mm.WhenMatched(
-					mm.And(psql.Quote("s", "quantity").EQ(psql.Arg(0))),
-					mm.ThenDelete(),
+				mm.WhenMatched().And(psql.Quote("s", "quantity").EQ(psql.Arg(0))).ThenDelete(),
+				mm.WhenMatched().And(psql.Quote("s", "quantity").GT(psql.Arg(0))).ThenUpdate(
+					mm.SetCol("quantity").ToExpr(psql.Quote("s", "quantity")),
+					mm.SetCol("updated_at").ToDefault(),
 				),
-				mm.WhenMatched(
-					mm.And(psql.Quote("s", "quantity").GT(psql.Arg(0))),
-					mm.ThenUpdate(
-						mm.SetCol("quantity").ToExpr(psql.Quote("s", "quantity")),
-						mm.SetCol("updated_at").ToDefault(),
-					),
+				mm.WhenNotMatchedByTarget().And(psql.Quote("s", "quantity").GT(psql.Arg(0))).ThenInsert(
+					mm.Columns("product_id", "quantity"),
+					mm.Values(psql.Quote("s", "product_id"), psql.Quote("s", "quantity")),
 				),
-				mm.WhenNotMatchedByTarget(
-					mm.And(psql.Quote("s", "quantity").GT(psql.Arg(0))),
-					mm.ThenInsert(
-						mm.Columns("product_id", "quantity"),
-						mm.Values(psql.Quote("s", "product_id"), psql.Quote("s", "quantity")),
-					),
-				),
-				mm.WhenNotMatchedBySource(
-					mm.ThenUpdate(
-						mm.SetCol("quantity").ToArg(0),
-					),
+				mm.WhenNotMatchedBySource().ThenUpdate(
+					mm.SetCol("quantity").ToArg(0),
 				),
 				mm.Returning("*"),
 			),
@@ -489,11 +417,9 @@ func TestMerge(t *testing.T) {
 				mm.Using("source_data").As("s").On(
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
-				mm.WhenMatched(
-					mm.ThenUpdate(
-						mm.SetCol("name").ToExpr(psql.Quote("s", "name")),
-						mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
-					),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("name").ToExpr(psql.Quote("s", "name")),
+					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `WITH source_data ("id", "name", "value") AS (SELECT "product_id", "product_name", "price" FROM products)

--- a/dialect/psql/mm/qm.go
+++ b/dialect/psql/mm/qm.go
@@ -142,89 +142,138 @@ func (u UsingChain) OnEQ(left, right bob.Expression) bob.Mod[*dialect.MergeQuery
 	return u.On(expr.X[dialect.Expression, dialect.Expression](left).EQ(right))
 }
 
-// WhenMatched creates a WHEN MATCHED clause
-func WhenMatched(mods ...bob.Mod[*WhenClause]) bob.Mod[*dialect.MergeQuery] {
-	return whenClause(dialect.MergeWhenMatched, mods...)
+// WhenMatchedChain is a chain for building WHEN MATCHED and WHEN NOT MATCHED BY SOURCE clauses
+type WhenMatchedChain struct {
+	whenType  dialect.MergeWhenType
+	condition bob.Expression
 }
 
-// WhenNotMatched creates a WHEN NOT MATCHED (BY TARGET) clause
-func WhenNotMatched(mods ...bob.Mod[*WhenClause]) bob.Mod[*dialect.MergeQuery] {
-	return whenClause(dialect.MergeWhenNotMatched, mods...)
-}
-
-// WhenNotMatchedByTarget is an alias for WhenNotMatched with explicit BY TARGET
-func WhenNotMatchedByTarget(mods ...bob.Mod[*WhenClause]) bob.Mod[*dialect.MergeQuery] {
-	return whenClause(dialect.MergeWhenNotMatchedByTarget, mods...)
-}
-
-// WhenNotMatchedBySource creates a WHEN NOT MATCHED BY SOURCE clause
-func WhenNotMatchedBySource(mods ...bob.Mod[*WhenClause]) bob.Mod[*dialect.MergeQuery] {
-	return whenClause(dialect.MergeWhenNotMatchedBySource, mods...)
-}
-
-func whenClause(t dialect.MergeWhenType, mods ...bob.Mod[*WhenClause]) bob.Mod[*dialect.MergeQuery] {
-	wc := &WhenClause{Type: t}
-	for _, mod := range mods {
-		mod.Apply(wc)
+// And adds a condition to the WHEN clause
+func (c WhenMatchedChain) And(condition bob.Expression) WhenMatchedChain {
+	if c.condition == nil {
+		c.condition = condition
+	} else {
+		c.condition = expr.X[dialect.Expression, dialect.Expression](c.condition).And(condition)
 	}
+	return c
+}
+
+// ThenDoNothing sets the action to DO NOTHING
+func (c WhenMatchedChain) ThenDoNothing() bob.Mod[*dialect.MergeQuery] {
 	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
 		m.When = append(m.When, dialect.MergeWhen{
-			Type:      wc.Type,
-			Condition: wc.Condition,
-			Action:    wc.Action,
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action:    dialect.MergeAction{Type: dialect.MergeActionDoNothing},
 		})
 	})
 }
 
-// WhenClause is a builder for WHEN clauses
-type WhenClause struct {
-	Type      dialect.MergeWhenType
-	Condition bob.Expression
-	Action    dialect.MergeAction
-}
-
-// And adds a condition to the WHEN clause
-func And(condition bob.Expression) bob.Mod[*WhenClause] {
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		if w.Condition == nil {
-			w.Condition = condition
-		} else {
-			w.Condition = expr.X[dialect.Expression, dialect.Expression](w.Condition).And(condition)
-		}
-	})
-}
-
-// ThenDoNothing sets the action to DO NOTHING
-func ThenDoNothing() bob.Mod[*WhenClause] {
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		w.Action = dialect.MergeAction{Type: dialect.MergeActionDoNothing}
-	})
-}
-
 // ThenDelete sets the action to DELETE
-func ThenDelete() bob.Mod[*WhenClause] {
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		w.Action = dialect.MergeAction{Type: dialect.MergeActionDelete}
+func (c WhenMatchedChain) ThenDelete() bob.Mod[*dialect.MergeQuery] {
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action:    dialect.MergeAction{Type: dialect.MergeActionDelete},
+		})
 	})
 }
 
 // ThenUpdate sets the action to UPDATE with SET clauses
-// Supports MERGE UPDATE syntax:
-//   - column = expression
-//   - column = DEFAULT
-//   - (columns...) = ROW (expressions...)
-//   - (columns...) = (subquery)
-func ThenUpdate(sets ...bob.Mod[*UpdateAction]) bob.Mod[*WhenClause] {
+func (c WhenMatchedChain) ThenUpdate(sets ...bob.Mod[*UpdateAction]) bob.Mod[*dialect.MergeQuery] {
 	ua := &UpdateAction{}
 	for _, s := range sets {
 		s.Apply(ua)
 	}
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		w.Action = dialect.MergeAction{
-			Type: dialect.MergeActionUpdate,
-			Set:  ua.Set,
-		}
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action: dialect.MergeAction{
+				Type: dialect.MergeActionUpdate,
+				Set:  ua.Set,
+			},
+		})
 	})
+}
+
+// WhenNotMatchedChain is a chain for building WHEN NOT MATCHED [BY TARGET] clauses
+type WhenNotMatchedChain struct {
+	whenType  dialect.MergeWhenType
+	condition bob.Expression
+}
+
+// And adds a condition to the WHEN clause
+func (c WhenNotMatchedChain) And(condition bob.Expression) WhenNotMatchedChain {
+	if c.condition == nil {
+		c.condition = condition
+	} else {
+		c.condition = expr.X[dialect.Expression, dialect.Expression](c.condition).And(condition)
+	}
+	return c
+}
+
+// ThenDoNothing sets the action to DO NOTHING
+func (c WhenNotMatchedChain) ThenDoNothing() bob.Mod[*dialect.MergeQuery] {
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action:    dialect.MergeAction{Type: dialect.MergeActionDoNothing},
+		})
+	})
+}
+
+// ThenInsert sets the action to INSERT
+func (c WhenNotMatchedChain) ThenInsert(mods ...bob.Mod[*InsertAction]) bob.Mod[*dialect.MergeQuery] {
+	ia := &InsertAction{}
+	for _, mod := range mods {
+		mod.Apply(ia)
+	}
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action: dialect.MergeAction{
+				Type:       dialect.MergeActionInsert,
+				Columns:    ia.Columns,
+				Values:     ia.Values,
+				Overriding: ia.Overriding,
+			},
+		})
+	})
+}
+
+// ThenInsertDefaultValues sets the action to INSERT DEFAULT VALUES
+func (c WhenNotMatchedChain) ThenInsertDefaultValues() bob.Mod[*dialect.MergeQuery] {
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      c.whenType,
+			Condition: c.condition,
+			Action:    dialect.MergeAction{Type: dialect.MergeActionInsert},
+		})
+	})
+}
+
+// WhenMatched creates a WHEN MATCHED clause chain
+func WhenMatched() WhenMatchedChain {
+	return WhenMatchedChain{whenType: dialect.MergeWhenMatched}
+}
+
+// WhenNotMatched creates a WHEN NOT MATCHED (BY TARGET) clause chain
+func WhenNotMatched() WhenNotMatchedChain {
+	return WhenNotMatchedChain{whenType: dialect.MergeWhenNotMatched}
+}
+
+// WhenNotMatchedByTarget is an alias for WhenNotMatched with explicit BY TARGET
+func WhenNotMatchedByTarget() WhenNotMatchedChain {
+	return WhenNotMatchedChain{whenType: dialect.MergeWhenNotMatchedByTarget}
+}
+
+// WhenNotMatchedBySource creates a WHEN NOT MATCHED BY SOURCE clause chain
+func WhenNotMatchedBySource() WhenMatchedChain {
+	return WhenMatchedChain{whenType: dialect.MergeWhenNotMatchedBySource}
 }
 
 // UpdateAction is a builder for UPDATE action in MERGE
@@ -315,34 +364,6 @@ func (s SetColsChain) ToExprs(values ...bob.Expression) bob.Mod[*UpdateAction] {
 func (s SetColsChain) ToQuery(q bob.Query) bob.Mod[*UpdateAction] {
 	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
 		u.Set = append(u.Set, queryAssignment{cols: s.colExprs(), query: q})
-	})
-}
-
-// ThenInsert sets the action to INSERT
-// Use with Columns(), Values(), OverridingSystem(), OverridingUser() modifiers
-// If no Values() is specified, DEFAULT VALUES will be used
-func ThenInsert(mods ...bob.Mod[*InsertAction]) bob.Mod[*WhenClause] {
-	ia := &InsertAction{}
-	for _, mod := range mods {
-		mod.Apply(ia)
-	}
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		w.Action = dialect.MergeAction{
-			Type:       dialect.MergeActionInsert,
-			Columns:    ia.Columns,
-			Values:     ia.Values,
-			Overriding: ia.Overriding,
-		}
-	})
-}
-
-// ThenInsertDefaultValues sets the action to INSERT DEFAULT VALUES (shortcut)
-func ThenInsertDefaultValues() bob.Mod[*WhenClause] {
-	return bob.ModFunc[*WhenClause](func(w *WhenClause) {
-		w.Action = dialect.MergeAction{
-			Type: dialect.MergeActionInsert,
-			// Empty Values signals DEFAULT VALUES
-		}
 	})
 }
 

--- a/dialect/psql/table_test.go
+++ b/dialect/psql/table_test.go
@@ -231,17 +231,13 @@ func TestMerge(t *testing.T) {
 		mm.Using("user_updates").As("u").On(
 			Quote("u", "id").EQ(Quote("users", "id")),
 		),
-		mm.WhenMatched(
-			mm.ThenUpdate(
-				mm.SetCol("name").ToExpr(Quote("u", "name")),
-				mm.SetCol("email").ToExpr(Quote("u", "email")),
-			),
+		mm.WhenMatched().ThenUpdate(
+			mm.SetCol("name").ToExpr(Quote("u", "name")),
+			mm.SetCol("email").ToExpr(Quote("u", "email")),
 		),
-		mm.WhenNotMatched(
-			mm.ThenInsert(
-				mm.Columns("id", "name", "email"),
-				mm.Values(Quote("u", "id"), Quote("u", "name"), Quote("u", "email")),
-			),
+		mm.WhenNotMatched().ThenInsert(
+			mm.Columns("id", "name", "email"),
+			mm.Values(Quote("u", "id"), Quote("u", "name"), Quote("u", "email")),
 		),
 	)
 
@@ -310,10 +306,8 @@ func TestTableMergeWithVersion(t *testing.T) {
 			mm.Using("source").As("s").On(
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
-			mm.WhenMatched(
-				mm.ThenUpdate(
-					mm.SetCol("name").ToExpr(Quote("s", "name")),
-				),
+			mm.WhenMatched().ThenUpdate(
+				mm.SetCol("name").ToExpr(Quote("s", "name")),
 			),
 		)
 
@@ -339,10 +333,8 @@ func TestTableMergeWithVersion(t *testing.T) {
 			mm.Using("source").As("s").On(
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
-			mm.WhenMatched(
-				mm.ThenUpdate(
-					mm.SetCol("name").ToExpr(Quote("s", "name")),
-				),
+			mm.WhenMatched().ThenUpdate(
+				mm.SetCol("name").ToExpr(Quote("s", "name")),
 			),
 		)
 
@@ -368,10 +360,8 @@ func TestTableMergeWithVersion(t *testing.T) {
 			mm.Using("source").As("s").On(
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
-			mm.WhenMatched(
-				mm.ThenUpdate(
-					mm.SetCol("name").ToExpr(Quote("s", "name")),
-				),
+			mm.WhenMatched().ThenUpdate(
+				mm.SetCol("name").ToExpr(Quote("s", "name")),
 			),
 		)
 


### PR DESCRIPTION
Sorry for the back-and-forth on this - after the initial merge implementation I went back and re-read the MERGE statement syntax more carefully:

```
WHEN MATCHED [ AND condition ] THEN { merge_update | merge_delete | DO NOTHING }
WHEN NOT MATCHED BY SOURCE [ AND condition ] THEN { merge_update | merge_delete | DO NOTHING }
WHEN NOT MATCHED [ BY TARGET ] [ AND condition ] THEN { merge_insert | DO NOTHING }
```

It became clear that each `WHEN MATCHED / WHEN NOT MATCHED` clause is a self-contained, standalone expression — the condition (`AND ...`) and the action (`THEN ...`) are integral parts of that single clause, not independent modifiers applied to some external builder. The previous functional-options approach (`WhenMatched(And(...), ThenUpdate(...))`) obscured this structure by treating the condition and action as separate, unrelated mods passed into a bag.

Switching to a fluent chain makes the code mirror the SQL grammar directly:

```go
// Before
mm.WhenMatched(
    mm.And(psql.Quote("s", "quantity").GT(psql.Arg(0))),
    mm.ThenUpdate(
        mm.SetCol("quantity").ToExpr(psql.Quote("s", "quantity")),
    ),
)

// After
mm.WhenMatched().
    And(psql.Quote("s", "quantity").GT(psql.Arg(0))).
    ThenUpdate(
        mm.SetCol("quantity").ToExpr(psql.Quote("s", "quantity")),
    )
```

### Changes

- `WhenMatched()`, `WhenNotMatched()`, `WhenNotMatchedByTarget()`, `WhenNotMatchedBySource()` now take no arguments and return a chain type
- `WhenMatchedChain` (for `MATCHED` / `NOT MATCHED BY SOURCE`) exposes `.And()`, `.ThenUpdate()`, `.ThenDelete()`, `.ThenDoNothing()`
- `WhenNotMatchedChain` (for `NOT MATCHED [BY TARGET]`) exposes `.And()`, `.ThenInsert()`, `.ThenInsertDefaultValues()`, `.ThenDoNothing()`
- Removed standalone `And`, `ThenDoNothing`, `ThenDelete`, `ThenUpdate`, `ThenInsert`, `ThenInsertDefaultValues` functions and the `WhenClause` type
- All existing tests updated and passing