### PR TITLE
fix(pgx): return ErrTxClosed from Commit instead of swallowing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `pgx` driver `Commit()` returning `nil` instead of `pgx.ErrTxClosed` when the transaction is already closed (e.g., rolled back by context expiry). This prevented silent data loss by correctly propagating the error to the caller. (thanks @wucm667)
 - Fix self-referencing relationship back-references so generated preload/load helpers no longer create cyclic parent links. (thanks @atzedus)
 - Fix collisions for preloader alias generation. Replaced `RandInt` with `NextUniqueInt` (thanks @atzedus)
 - Fix an issue where the random function of aliased custom types were not being used in generated query tests.

--- a/drivers/pgx/tx.go
+++ b/drivers/pgx/tx.go
@@ -108,7 +108,7 @@ func (t Tx) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
 // Commit implements bob.Transaction.
 func (t Tx) Commit(ctx context.Context) error {
 	err := t.tx.Commit(ctx)
-	if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

When a transaction is already closed (e.g., rolled back by the context expiry goroutine in `beginTx`), calling `Commit()` returns `nil` instead of `pgx.ErrTxClosed`. This makes the client believe the commit succeeded when it actually failed, potentially leading to silent data loss.

## Root Cause

In `drivers/pgx/tx.go`, `Commit()` explicitly swallows `pgx.ErrTxClosed`:

```go
func (t Tx) Commit(ctx context.Context) error {
    err := t.tx.Commit(ctx)
    if err != nil && !errors.Is(err, pgx.ErrTxClosed) { // ← swallows ErrTxClosed
        return err
    }
    // ...
    return nil  // returns nil even when tx was already closed
}
```

This differs from Go stdlib behavior where `sql.Tx.Commit()` returns `ErrTxDone` if the transaction is already closed.

## Fix

Remove the `&& !errors.Is(err, pgx.ErrTxClosed)` condition from `Commit()`:

```go
if err != nil {  // now returns ErrTxClosed to caller
    return err
}
```

`Rollback()` continues to swallow `ErrTxClosed` to support the idiomatic `defer tx.Rollback()` pattern.

## Testing

All project tests pass.

Fixes #640