### PR TITLE
More consistent naming of generated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Renamed the generated `ThenLoadCount` variable to `SelectThenLoadCount` for naming consistency with `SelectThenLoad`/`InsertThenLoad`/`UpdateThenLoad`. Update call sites from `models.ThenLoadCount.X.Y` to `models.SelectThenLoadCount.X.Y`. (thanks @jacobmolby)
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
 

--- a/gen/templates/counts/bob_counts.bob.go.tpl
+++ b/gen/templates/counts/bob_counts.bob.go.tpl
@@ -9,7 +9,7 @@
 {{block "helpers/count_variables" . -}}
 var (
 	PreloadCount = getPreloadCount()
-	ThenLoadCount = getThenLoadCount[*dialect.SelectQuery]()
+	SelectThenLoadCount = getThenLoadCount[*dialect.SelectQuery]()
 	InsertThenLoadCount = getThenLoadCount[*dialect.InsertQuery]()
 )
 {{- end}}

--- a/gen/templates/counts/bob_counts.bob_test.go.tpl
+++ b/gen/templates/counts/bob_counts.bob_test.go.tpl
@@ -48,15 +48,15 @@ func Test{{$tAlias.UpSingular}}LoadCountMethods(t *testing.T) {
 	{{end}}
 }
 
-// Test that ThenLoadCount has {{$tAlias.UpSingular}} with methods for to-many relationships
-func TestThenLoadCount{{$tAlias.UpSingular}}(t *testing.T) {
-	_ = ThenLoadCount.{{$tAlias.UpSingular}}
+// Test that SelectThenLoadCount has {{$tAlias.UpSingular}} with methods for to-many relationships
+func TestSelectThenLoadCount{{$tAlias.UpSingular}}(t *testing.T) {
+	_ = SelectThenLoadCount.{{$tAlias.UpSingular}}
 
 	{{range $rel := $rels -}}
 	{{- if not $rel.IsToMany}}{{continue}}{{end -}}
 	{{- $relAlias := $tAlias.Relationship $rel.Name}}
 	// Verify {{$relAlias}} loader exists
-	_ = ThenLoadCount.{{$tAlias.UpSingular}}.{{$relAlias}}
+	_ = SelectThenLoadCount.{{$tAlias.UpSingular}}.{{$relAlias}}
 	{{end}}
 }
 

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -567,8 +567,8 @@ func TestPreloadCountUserVideos(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountUserVideos tests using ThenLoadCount to load counts in a separate query
-func TestThenLoadCountUserVideos(t *testing.T) {
+// TestSelectThenLoadCountUserVideos tests using SelectThenLoadCount to load counts in a separate query
+func TestSelectThenLoadCountUserVideos(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -591,12 +591,12 @@ func TestThenLoadCountUserVideos(t *testing.T) {
 		}
 	}
 
-	// Query users with ThenLoadCount to load video counts in a separate query
+	// Query users with SelectThenLoadCount to load video counts in a separate query
 	users, err := models.Users.Query(
-		models.ThenLoadCount.User.Videos(),
+		models.SelectThenLoadCount.User.Videos(),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 3 {
@@ -665,8 +665,8 @@ func TestPreloadCountWithFilter(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountWithFilter tests ThenLoadCount with filtering mods
-func TestThenLoadCountWithFilter(t *testing.T) {
+// TestSelectThenLoadCountWithFilter tests SelectThenLoadCount with filtering mods
+func TestSelectThenLoadCountWithFilter(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -690,16 +690,16 @@ func TestThenLoadCountWithFilter(t *testing.T) {
 		videoIDs = append(videoIDs, video.ID)
 	}
 
-	// Query user with ThenLoadCount filtering for videos with ID > first video ID
+	// Query user with SelectThenLoadCount filtering for videos with ID > first video ID
 	// This should count only 4 videos
 	users, err := models.Users.Query(
 		models.SelectWhere.Users.ID.EQ(user.ID),
-		models.ThenLoadCount.User.Videos(
+		models.SelectThenLoadCount.User.Videos(
 			models.SelectWhere.Videos.ID.GT(videoIDs[0]),
 		),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with filtered ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with filtered SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 1 {

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -567,8 +567,8 @@ func TestPreloadCountUserVideos(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountUserVideos tests using ThenLoadCount to load counts in a separate query
-func TestThenLoadCountUserVideos(t *testing.T) {
+// TestSelectThenLoadCountUserVideos tests using SelectThenLoadCount to load counts in a separate query
+func TestSelectThenLoadCountUserVideos(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -591,12 +591,12 @@ func TestThenLoadCountUserVideos(t *testing.T) {
 		}
 	}
 
-	// Query users with ThenLoadCount to load video counts in a separate query
+	// Query users with SelectThenLoadCount to load video counts in a separate query
 	users, err := models.Users.Query(
-		models.ThenLoadCount.User.Videos(),
+		models.SelectThenLoadCount.User.Videos(),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 3 {
@@ -665,8 +665,8 @@ func TestPreloadCountWithFilter(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountWithFilter tests ThenLoadCount with filtering mods
-func TestThenLoadCountWithFilter(t *testing.T) {
+// TestSelectThenLoadCountWithFilter tests SelectThenLoadCount with filtering mods
+func TestSelectThenLoadCountWithFilter(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -690,16 +690,16 @@ func TestThenLoadCountWithFilter(t *testing.T) {
 		videoIDs = append(videoIDs, video.ID)
 	}
 
-	// Query user with ThenLoadCount filtering for videos with ID > first video ID
+	// Query user with SelectThenLoadCount filtering for videos with ID > first video ID
 	// This should count only 4 videos
 	users, err := models.Users.Query(
 		models.SelectWhere.Users.ID.EQ(user.ID),
-		models.ThenLoadCount.User.Videos(
+		models.SelectThenLoadCount.User.Videos(
 			models.SelectWhere.Videos.ID.GT(videoIDs[0]),
 		),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with filtered ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with filtered SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 1 {

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -536,8 +536,8 @@ func TestPreloadCountUserVideos(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountUserVideos tests using ThenLoadCount to load counts in a separate query
-func TestThenLoadCountUserVideos(t *testing.T) {
+// TestSelectThenLoadCountUserVideos tests using SelectThenLoadCount to load counts in a separate query
+func TestSelectThenLoadCountUserVideos(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -560,12 +560,12 @@ func TestThenLoadCountUserVideos(t *testing.T) {
 		}
 	}
 
-	// Query users with ThenLoadCount to load video counts in a separate query
+	// Query users with SelectThenLoadCount to load video counts in a separate query
 	users, err := models.Users.Query(
-		models.ThenLoadCount.User.Videos(),
+		models.SelectThenLoadCount.User.Videos(),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 3 {
@@ -637,8 +637,8 @@ func TestPreloadCountWithFilter(t *testing.T) {
 	}
 }
 
-// TestThenLoadCountWithFilter tests ThenLoadCount with filtering mods
-func TestThenLoadCountWithFilter(t *testing.T) {
+// TestSelectThenLoadCountWithFilter tests SelectThenLoadCount with filtering mods
+func TestSelectThenLoadCountWithFilter(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")
 	}
@@ -666,15 +666,15 @@ func TestThenLoadCountWithFilter(t *testing.T) {
 		).CreateOrFail(ctx, t, tx)
 	}
 
-	// Query user1 with ThenLoadCount filtering for videos belonging to user1
+	// Query user1 with SelectThenLoadCount filtering for videos belonging to user1
 	users, err := models.Users.Query(
 		models.SelectWhere.Users.ID.EQ(user1.ID),
-		models.ThenLoadCount.User.Videos(
+		models.SelectThenLoadCount.User.Videos(
 			models.SelectWhere.Videos.UserID.EQ(user1.ID),
 		),
 	).All(ctx, tx)
 	if err != nil {
-		t.Fatalf("Error querying users with filtered ThenLoadCount: %v", err)
+		t.Fatalf("Error querying users with filtered SelectThenLoadCount: %v", err)
 	}
 
 	if len(users) != 1 {


### PR DESCRIPTION
The `ThenLoadCount` should probably have been called `SelectThenLoadCount` for consistency with the other methods. This fixes it. 