### PR TITLE
fix: a relation should only be required if all columns require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
 
+### Fixed
+
+- Fix generated factory requiredness for relationships with mixed nullable composite foreign key columns.
+
 ## [v0.43.0] - 2026-04-29
 
 ### Added

--- a/gen/drivers/table.go
+++ b/gen/drivers/table.go
@@ -109,12 +109,12 @@ func (t Table[C, I]) RelIsRequired(rel orm.Relationship) bool {
 	}
 
 	for _, colName := range firstSide.FromColumns {
-		if !t.GetColumn(colName).Nullable {
-			return true
+		if t.GetColumn(colName).Nullable {
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 // Used in templates to know if the given table is a join table for this relationship

--- a/gen/drivers/table.go
+++ b/gen/drivers/table.go
@@ -104,7 +104,7 @@ func (t Table[C, I]) RelIsRequired(rel orm.Relationship) bool {
 	}
 
 	firstSide := rel.Sides[0]
-	if firstSide.Modify == "to" {
+	if firstSide.Modify == "to" || len(firstSide.FromColumns) == 0 {
 		return false
 	}
 

--- a/gen/drivers/table_test.go
+++ b/gen/drivers/table_test.go
@@ -2,6 +2,8 @@ package drivers
 
 import (
 	"testing"
+
+	"github.com/stephenafamo/bob/orm"
 )
 
 func TestGetTable(t *testing.T) {
@@ -95,5 +97,105 @@ func TestCanSoftDelete(t *testing.T) {
 		if got := table.CanSoftDelete("deleted_at"); got != test.Can {
 			t.Errorf("%d) wrong: %t", i, got)
 		}
+	}
+}
+
+func TestRelIsRequired(t *testing.T) {
+	t.Parallel()
+
+	table := Table[any, any]{
+		Columns: []Column{
+			{Name: "required_one", Nullable: false},
+			{Name: "required_two", Nullable: false},
+			{Name: "optional_one", Nullable: true},
+		},
+	}
+
+	tests := []struct {
+		name string
+		rel  orm.Relationship
+		want bool
+	}{
+		{
+			name: "never required",
+			rel: orm.Relationship{
+				NeverRequired: true,
+				Sides: []orm.RelSide{{
+					Modify:      "from",
+					FromColumns: []string{"required_one"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "modify to",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify:      "to",
+					FromColumns: []string{"required_one"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "empty from columns",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify: "from",
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "single required column",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify:      "from",
+					FromColumns: []string{"required_one"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "single optional column",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify:      "from",
+					FromColumns: []string{"optional_one"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "all composite columns required",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify:      "from",
+					FromColumns: []string{"required_one", "required_two"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "mixed composite columns optional",
+			rel: orm.Relationship{
+				Sides: []orm.RelSide{{
+					Modify:      "from",
+					FromColumns: []string{"required_one", "optional_one"},
+				}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := table.RelIsRequired(tt.rel); got != tt.want {
+				t.Fatalf("RelIsRequired() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }

--- a/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
+++ b/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
@@ -9,6 +9,7 @@ func (m {{$tAlias.DownSingular}}Mods) WithParentsCascading() {{$tAlias.UpSingula
     ctx = {{$tAlias.DownSingular}}WithParentsCascadingCtx.WithValue(ctx, true)
     {{range $.Relationships.Get $table.Key -}}
     {{- if .IsToMany -}}{{continue}}{{end -}}
+    {{- if not ($table.RelIsRequired .) -}}{{continue}}{{end -}}
     {{- $ftable := $.Aliases.Table .Foreign -}}
     {{- $relAlias := $tAlias.Relationship .Name -}}
     {

--- a/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
+++ b/gen/templates/factory/table/012_rel_to_one_mods.go.tpl
@@ -9,7 +9,6 @@ func (m {{$tAlias.DownSingular}}Mods) WithParentsCascading() {{$tAlias.UpSingula
     ctx = {{$tAlias.DownSingular}}WithParentsCascadingCtx.WithValue(ctx, true)
     {{range $.Relationships.Get $table.Key -}}
     {{- if .IsToMany -}}{{continue}}{{end -}}
-    {{- if not ($table.RelIsRequired .) -}}{{continue}}{{end -}}
     {{- $ftable := $.Aliases.Table .Foreign -}}
     {{- $relAlias := $tAlias.Relationship .Name -}}
     {


### PR DESCRIPTION
## What changed

This updates generated relation metadata so a relationship is marked required only when all columns in the relationship are required. Relationships without foreign-key columns are explicitly treated as not required.

It keeps `WithParentsCascading()` cascading through all to-one relationships when explicitly requested.

## Why

A relation with mixed required and optional columns should not be treated as required as soon as any single column is required. However, explicit parent cascading should still include optional parents because generated factory and unique-constraint workflows rely on that behavior.

## Validation

- `go test ./gen/drivers ./gen`
- `go test ./gen/bobgen-sqlite/driver -run 'TestSQLite/driver/modernc/generate' -count=1 -timeout=20m`
- `go test ./...` was also run; it hit Go's default 10m timeout in `TestSQLite/driver/modernc/generate`, and the timed-out subtest passed when rerun with a longer timeout.
