### PR TITLE
refactor(dialect/psql/mm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
+- **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
+
 ## [v0.43.0] - 2026-04-29
 
 ### Added

--- a/dialect/psql/merge_test.go
+++ b/dialect/psql/merge_test.go
@@ -18,7 +18,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("t", "customer_id").EQ(psql.Quote("customer_account", "customer_id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("balance").ToExpr(
+					mm.SetCol("balance").To(
 						psql.Raw("balance + ?", psql.Quote("t", "transaction_value")),
 					),
 				),
@@ -42,7 +42,7 @@ func TestMerge(t *testing.T) {
 					mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock_delta")),
 				),
 				mm.WhenMatched().And(psql.Raw("w.stock + s.stock_delta > 0")).ThenUpdate(
-					mm.SetCol("stock").ToExpr(psql.Raw("w.stock + s.stock_delta")),
+					mm.SetCol("stock").To(psql.Raw("w.stock + s.stock_delta")),
 				),
 				mm.WhenMatched().ThenDelete(),
 			),
@@ -77,7 +77,7 @@ func TestMerge(t *testing.T) {
 					mm.Values(psql.Quote("s", "winename"), psql.Quote("s", "stock")),
 				),
 				mm.WhenMatched().And(psql.Quote("w", "stock").NE(psql.Quote("s", "stock"))).ThenUpdate(
-					mm.SetCol("stock").ToExpr(psql.Quote("s", "stock")),
+					mm.SetCol("stock").To(psql.Quote("s", "stock")),
 				),
 				mm.WhenNotMatchedBySource().ThenDelete(),
 			),
