### PR TITLE
Remove As function documentation from starters

### DIFF
--- a/website/docs/query-builder/starters.md
+++ b/website/docs/query-builder/starters.md
@@ -88,11 +88,4 @@ There are a number of common starter functions shared by all supported dialects:
   psql.Raw("WHERE a = ?", "something")
   ```
 
-- `As(e Expression, alias string)`: For aliasing expressions.
-
-  ```go
-  // SQL: pilots as "p"
-  psql.As("pilots", "p")
-  ```
-
 See dialect documentation for extra starters


### PR DESCRIPTION
the As function was removed in [this commit](https://github.com/stephenafamo/bob/commit/de735d70dd8d81e419098e6546a030eeb3a44e7d) but is still documented.