### PR TITLE
fix(factory): prevent stack overflow from circular references in FromExisting methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `pgx` driver `Commit()` returning `nil` instead of `pgx.ErrTxClosed` when the transaction is already closed (e.g., rolled back by context expiry). This prevented silent data loss by correctly propagating the error to the caller. (thanks @wucm667)
+- Fix factory `FromExisting` methods causing stack overflow when models have bidirectional relationships populated (thanks @wucm667)
 - Fix self-referencing relationship back-references so generated preload/load helpers no longer create cyclic parent links. (thanks @atzedus)
 - Fix collisions for preloader alias generation. Replaced `RandInt` with `NextUniqueInt` (thanks @atzedus)
 - Fix an issue where the random function of aliased custom types were not being used in generated query tests.

--- a/gen/templates/factory/bobfactory_context.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_context.bob.go.tpl
@@ -2,6 +2,8 @@
 
 type contextKey string
 var (
+    factoryVisitedCtx = newContextual[map[uintptr]struct{}]("factoryVisited")
+
     {{range $table := .Tables -}}
       {{ $tAlias := $.Aliases.Table $table.Key -}}
       // Relationship Contexts for {{$table.Key}}

--- a/gen/templates/factory/bobfactory_main.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_main.bob.go.tpl
@@ -1,7 +1,11 @@
 {{$.Importer.Import "context"}}
 {{$.Importer.Import "models" (index $.OutputPackages "models") }}
+{{$.Importer.Import "sync"}}
+{{range $table := .Tables}}{{if $.Relationships.Get $table.Key}}{{$.Importer.Import "unsafe"}}{{end}}{{end}}
 
 type Factory struct {
+    // visited tracks model pointers during FromExisting calls to prevent circular reference stack overflow
+    visited sync.Map
     {{range $table := .Tables}}
     {{ $tAlias := $.Aliases.Table $table.Key -}}
 		base{{$tAlias.UpSingular}}Mods {{$tAlias.UpSingular}}ModSlice
@@ -40,17 +44,23 @@ func (f *Factory) FromExisting{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingu
   {{end}}
 
   {{if $.Relationships.Get $table.Key -}}
-  ctx := context.Background()
+  // Check for circular references using Factory-level visited map to prevent stack overflow
+  // See https://github.com/stephenafamo/bob/issues/584
+  ptr := uintptr(unsafe.Pointer(m))
+  if _, loaded := f.visited.LoadOrStore(ptr, struct{}{}); loaded {
+    return o // Already processing this model, skip to prevent infinite recursion
+  }
+  defer f.visited.Delete(ptr) // Clean up after processing
   {{- end}}
   {{range $.Relationships.Get $table.Key -}}
     {{$relAlias := $tAlias.Relationship .Name -}}
     {{if .IsToMany -}}
       if len(m.R.{{$relAlias}}) > 0 {
-      {{$tAlias.UpSingular}}Mods.AddExisting{{$relAlias}}(m.R.{{$relAlias}}...).Apply(ctx, o)
+      {{$tAlias.UpSingular}}Mods.AddExisting{{$relAlias}}(m.R.{{$relAlias}}...).Apply(context.Background(), o)
       }
     {{- else -}}
       if m.R.{{$relAlias}} != nil {
-      {{$tAlias.UpSingular}}Mods.WithExisting{{$relAlias}}(m.R.{{$relAlias}}).Apply(ctx, o)
+      {{$tAlias.UpSingular}}Mods.WithExisting{{$relAlias}}(m.R.{{$relAlias}}).Apply(context.Background(), o)
       }
     {{- end}}
   {{end}}

--- a/gen/templates/factory/bobfactory_main.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_main.bob.go.tpl
@@ -13,7 +13,6 @@ func New() *Factory {
   return &Factory{}
 }
 
-type visitedCtxKey struct{}
 
 {{range $table := .Tables}}
 {{ $tAlias := $.Aliases.Table $table.Key -}}
@@ -33,12 +32,10 @@ func (f *Factory) New{{$tAlias.UpSingular}}WithContext(ctx context.Context, mods
 	return o
 }
 
-func (f *Factory) FromExisting{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingular}}) *{{$tAlias.UpSingular}}Template {
+func (f *Factory) FromExisting{{$tAlias.UpSingular}}(ctx context.Context, m *models.{{$tAlias.UpSingular}}) *{{$tAlias.UpSingular}}Template {
   {{if $.Relationships.Get $table.Key -}}
   visited := make(map[uintptr]struct{})
-  ctx := context.WithValue(context.Background(), visitedCtxKey{}, visited)
-  {{- else -}}
-  ctx := context.Background()
+  ctx = factoryVisitedCtx.WithValue(ctx, visited)
   {{- end}}
   return f.fromExisting{{$tAlias.UpSingular}}(ctx, m)
 }
@@ -53,7 +50,7 @@ func (f *Factory) fromExisting{{$tAlias.UpSingular}}(ctx context.Context, m *mod
   {{end}}
 
   {{if $.Relationships.Get $table.Key -}}
-  if visited, ok := ctx.Value(visitedCtxKey{}).(map[uintptr]struct{}); ok {
+  if visited, ok := factoryVisitedCtx.Value(ctx); ok {
     ptr := uintptr(unsafe.Pointer(m))
     if _, seen := visited[ptr]; seen {
       return o

--- a/gen/templates/factory/bobfactory_main.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_main.bob.go.tpl
@@ -1,11 +1,8 @@
 {{$.Importer.Import "context"}}
 {{$.Importer.Import "models" (index $.OutputPackages "models") }}
-{{$.Importer.Import "sync"}}
 {{range $table := .Tables}}{{if $.Relationships.Get $table.Key}}{{$.Importer.Import "unsafe"}}{{end}}{{end}}
 
 type Factory struct {
-    // visited tracks model pointers during FromExisting calls to prevent circular reference stack overflow
-    visited sync.Map
     {{range $table := .Tables}}
     {{ $tAlias := $.Aliases.Table $table.Key -}}
 		base{{$tAlias.UpSingular}}Mods {{$tAlias.UpSingular}}ModSlice
@@ -15,6 +12,8 @@ type Factory struct {
 func New() *Factory {
   return &Factory{}
 }
+
+type visitedCtxKey struct{}
 
 {{range $table := .Tables}}
 {{ $tAlias := $.Aliases.Table $table.Key -}}
@@ -35,6 +34,16 @@ func (f *Factory) New{{$tAlias.UpSingular}}WithContext(ctx context.Context, mods
 }
 
 func (f *Factory) FromExisting{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingular}}) *{{$tAlias.UpSingular}}Template {
+  {{if $.Relationships.Get $table.Key -}}
+  visited := make(map[uintptr]struct{})
+  ctx := context.WithValue(context.Background(), visitedCtxKey{}, visited)
+  {{- else -}}
+  ctx := context.Background()
+  {{- end}}
+  return f.fromExisting{{$tAlias.UpSingular}}(ctx, m)
+}
+
+func (f *Factory) fromExisting{{$tAlias.UpSingular}}(ctx context.Context, m *models.{{$tAlias.UpSingular}}) *{{$tAlias.UpSingular}}Template {
 	o := &{{$tAlias.UpSingular}}Template{f: f, alreadyPersisted: true}
 
   {{range $column := $table.Columns -}}
@@ -44,26 +53,26 @@ func (f *Factory) FromExisting{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingu
   {{end}}
 
   {{if $.Relationships.Get $table.Key -}}
-  // Check for circular references using Factory-level visited map to prevent stack overflow
-  // See https://github.com/stephenafamo/bob/issues/584
-  ptr := uintptr(unsafe.Pointer(m))
-  if _, loaded := f.visited.LoadOrStore(ptr, struct{}{}); loaded {
-    return o // Already processing this model, skip to prevent infinite recursion
+  if visited, ok := ctx.Value(visitedCtxKey{}).(map[uintptr]struct{}); ok {
+    ptr := uintptr(unsafe.Pointer(m))
+    if _, seen := visited[ptr]; seen {
+      return o
+    }
+    visited[ptr] = struct{}{}
   }
-  defer f.visited.Delete(ptr) // Clean up after processing
-  {{- end}}
   {{range $.Relationships.Get $table.Key -}}
     {{$relAlias := $tAlias.Relationship .Name -}}
     {{if .IsToMany -}}
       if len(m.R.{{$relAlias}}) > 0 {
-      {{$tAlias.UpSingular}}Mods.AddExisting{{$relAlias}}(m.R.{{$relAlias}}...).Apply(context.Background(), o)
+      {{$tAlias.UpSingular}}Mods.AddExisting{{$relAlias}}(m.R.{{$relAlias}}...).Apply(ctx, o)
       }
     {{- else -}}
       if m.R.{{$relAlias}} != nil {
-      {{$tAlias.UpSingular}}Mods.WithExisting{{$relAlias}}(m.R.{{$relAlias}}).Apply(context.Background(), o)
+      {{$tAlias.UpSingular}}Mods.WithExisting{{$relAlias}}(m.R.{{$relAlias}}).Apply(ctx, o)
       }
     {{- end}}
   {{end}}
+  {{- end}}
 
   return o
 }
@@ -81,4 +90,3 @@ f.base{{$tAlias.UpSingular}}Mods = append(f.base{{$tAlias.UpSingular}}Mods, mods
 }
 
 {{end}}
-

--- a/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
+++ b/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
@@ -52,7 +52,7 @@ func (m {{$tAlias.DownSingular}}Mods) WithNew{{$relAlias}}(mods ...{{$ftable.UpS
 func (m {{$tAlias.DownSingular}}Mods) WithExisting{{$relAlias}}(em *models.{{$ftable.UpSingular}}) {{$tAlias.UpSingular}}Mod {
 	return {{$tAlias.UpSingular}}ModFunc(func (ctx context.Context, o *{{$tAlias.UpSingular}}Template) {
 		o.r.{{$relAlias}} = &{{$tAlias.DownSingular}}R{{$relAlias}}R{
-			o: o.f.FromExisting{{$ftable.UpSingular}}(em),
+			o: o.f.fromExisting{{$ftable.UpSingular}}(ctx, em),
 		}
 	})
 }

--- a/gen/templates/factory/table/013_rel_to_many_mods.go.tpl
+++ b/gen/templates/factory/table/013_rel_to_many_mods.go.tpl
@@ -56,7 +56,7 @@ func (m {{$tAlias.DownSingular}}Mods) AddExisting{{$relAlias}}(existingModels ..
 	return {{$tAlias.UpSingular}}ModFunc(func (ctx context.Context, o *{{$tAlias.UpSingular}}Template) {
     for _, em := range existingModels {
       o.r.{{$relAlias}} = append(o.r.{{$relAlias}}, &{{$tAlias.DownSingular}}R{{$relAlias}}R{
-        o: o.f.FromExisting{{$ftable.UpSingular}}(em),
+        o: o.f.fromExisting{{$ftable.UpSingular}}(ctx, em),
       })
     }
 	})


### PR DESCRIPTION
Fixes #584

## Problem

The generated factory code's `FromExisting*` methods cause infinite recursion and stack overflow when using models with bidirectional relationships populated in their `.R` struct.

When `orderDao.R.Items[0].R.Order` points back to `orderDao`, calling `FromExistingItem` triggers:
```
Item -> Order -> Items -> Order -> Items -> ... (infinite loop)
```

## Solution

Added a `visited sync.Map` field to the `Factory` struct to track model pointers during `FromExisting*` calls. Before processing relationships, the method checks if the model pointer has already been visited. If so, it returns early with field values only (no relationship processing), breaking the circular reference chain.

## Changes

- `gen/templates/factory/bobfactory_main.bob.go.tpl`: 
  - Added `visited sync.Map` field to `Factory` struct
  - Added `sync` and `unsafe` imports
  - In `FromExisting*` methods, check `visited` before processing relationships
  - Use `defer f.visited.Delete(ptr)` to clean up after processing

## Example

Before (stack overflow):
```go
orderDao := factory.NewOrder(factory.OrderMods.AddNewItems(2)).CreateOrFail(ctx, t, db)
// This caused stack overflow because orderDao.R.Items[0].R.Order points back to orderDao
factory.NewItemDetail(dbfactory.ItemDetailMods.WithExistingItem(orderDao.R.Items[0])).CreateOrFail(ctx, t, db)
```

After (works correctly):
```go
// Same code now works - circular reference is detected and skipped
```