@@ -94,7 +94,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("price").ToExpr(psql.Quote("u", "price")),
+					mm.SetCol("price").To(psql.Quote("u", "price")),
 				),
 				mm.WhenNotMatched().ThenInsert(
 					mm.Columns("id", "name", "price"),
@@ -115,7 +115,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("src", "id").EQ(psql.Quote("target_table", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("value").ToExpr(psql.Quote("src", "value")),
+					mm.SetCol("value").To(psql.Quote("src", "value")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO target_table
@@ -129,9 +129,9 @@ func TestMerge(t *testing.T) {
 					psql.Quote("u", "id").EQ(psql.Quote("employees", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
-					mm.SetCol("salary").ToExpr(psql.Quote("u", "salary")),
-					mm.SetCol("department").ToExpr(psql.Quote("u", "department")),
+					mm.SetCol("name").To(psql.Quote("u", "name")),
+					mm.SetCol("salary").To(psql.Quote("u", "salary")),
+					mm.SetCol("department").To(psql.Quote("u", "department")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO employees
@@ -145,8 +145,8 @@ func TestMerge(t *testing.T) {
 					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("updated_at").ToDefault(),
-					mm.SetCol("name").ToExpr(psql.Quote("u", "name")),
+					mm.SetCol("updated_at").To(psql.Raw("DEFAULT")),
+					mm.SetCol("name").To(psql.Quote("u", "name")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO products
@@ -201,7 +201,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
+					mm.SetCol("value").To(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `WITH source_data AS (SELECT "id", "value" FROM temp_table)
@@ -253,26 +253,6 @@ func TestMerge(t *testing.T) {
 				USING new_products AS "n" ON "n"."sku" = "products"."sku"
 				WHEN NOT MATCHED THEN INSERT ("id", "sku", "name") OVERRIDING USER VALUE VALUES ("n"."id", "n"."sku", "n"."name")`,
 		},
-		"merge with Recursive CTE": {
-			Query: psql.Merge(
-				mm.With("hierarchy").As(psql.Select(
-					sm.Columns("id", "parent_id", "name"),
-					sm.From("categories"),
-				)),
-				mm.Recursive(true),
-				mm.Into("target"),
-				mm.Using("hierarchy").As("h").On(
-					psql.Quote("h", "id").EQ(psql.Quote("target", "id")),
-				),
-				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("name").ToExpr(psql.Quote("h", "name")),
-				),
-			),
-			ExpectedSQL: `WITH RECURSIVE hierarchy AS (SELECT "id", "parent_id", "name" FROM categories)
-				MERGE INTO target
-				USING hierarchy AS "h" ON "h"."id" = "target"."id"
-				WHEN MATCHED THEN UPDATE SET "name" = "h"."name"`,
-		},
 		"merge with Only target": {
 			Query: psql.Merge(
 				mm.Into("parent_table"),
@@ -281,7 +261,7 @@ func TestMerge(t *testing.T) {
 					psql.Quote("s", "id").EQ(psql.Quote("parent_table", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
+					mm.SetCol("value").To(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `MERGE INTO ONLY parent_table
@@ -386,8 +366,8 @@ func TestMerge(t *testing.T) {
 				),
 				mm.WhenMatched().And(psql.Quote("s", "quantity").EQ(psql.Arg(0))).ThenDelete(),
 				mm.WhenMatched().And(psql.Quote("s", "quantity").GT(psql.Arg(0))).ThenUpdate(
-					mm.SetCol("quantity").ToExpr(psql.Quote("s", "quantity")),
-					mm.SetCol("updated_at").ToDefault(),
+					mm.SetCol("quantity").To(psql.Quote("s", "quantity")),
+					mm.SetCol("updated_at").To(psql.Raw("DEFAULT")),
 				),
 				mm.WhenNotMatchedByTarget().And(psql.Quote("s", "quantity").GT(psql.Arg(0))).ThenInsert(
 					mm.Columns("product_id", "quantity"),
@@ -418,8 +398,8 @@ func TestMerge(t *testing.T) {
 					psql.Quote("s", "id").EQ(psql.Quote("target", "id")),
 				),
 				mm.WhenMatched().ThenUpdate(
-					mm.SetCol("name").ToExpr(psql.Quote("s", "name")),
-					mm.SetCol("value").ToExpr(psql.Quote("s", "value")),
+					mm.SetCol("name").To(psql.Quote("s", "name")),
+					mm.SetCol("value").To(psql.Quote("s", "value")),
 				),
 			),
 			ExpectedSQL: `WITH source_data ("id", "name", "value") AS (SELECT "product_id", "product_name", "price" FROM products)

--- a/dialect/psql/mm/qm.go
+++ b/dialect/psql/mm/qm.go
@@ -12,30 +12,28 @@ import (
 	"github.com/stephenafamo/bob/mods"
 )
 
-// rowAssignment represents (columns...) = [ROW] (values...)
-type rowAssignment struct {
+// columnsAssignment represents (columns...) = [ROW] (values...) or (columns...) = (subquery)
+type columnsAssignment struct {
 	cols   []bob.Expression
-	values []bob.Expression
+	values []any // bob.Expression values or a single bob.Query for subquery
 	isRow  bool
 }
 
-func (r rowAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	// Write (col1, col2, ...)
+func (a columnsAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	w.WriteString("(")
-	colArgs, err := bob.ExpressSlice(ctx, w, d, start, r.cols, "", ", ", "")
+	colArgs, err := bob.ExpressSlice(ctx, w, d, start, a.cols, "", ", ", "")
 	if err != nil {
 		return nil, err
 	}
 
 	w.WriteString(") = ")
 
-	if r.isRow {
+	if a.isRow {
 		w.WriteString("ROW ")
 	}
 
-	// Write (val1, val2, ...)
 	w.WriteString("(")
-	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), r.values, "", ", ", "")
+	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), a.values, "", ", ", "")
 	if err != nil {
 		return nil, err
 	}
@@ -44,38 +42,9 @@ func (r rowAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Di
 	return append(colArgs, valArgs...), nil
 }
 
-// queryAssignment represents (columns...) = (subquery)
-type queryAssignment struct {
-	cols  []bob.Expression
-	query bob.Query
-}
-
-func (q queryAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	// Write (col1, col2, ...)
-	w.WriteString("(")
-	colArgs, err := bob.ExpressSlice(ctx, w, d, start, q.cols, "", ", ", "")
-	if err != nil {
-		return nil, err
-	}
-
-	w.WriteString(") = (")
-
-	// Write subquery
-	queryArgs, err := bob.Express(ctx, w, d, start+len(colArgs), q.query)
-	if err != nil {
-		return nil, err
-	}
-	w.WriteString(")")
-
-	return append(colArgs, queryArgs...), nil
-}
-
+// With adds a WITH clause (CTE) to the MERGE statement.
 func With(name string, columns ...string) dialect.CTEChain[*dialect.MergeQuery] {
 	return dialect.With[*dialect.MergeQuery](name, columns...)
-}
-
-func Recursive(r bool) bob.Mod[*dialect.MergeQuery] {
-	return mods.Recursive[*dialect.MergeQuery](r)
 }
 
 // Into specifies the target table for the MERGE statement
@@ -110,23 +79,25 @@ func Using(source any) UsingChain {
 	return UsingChain{source: source}
 }
 
-// UsingChain is a chain for building the USING clause
 type UsingChain struct {
 	source any
 	alias  string
 	only   bool
 }
 
+// As sets an alias for the USING source.
 func (u UsingChain) As(alias string) UsingChain {
 	u.alias = alias
 	return u
 }
 
+// Only adds the ONLY modifier to the USING source.
 func (u UsingChain) Only() UsingChain {
 	u.only = true
 	return u
 }
 
+// On sets the join condition for the USING clause.
 func (u UsingChain) On(condition bob.Expression) bob.Mod[*dialect.MergeQuery] {
 	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
 		m.Using = dialect.MergeUsing{
@@ -138,35 +109,51 @@ func (u UsingChain) On(condition bob.Expression) bob.Mod[*dialect.MergeQuery] {
 	})
 }
 
+// OnEQ is a shorthand for On(left.EQ(right)).
 func (u UsingChain) OnEQ(left, right bob.Expression) bob.Mod[*dialect.MergeQuery] {
 	return u.On(expr.X[dialect.Expression, dialect.Expression](left).EQ(right))
 }
 
-// WhenMatchedChain is a chain for building WHEN MATCHED and WHEN NOT MATCHED BY SOURCE clauses
-type WhenMatchedChain struct {
+// whenBase holds common fields for all WHEN chain types.
+type whenBase struct {
 	whenType  dialect.MergeWhenType
 	condition bob.Expression
 }
 
+func (b whenBase) andCondition(condition bob.Expression) whenBase {
+	if b.condition == nil {
+		b.condition = condition
+	} else {
+		b.condition = expr.X[dialect.Expression, dialect.Expression](b.condition).And(condition)
+	}
+	return b
+}
+
+func (b whenBase) thenDoNothing() bob.Mod[*dialect.MergeQuery] {
+	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
+		m.When = append(m.When, dialect.MergeWhen{
+			Type:      b.whenType,
+			Condition: b.condition,
+			Action:    dialect.MergeAction{Type: dialect.MergeActionDoNothing},
+		})
+	})
+}
+
+// WhenMatchedChain builds WHEN MATCHED and WHEN NOT MATCHED BY SOURCE clauses.
+// Available actions: UPDATE, DELETE, DO NOTHING.
+type WhenMatchedChain struct {
+	whenBase
+}
+
 // And adds a condition to the WHEN clause
 func (c WhenMatchedChain) And(condition bob.Expression) WhenMatchedChain {
-	if c.condition == nil {
-		c.condition = condition
-	} else {
-		c.condition = expr.X[dialect.Expression, dialect.Expression](c.condition).And(condition)
-	}
+	c.whenBase = c.andCondition(condition)
 	return c
 }
 
 // ThenDoNothing sets the action to DO NOTHING
 func (c WhenMatchedChain) ThenDoNothing() bob.Mod[*dialect.MergeQuery] {
-	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
-		m.When = append(m.When, dialect.MergeWhen{
-			Type:      c.whenType,
-			Condition: c.condition,
-			Action:    dialect.MergeAction{Type: dialect.MergeActionDoNothing},
-		})
-	})
+	return c.thenDoNothing()
 }
 
 // ThenDelete sets the action to DELETE
@@ -198,31 +185,21 @@ func (c WhenMatchedChain) ThenUpdate(sets ...bob.Mod[*UpdateAction]) bob.Mod[*di
 	})
 }
 
-// WhenNotMatchedChain is a chain for building WHEN NOT MATCHED [BY TARGET] clauses
+// WhenNotMatchedChain builds WHEN NOT MATCHED [BY TARGET] clauses.
+// Available actions: INSERT, DO NOTHING.
 type WhenNotMatchedChain struct {
-	whenType  dialect.MergeWhenType
-	condition bob.Expression
+	whenBase
 }
 
 // And adds a condition to the WHEN clause
 func (c WhenNotMatchedChain) And(condition bob.Expression) WhenNotMatchedChain {
-	if c.condition == nil {
-		c.condition = condition
-	} else {
-		c.condition = expr.X[dialect.Expression, dialect.Expression](c.condition).And(condition)
-	}
+	c.whenBase = c.andCondition(condition)
 	return c
 }
 
 // ThenDoNothing sets the action to DO NOTHING
 func (c WhenNotMatchedChain) ThenDoNothing() bob.Mod[*dialect.MergeQuery] {
-	return bob.ModFunc[*dialect.MergeQuery](func(m *dialect.MergeQuery) {
-		m.When = append(m.When, dialect.MergeWhen{
-			Type:      c.whenType,
-			Condition: c.condition,
-			Action:    dialect.MergeAction{Type: dialect.MergeActionDoNothing},
-		})
-	})
+	return c.thenDoNothing()
 }
 
 // ThenInsert sets the action to INSERT
@@ -258,82 +235,60 @@ func (c WhenNotMatchedChain) ThenInsertDefaultValues() bob.Mod[*dialect.MergeQue
 
 // WhenMatched creates a WHEN MATCHED clause chain
 func WhenMatched() WhenMatchedChain {
-	return WhenMatchedChain{whenType: dialect.MergeWhenMatched}
+	return WhenMatchedChain{whenBase{whenType: dialect.MergeWhenMatched}}
 }
 
 // WhenNotMatched creates a WHEN NOT MATCHED (BY TARGET) clause chain
 func WhenNotMatched() WhenNotMatchedChain {
-	return WhenNotMatchedChain{whenType: dialect.MergeWhenNotMatched}
+	return WhenNotMatchedChain{whenBase{whenType: dialect.MergeWhenNotMatched}}
 }
 
 // WhenNotMatchedByTarget is an alias for WhenNotMatched with explicit BY TARGET
 func WhenNotMatchedByTarget() WhenNotMatchedChain {
-	return WhenNotMatchedChain{whenType: dialect.MergeWhenNotMatchedByTarget}
+	return WhenNotMatchedChain{whenBase{whenType: dialect.MergeWhenNotMatchedByTarget}}
 }
+
+// WhenNotMatchedBySourceChain is an alias for WhenMatchedChain.
+// It exists for API clarity so WhenNotMatchedBySource() returns a chain name
+// that matches the clause kind, while reusing the same action set.
+// Available actions: UPDATE, DELETE, DO NOTHING.
+type WhenNotMatchedBySourceChain = WhenMatchedChain
 
 // WhenNotMatchedBySource creates a WHEN NOT MATCHED BY SOURCE clause chain
-func WhenNotMatchedBySource() WhenMatchedChain {
-	return WhenMatchedChain{whenType: dialect.MergeWhenNotMatchedBySource}
+func WhenNotMatchedBySource() WhenNotMatchedBySourceChain {
+	return WhenNotMatchedBySourceChain{whenBase{whenType: dialect.MergeWhenNotMatchedBySource}}
 }
 
-// UpdateAction is a builder for UPDATE action in MERGE
+// UpdateAction collects SET clauses for WHEN ... THEN UPDATE actions.
 type UpdateAction struct {
 	Set []any
 }
 
-// Set adds raw SET expressions to the UPDATE action
+func (u *UpdateAction) AppendSet(clauses ...any) {
+	u.Set = append(u.Set, clauses...)
+}
+
+// Set adds raw SET expressions to the UPDATE action.
 func Set(sets ...bob.Expression) bob.Mod[*UpdateAction] {
 	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
 		u.Set = append(u.Set, internal.ToAnySlice(sets)...)
 	})
 }
 
-// SetCol creates a single column setter: column = expression | DEFAULT
-func SetCol(column string) SetChain {
-	return SetChain{column: column}
+// SetCol creates a single column setter using mods.Set.
+// Usage:
+//
+//	mm.SetCol("name").To(psql.Quote("s", "name"))
+//	mm.SetCol("status").ToArg("active")
+func SetCol(column string) mods.Set[*UpdateAction] {
+	return mods.Set[*UpdateAction]{column}
 }
 
-// SetChain is a chain for building SET column = value
-type SetChain struct {
-	column string
-}
-
-// To sets column to a raw value: column = value
-func (s SetChain) To(value any) bob.Mod[*UpdateAction] {
-	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, expr.OP("=", expr.Quote(s.column), value))
-	})
-}
-
-// ToArg sets column to a parameterized value: column = $N
-func (s SetChain) ToArg(value any) bob.Mod[*UpdateAction] {
-	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, expr.OP("=", expr.Quote(s.column), expr.Arg(value)))
-	})
-}
-
-// ToExpr sets column to an expression: column = expression
-// Use psql.Quote("source_alias", "column") to reference source columns
-// Use psql.Quote("target_alias", "column") to reference target columns
-func (s SetChain) ToExpr(e bob.Expression) bob.Mod[*UpdateAction] {
-	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, expr.OP("=", expr.Quote(s.column), e))
-	})
-}
-
-// ToDefault sets column to DEFAULT: column = DEFAULT
-func (s SetChain) ToDefault() bob.Mod[*UpdateAction] {
-	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, expr.OP("=", expr.Quote(s.column), expr.Raw("DEFAULT")))
-	})
-}
-
-// SetCols creates a multi-column setter: (columns...) = ROW(...) | (subquery)
+// SetCols creates a multi-column setter: (columns...) = ROW(...) | (values...) | (subquery)
 func SetCols(columns ...string) SetColsChain {
 	return SetColsChain{columns: columns}
 }
 
