### PR TITLE
feat: add Unqualified() and UnquotedLast() methods to Quote expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added PostgreSQL `MERGE` statement SQL parser used for sql-to-code generation (thanks @atzedus)
+- Added `Unqualified()` method to quoted expressions returned by `Quote()` across all dialects. Returns a new expression containing only the last identifier part. (thanks @atzedus)
+- Added `UnquotedLast()` method to quoted expressions for extracting the last identifier as a string. (thanks @atzedus)
 
 ### Changed
 

--- a/expr/chain.go
+++ b/expr/chain.go
@@ -16,6 +16,23 @@ func (x Chain[T, B]) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	return bob.Express(ctx, w, d, start, x.Base)
 }
 
+// Unqualified returns a new expression containing only the last qualified part.
+// If the base expression doesn't support Unqualified, returns the base expression unchanged.
+func (x Chain[T, B]) Unqualified() T {
+	if u, ok := x.Base.(interface{ Unqualified() bob.Expression }); ok {
+		return X[T, B](u.Unqualified())
+	}
+	return X[T, B](x.Base)
+}
+
+// UnquotedLast returns the last element as a raw unquoted string, or empty string if not supported.
+func (x Chain[T, B]) UnquotedLast() string {
+	if u, ok := x.Base.(interface{ UnquotedLast() string }); ok {
+		return u.UnquotedLast()
+	}
+	return ""
+}
+
 // IS DISTINCT FROM
 func (x Chain[T, B]) IsDistinctFrom(exp bob.Expression) T {
 	return X[T, B](Join{Exprs: []bob.Expression{x.Base, isDistinctFrom, exp}})

--- a/expr/quote.go
+++ b/expr/quote.go
@@ -13,6 +13,7 @@ func Quote(aa ...string) bob.Expression {
 		if v == "" {
 			continue
 		}
+
 		ss = append(ss, v)
 	}
 
@@ -21,6 +22,24 @@ func Quote(aa ...string) bob.Expression {
 
 // quoted and joined... something like "users"."id"
 type quoted []string
+
+// Unqualified returns a quoted expression containing only the last identifier part.
+func (q quoted) Unqualified() quoted {
+	if len(q) == 0 {
+		return quoted{}
+	}
+
+	return quoted{q[len(q)-1]}
+}
+
+// UnquotedLast returns the last element of the quoted slice, or empty string if empty.
+func (q quoted) UnquotedLast() string {
+	if len(q) == 0 {
+		return ""
+	}
+
+	return q[len(q)-1]
+}
 
 func (q quoted) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	if len(q) == 0 {


### PR DESCRIPTION
- Added `Unqualified()` method to quoted expressions returned by `Quote()` — returns a new expression containing only the last identifier part
- Added `UnquotedLast()` method to extract the last identifier as a string
- Both methods available on all dialect quote expressions (psql, mysql, sqlite)

**Why this is needed**

Generated column structures use `Quote()` extensively to create qualified column references like `"schema"."table"."column"`. The new methods allow users to extract just the unqualified column name without the full qualification when needed.

**Example usage**

```go
// Old approach
mm.Columns("status") // not type-safe or dbinfo plugin needed to use

// New approach with extracted unqualified name
mm.Columns(dbmodels.AuditEvents.Columns.Status.UnquotedLast())

sm.Where(dbmodels.Users.Columns.ID.Unqualified().EQ(psql.Arg(1)) // SQL: "id" = $1
```

This avoids accidental double-quoting and makes the generated column API more ergonomic. The `Unqualified()` method returns an expression that can be further chained or rendered as SQL, while `UnquotedLast()` provides direct string access for simple cases.