### PR TITLE
Allow .As() directly on query builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added PostgreSQL `MERGE` statement SQL parser used for sql-to-code generation (thanks @atzedus)
+- Added `As(alias)` method to `bob.BaseQuery`, allowing queries (e.g. `mysql.Select(...)`) to be aliased directly when used as subqueries in a column list. (thanks @jacobmolby)
 
 ### Changed
 

--- a/dialect/mysql/select_test.go
+++ b/dialect/mysql/select_test.go
@@ -98,6 +98,21 @@ func TestSelect(t *testing.T) {
 				sm.GroupBy("status"),
 			),
 		},
+		"select with aliased subquery in columns": {
+			ExpectedSQL: "SELECT COUNT(*) AS `all`, (SELECT COUNT(*) AS `c` FROM teams WHERE (active = ?)) AS `active_count` FROM teams",
+			Query: mysql.Select(
+				sm.Columns(
+					mysql.Raw("COUNT(*)").As("all"),
+					mysql.Select(
+						sm.Columns(mysql.Raw("COUNT(*)").As("c")),
+						sm.From("teams"),
+						sm.Where(mysql.Raw("active").EQ(mysql.Arg(true))),
+					).As("active_count"),
+				),
+				sm.From("teams"),
+			),
+			ExpectedArgs: []any{true},
+		},
 		"select with grouped IN": {
 			Query: mysql.Select(
 				sm.Columns("id", "name"),

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -139,6 +139,21 @@ func TestSelect(t *testing.T) {
 				sm.GroupBy("status"),
 			),
 		},
+		"select with aliased subquery in columns": {
+			ExpectedSQL: `SELECT COUNT(*) AS "all", (SELECT COUNT(*) AS "c" FROM teams WHERE (active = $1)) AS "active_count" FROM teams`,
+			Query: psql.Select(
+				sm.Columns(
+					psql.Raw("COUNT(*)").As("all"),
+					psql.Select(
+						sm.Columns(psql.Raw("COUNT(*)").As("c")),
+						sm.From("teams"),
+						sm.Where(psql.Raw("active").EQ(psql.Arg(true))),
+					).As("active_count"),
+				),
+				sm.From("teams"),
+			),
+			ExpectedArgs: []any{true},
+		},
 		"select with grouped IN": {
 			Query: psql.Select(
 				sm.Columns("id", "name"),

--- a/dialect/sqlite/select_test.go
+++ b/dialect/sqlite/select_test.go
@@ -105,6 +105,21 @@ func TestSelect(t *testing.T) {
 				sm.GroupBy("status"),
 			),
 		},
+		"select with aliased subquery in columns": {
+			ExpectedSQL: `SELECT COUNT(*) AS "all", (SELECT COUNT(*) AS "c" FROM teams WHERE (active = ?1)) AS "active_count" FROM teams`,
+			Query: sqlite.Select(
+				sm.Columns(
+					sqlite.Raw("COUNT(*)").As("all"),
+					sqlite.Select(
+						sm.Columns(sqlite.Raw("COUNT(*)").As("c")),
+						sm.From("teams"),
+						sm.Where(sqlite.Raw("active").EQ(sqlite.Arg(true))),
+					).As("active_count"),
+				),
+				sm.From("teams"),
+			),
+			ExpectedArgs: []any{true},
+		},
 		"select with grouped IN": {
 			Query: sqlite.Select(
 				sm.Columns("id", "name"),

--- a/query.go
+++ b/query.go
@@ -132,6 +132,27 @@ func (b BaseQuery[E]) WriteQuery(ctx context.Context, w io.StringWriter, start i
 	return b.Expression.WriteSQL(ctx, w, b.Dialect, start)
 }
 
+// As wraps the query in parentheses and aliases it: (<query>) AS "alias".
+// Useful when using a query as a correlated subquery in a column list.
+func (b BaseQuery[E]) As(alias string) Expression {
+	return aliasedQuery{inner: b, alias: alias}
+}
+
+type aliasedQuery struct {
+	inner Expression
+	alias string
+}
+
+func (a aliasedQuery) WriteSQL(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error) {
+	args, err := a.inner.WriteSQL(ctx, w, d, start)
+	if err != nil {
+		return args, err
+	}
+	w.WriteString(" AS ")
+	d.WriteQuoted(w, a.alias)
+	return args, nil
+}
+
 // Satisfies the Expression interface, but uses its own dialect instead
 // of the dialect passed to it
 func (b BaseQuery[E]) WriteSQL(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error) {


### PR DESCRIPTION
Adds an `As(alias string) Expression` method to `bob.BaseQuery`, so SELECT (and other queries) can be aliased directly when used as subqueries in a column list.

**Before:**

```go
mysql.Select(
    sm.Columns(
        mysql.Raw("COUNT(*)").As("all"),
        mysql.Group(mysql.Select(
            sm.Columns(mysql.Raw("COUNT(*)").As("c")),
            sm.From("teams"),
            sm.Where(mysql.Raw("active").EQ(mysql.Arg(true))),
        )).As("active_count"),
    ),
    sm.From("teams"),
)
```

**After:**

```go
mysql.Select(
    sm.Columns(
        mysql.Raw("COUNT(*)").As("all"),
        mysql.Select(
            sm.Columns(mysql.Raw("COUNT(*)").As("c")),
            sm.From("teams"),
            sm.Where(mysql.Raw("active").EQ(mysql.Arg(true))),
        ).As("active_count"),
    ),
    sm.From("teams"),
)
```

Generated SQL is identical:

```sql
SELECT COUNT(*) AS `all`, (SELECT COUNT(*) AS `c` FROM teams WHERE (active = ?)) AS `active_count` FROM teams
```

Works across all dialects (mysql/psql/sqlite). Existing `Group(...).As(...)` still works.