-// SetColsChain is a chain for building SET (columns...) = ROW(...) | (subquery)
 type SetColsChain struct {
 	columns []string
 }
@@ -349,26 +304,25 @@ func (s SetColsChain) colExprs() []bob.Expression {
 // ToRow sets columns to ROW of expressions: (columns...) = ROW (expressions...)
 func (s SetColsChain) ToRow(values ...bob.Expression) bob.Mod[*UpdateAction] {
 	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, rowAssignment{cols: s.colExprs(), values: values, isRow: true})
+		u.Set = append(u.Set, columnsAssignment{cols: s.colExprs(), values: internal.ToAnySlice(values), isRow: true})
 	})
 }
 
-// ToExprs sets columns to expressions without ROW: (columns...) = (expressions...)
+// ToExprs sets columns to expressions: (columns...) = (expressions...)
 func (s SetColsChain) ToExprs(values ...bob.Expression) bob.Mod[*UpdateAction] {
 	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, rowAssignment{cols: s.colExprs(), values: values, isRow: false})
+		u.Set = append(u.Set, columnsAssignment{cols: s.colExprs(), values: internal.ToAnySlice(values)})
 	})
 }
 
 // ToQuery sets columns from a subquery: (columns...) = (subquery)
 func (s SetColsChain) ToQuery(q bob.Query) bob.Mod[*UpdateAction] {
 	return bob.ModFunc[*UpdateAction](func(u *UpdateAction) {
-		u.Set = append(u.Set, queryAssignment{cols: s.colExprs(), query: q})
+		u.Set = append(u.Set, columnsAssignment{cols: s.colExprs(), values: []any{q}})
 	})
 }
 
