### PR TITLE
fix: template for random_factory imports unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
 
+### Fixed
+
+- Avoid unnecessary imports in generated random factory code when a type has no random expression.
+
 ## [v0.43.0] - 2026-04-29
 
 ### Added

--- a/gen/templates/factory/bobfactory_random.bob.go.tpl
+++ b/gen/templates/factory/bobfactory_random.bob.go.tpl
@@ -19,12 +19,12 @@ var defaultFaker = faker.New()
 
 {{range $colTyp := keys $doneTypes | sortAlpha -}}
     {{- $typDef := $.Types.Index $colTyp -}}
-    {{- $typ := $.Types.Get $.CurrentPackage $.Importer $colTyp -}}
     {{- if not $typDef.RandomExpr -}}{{continue}}{{/*
       Ensures that compilation fails.
       Users of custom types can decide to use a non-random expression
       but this would be a conscious decision.
     */}}{{- end -}}
+    {{- $typ := $.Types.Get $.CurrentPackage $.Importer $colTyp -}}
     {{- $.Importer.ImportList $typDef.RandomExprImports -}}
     func random_{{normalizeType $colTyp}}(f *faker.Faker, limits ...string) {{$typ}} {
       if f == nil {


### PR DESCRIPTION
## What changed

This narrows the random factory template import condition so it only imports when the generated code actually needs the dependency.

## Why

The previous template condition could include an unnecessary import in generated random factory code.

## Validation

- `go test ./gen`