-// InsertAction is a builder for INSERT action in MERGE
-// Supports: INSERT [(columns...)] [OVERRIDING {SYSTEM|USER} VALUE] {VALUES (...) | DEFAULT VALUES}
+// InsertAction collects options for WHEN ... THEN INSERT actions.
 type InsertAction struct {
 	Columns    []string
 	Values     []bob.Expression
@@ -387,7 +341,7 @@ func Columns(columns ...string) bob.Mod[*InsertAction] {
 // Expressions can reference source data columns (for WHEN NOT MATCHED BY TARGET)
 // Use psql.Quote("source_alias", "column") to reference source columns
 // Use psql.Arg(value) for literal values
-// Use expr.Raw("DEFAULT") for DEFAULT keyword
+// Use psql.Raw("DEFAULT") for DEFAULT keyword
 func Values(values ...bob.Expression) bob.Mod[*InsertAction] {
 	return bob.ModFunc[*InsertAction](func(i *InsertAction) {
 		i.Values = append(i.Values, values...)

--- a/dialect/psql/table_test.go
+++ b/dialect/psql/table_test.go
@@ -232,8 +232,8 @@ func TestMerge(t *testing.T) {
 			Quote("u", "id").EQ(Quote("users", "id")),
 		),
 		mm.WhenMatched().ThenUpdate(
-			mm.SetCol("name").ToExpr(Quote("u", "name")),
-			mm.SetCol("email").ToExpr(Quote("u", "email")),
+			mm.SetCol("name").To(Quote("u", "name")),
+			mm.SetCol("email").To(Quote("u", "email")),
 		),
 		mm.WhenNotMatched().ThenInsert(
 			mm.Columns("id", "name", "email"),
@@ -307,7 +307,7 @@ func TestTableMergeWithVersion(t *testing.T) {
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
 			mm.WhenMatched().ThenUpdate(
-				mm.SetCol("name").ToExpr(Quote("s", "name")),
+				mm.SetCol("name").To(Quote("s", "name")),
 			),
 		)
 
@@ -334,7 +334,7 @@ func TestTableMergeWithVersion(t *testing.T) {
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
 			mm.WhenMatched().ThenUpdate(
-				mm.SetCol("name").ToExpr(Quote("s", "name")),
+				mm.SetCol("name").To(Quote("s", "name")),
 			),
 		)
 
@@ -361,7 +361,7 @@ func TestTableMergeWithVersion(t *testing.T) {
 				Quote("s", "id").EQ(Quote("users", "id")),
 			),
 			mm.WhenMatched().ThenUpdate(
-				mm.SetCol("name").ToExpr(Quote("s", "name")),
+				mm.SetCol("name").To(Quote("s", "name")),
 			),
 		)
 


### PR DESCRIPTION
### Changes

**WHEN chains**

Introduced a shared `whenBase` struct and split the chain logic so that:
- `WhenMatchedChain` (returned by `WhenMatched()`, `WhenNotMatchedBySource()`) — exposes `ThenUpdate`, `ThenDelete`, `ThenDoNothing`
- `WhenNotMatchedChain` (returned by `WhenNotMatched()`, `WhenNotMatchedByTarget()`) — exposes `ThenInsert`, `ThenInsertDefaultValues`, `ThenDoNothing`

Previously both chain types already existed but had identical structure; this change extracts common logic into `whenBase` to reduce duplication.

**`SetCol` now reuses `mods.Set`**

`SetCol` returns `mods.Set[*UpdateAction]` (the same generic type used in `um` for UPDATE queries). This is enabled by adding `AppendSet` method to `UpdateAction`. The custom `SetChain` type with `To`/`ToArg`/`ToExpr`/`ToDefault` methods is removed.

**Unified `columnsAssignment`**

Merged the separate `rowAssignment` and `queryAssignment` types into a single `columnsAssignment` that handles both ROW expressions and subqueries via `[]any`.

**Removed `Recursive`**

`mm.Recursive()` is removed because PostgreSQL does not support `WITH RECURSIVE` in MERGE statements.

### Breaking Changes

| Before | After | Rationale |
|--------|-------|-----------|
| `mm.SetCol("x").ToExpr(val)` | `mm.SetCol("x").To(val)` | `.To(any)` already accepts any expression; `ToExpr` was redundant |
| `mm.SetCol("x").ToDefault()` | `mm.SetCol("x").To(psql.Raw("DEFAULT"))` | Eliminates special-case method; aligns with `mods.Set` pattern |
| `mm.SetCol("x").ToArg(val)` | `mm.SetCol("x").ToArg(val)` | *(unchanged — still available)* |
| `mm.Recursive(true)` | *(removed)* | MERGE does not support WITH RECURSIVE per PostgreSQL spec |

The `WhenMatchedChain`/`WhenNotMatchedChain` types retain the same method names as before. The only behavioral constraint added is that `ThenInsert`/`ThenInsertDefaultValues` are no longer available on `WhenMatchedChain`, and `ThenUpdate`/`ThenDelete` are no longer available on `WhenNotMatchedChain` — matching what PostgreSQL actually accepts.

### Why these breaking changes?

1. **`ToExpr` removal** — `mods.Set.To` accepts `any`, which already covers `bob.Expression`. Having a separate `ToExpr` forced users to choose between two identical methods. Reusing `mods.Set` aligns mm with the rest of the codebase (e.g. `um.SetCol`).

2. **`ToDefault` removal** — DEFAULT is simply a raw SQL keyword. Treating it as `To(psql.Raw("DEFAULT"))` is consistent with how other "special" values are handled, and doesn't need a dedicated method.

3. **`Recursive` removal** — exposing this function was misleading since the generated SQL would be rejected by PostgreSQL. Removing it prevents runtime errors.