### PR TITLE
feat: add unqualified column type API and migration notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL `MERGE` statement SQL parser used for sql-to-code generation (thanks @atzedus)
 - Added `As(alias)` method to `bob.BaseQuery`, allowing queries (e.g. `mysql.Select(...)`) to be aliased directly when used as subqueries in a column list. (thanks @jacobmolby)
 - Added unqualified columns API: generated column structures now provide Alias(), Name(), and AliasedAs(alias) methods for easier column metadata access and aliasing. (thanks @atzedus)
+- Added `bob.ParensOmitter` interface with `ShouldOmitParens() bool` to let expressions opt out of automatic parenthesis wrapping in expression builders. (thanks @atzedus)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added PostgreSQL `MERGE` statement SQL parser used for sql-to-code generation (thanks @atzedus)
 - Added `As(alias)` method to `bob.BaseQuery`, allowing queries (e.g. `mysql.Select(...)`) to be aliased directly when used as subqueries in a column list. (thanks @jacobmolby)
-- Added unqualified columns API: generated column structures now provide Alias(), Name(), and AliasedAs(alias) methods for easier column metadata access and aliasing. (thanks @atzedus)
+- Added unqualified columns API: generated column structures now provide Alias(), Name(), AliasedAs(alias) and Unqualified() methods for easier column metadata access and aliasing. (thanks @atzedus)
 - Added `bob.ParensOmitter` interface with `ShouldOmitParens() bool` to let expressions opt out of automatic parenthesis wrapping in expression builders. (thanks @atzedus)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added PostgreSQL `MERGE` statement SQL parser used for sql-to-code generation (thanks @atzedus)
 - Added `As(alias)` method to `bob.BaseQuery`, allowing queries (e.g. `mysql.Select(...)`) to be aliased directly when used as subqueries in a column list. (thanks @jacobmolby)
+- Added unqualified columns API: generated column structures now provide Alias(), Name(), and AliasedAs(alias) methods for easier column metadata access and aliasing. (thanks @atzedus)
 
 ### Changed
 
 - **BREAKING:** Renamed the generated `ThenLoadCount` variable to `SelectThenLoadCount` for naming consistency with `SelectThenLoad`/`InsertThenLoad`/`UpdateThenLoad`. Update call sites from `models.ThenLoadCount.X.Y` to `models.SelectThenLoadCount.X.Y`. (thanks @jacobmolby)
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
+- **BREAKING:** Generated column accessor fields in *Columns structs (e.g., models.Users.Columns.ID, models.Users.Columns.Name) now return a dialect-specific column type (e.g., userColumn) that embeds dialect.Expression, instead of directly returning dialect.Expression. This allows access to the new Alias(), Name(), and AliasedAs() methods. For code that previously used the column accessors directly as expressions, simply add .Expression to access the underlying expression: models.Users.Columns.ID becomes models.Users.Columns.ID.Expression. (thanks @atzedus)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Renamed the generated `ThenLoadCount` variable to `SelectThenLoadCount` for naming consistency with `SelectThenLoad`/`InsertThenLoad`/`UpdateThenLoad`. Update call sites from `models.ThenLoadCount.X.Y` to `models.SelectThenLoadCount.X.Y`. (thanks @jacobmolby)
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
-- **BREAKING:** Generated column accessor fields in *Columns structs (e.g., models.Users.Columns.ID, models.Users.Columns.Name) now return a dialect-specific column type (e.g., userColumn) that embeds dialect.Expression, instead of directly returning dialect.Expression. This allows access to the new Alias(), Name(), and AliasedAs() methods. For code that previously used the column accessors directly as expressions, simply add .Expression to access the underlying expression: models.Users.Columns.ID becomes models.Users.Columns.ID.Expression. (thanks @atzedus)
+- **BREAKING:** Generated `*Columns` accessor fields now return a dialect-specific wrapper type (e.g., `userColumn`) instead of plain `dialect.Expression`. The wrapper still implements `dialect.Expression` and avoids extra auto-parentheses in expression builders. Use `.Expression` only when you explicitly need the embedded expression value. (thanks @atzedus)
 
 ### Fixed
 

--- a/dialect/psql/merge_test.go
+++ b/dialect/psql/merge_test.go
@@ -9,12 +9,6 @@ import (
 	testutils "github.com/stephenafamo/bob/test/utils"
 )
 
-type wrappedExpr struct {
-	psql.Expression
-}
-
-func (wrappedExpr) ShouldOmitParens() bool { return true }
-
 func TestMerge(t *testing.T) {
 	examples := testutils.Testcases{
 		"simple merge with update and insert": {
@@ -291,19 +285,6 @@ func TestMerge(t *testing.T) {
 				mm.Into("target"),
 				mm.Using("source").As("s").OnEQ(
 					psql.Quote("s", "id"),
-					psql.Quote("target", "id"),
-				),
-				mm.WhenMatched().ThenDoNothing(),
-			),
-			ExpectedSQL: `MERGE INTO target
-				USING source AS "s" ON "s"."id" = "target"."id"
-				WHEN MATCHED THEN DO NOTHING`,
-		},
-		"merge with OnEQ wrapper expression": {
-			Query: psql.Merge(
-				mm.Into("target"),
-				mm.Using("source").As("s").OnEQ(
-					wrappedExpr{Expression: psql.Quote("s", "id")},
 					psql.Quote("target", "id"),
 				),
 				mm.WhenMatched().ThenDoNothing(),

--- a/dialect/psql/merge_test.go
+++ b/dialect/psql/merge_test.go
@@ -9,6 +9,12 @@ import (
 	testutils "github.com/stephenafamo/bob/test/utils"
 )
 
+type wrappedExpr struct {
+	psql.Expression
+}
+
+func (wrappedExpr) ShouldOmitParens() bool { return true }
+
 func TestMerge(t *testing.T) {
 	examples := testutils.Testcases{
 		"simple merge with update and insert": {
@@ -285,6 +291,19 @@ func TestMerge(t *testing.T) {
 				mm.Into("target"),
 				mm.Using("source").As("s").OnEQ(
 					psql.Quote("s", "id"),
+					psql.Quote("target", "id"),
+				),
+				mm.WhenMatched().ThenDoNothing(),
+			),
+			ExpectedSQL: `MERGE INTO target
+				USING source AS "s" ON "s"."id" = "target"."id"
+				WHEN MATCHED THEN DO NOTHING`,
+		},
+		"merge with OnEQ wrapper expression": {
+			Query: psql.Merge(
+				mm.Into("target"),
+				mm.Using("source").As("s").OnEQ(
+					wrappedExpr{Expression: psql.Quote("s", "id")},
 					psql.Quote("target", "id"),
 				),
 				mm.WhenMatched().ThenDoNothing(),

--- a/expr/builder.go
+++ b/expr/builder.go
@@ -32,6 +32,13 @@ func X[T bob.Expression, B builder[T]](exp bob.Expression, others ...bob.Express
 		break
 	case T:
 		return t
+	case bob.ParensOmitter:
+		if t.ShouldOmitParens() {
+			// Expression handles its own wrapping rules.
+			break
+		}
+
+		exp = group{exp}
 	default:
 		exp = group{exp}
 	}

--- a/expression.go
+++ b/expression.go
@@ -35,6 +35,14 @@ type Expression interface {
 	WriteSQL(ctx context.Context, w io.StringWriter, d Dialect, start int) (args []any, err error)
 }
 
+// ParensOmitter marks expressions that should not be auto-wrapped with
+// parentheses by expression builders.
+type ParensOmitter interface {
+	// ShouldOmitParens reports whether expression builders should skip
+	// automatic parenthesis wrapping for this expression.
+	ShouldOmitParens() bool
+}
+
 type ExpressionFunc func(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error)
 
 func (e ExpressionFunc) WriteSQL(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error) {

--- a/expression_test.go
+++ b/expression_test.go
@@ -187,3 +187,32 @@ func TestErrNoNamedArgs(t *testing.T) {
 		t.Fatalf("Expected to get ErrNoNamedArgs but got %v", err)
 	}
 }
+
+type wrappedExpr struct {
+	Expression
+}
+
+func (wrappedExpr) ShouldOmitParens() bool { return true }
+
+func TestParensOmitter(t *testing.T) {
+	var _ ParensOmitter = wrappedExpr{}
+
+	wrapped := wrappedExpr{Expression: ExpressionFunc(func(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error) {
+		d.WriteQuoted(w, "s")
+		w.WriteString(".")
+		d.WriteQuoted(w, "id")
+		return nil, nil
+	})}
+
+	if !wrapped.ShouldOmitParens() {
+		t.Fatalf("expected wrapped expression to opt out of auto parenthesis wrapping")
+	}
+
+	w := bytes.NewBuffer(nil)
+	args, err := Express(context.Background(), w, d, 1, wrapped)
+	if err != nil {
+		t.Fatalf("err while expressing wrapped expression: %v", err)
+	}
+
+	compare(t, `"s"."id"`, w.String(), nil, args)
+}

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -126,6 +126,11 @@ func (c {{$tAlias.DownSingular}}Column) Name() string {
 	return c.name
 }
 
+// ShouldOmitParens prevents automatic parenthesis wrapping in expression builders.
+func (c {{$tAlias.DownSingular}}Column) ShouldOmitParens() bool {
+	return true
+}
+
 // AliasedAs returns a copy of the column qualified by alias.
 func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSingular}}Column {
 	return {{$tAlias.DownSingular}}Column{

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -113,6 +113,14 @@ type {{$tAlias.DownSingular}}Column struct {
 	name  string
 }
 
+func (c {{$tAlias.DownSingular}}Column) Alias() string {
+	return c.alias
+}
+
+func (c {{$tAlias.DownSingular}}Column) Name() string {
+	return c.name
+}
+
 func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSingular}}Column {
 	return {{$tAlias.DownSingular}}Column{
 		Expression: {{$.Dialect}}.Quote(alias, c.name),
@@ -121,10 +129,6 @@ func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSi
 	}
 }
 
-func (c {{$tAlias.DownSingular}}Column) Alias() string {
-	return c.alias
-}
-
-func (c {{$tAlias.DownSingular}}Column) Name() string {
-	return c.name
+func (c {{$tAlias.DownSingular}}Column) Unqualified() {{$tAlias.DownSingular}}Column {
+  return build{{$tAlias.UpSingular}}Column("", c.name)
 }

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -87,14 +87,17 @@ type {{$tAlias.DownSingular}}Columns struct {
 	{{end -}}
 }
 
+// Alias returns the current table alias for the columns set.
 func (c {{$tAlias.DownSingular}}Columns) Alias() string {
   return c.tableAlias
 }
 
+// AliasedAs returns a copy of the columns set qualified by tableName.
 func ({{$tAlias.DownSingular}}Columns) AliasedAs(tableName string) {{$tAlias.DownSingular}}Columns {
   return build{{$tAlias.UpSingular}}Columns(tableName)
 }
 
+// Unqualified returns a copy of the columns set without table qualification.
 func (c {{$tAlias.DownSingular}}Columns) Unqualified() {{$tAlias.DownSingular}}Columns {
   return build{{$tAlias.UpSingular}}Columns("")
 }
@@ -113,14 +116,17 @@ type {{$tAlias.DownSingular}}Column struct {
 	name  string
 }
 
+// Alias returns the current table alias for the column.
 func (c {{$tAlias.DownSingular}}Column) Alias() string {
 	return c.alias
 }
 
+// Name returns the unqualified column name.
 func (c {{$tAlias.DownSingular}}Column) Name() string {
 	return c.name
 }
 
+// AliasedAs returns a copy of the column qualified by alias.
 func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSingular}}Column {
 	return {{$tAlias.DownSingular}}Column{
 		Expression: {{$.Dialect}}.Quote(alias, c.name),
@@ -129,6 +135,7 @@ func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSi
 	}
 }
 
+// Unqualified returns a copy of the column without table qualification.
 func (c {{$tAlias.DownSingular}}Column) Unqualified() {{$tAlias.DownSingular}}Column {
   return build{{$tAlias.UpSingular}}Column("", c.name)
 }

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -73,7 +73,7 @@ func build{{$tAlias.UpSingular}}Columns(tableName string) {{$tAlias.DownSingular
     tableAlias: tableName,
     {{range $column := $table.Columns -}}
     {{- $colAlias := $tAlias.Column $column.Name -}}
-    {{$colAlias}}: {{$.Dialect}}.Quote(tableName, {{quote $column.Name}}),
+    {{$colAlias}}: build{{$tAlias.UpSingular}}Column(tableName, {{quote $column.Name}}),
     {{end -}}
   }
 }
@@ -83,7 +83,7 @@ type {{$tAlias.DownSingular}}Columns struct {
   tableAlias string
 	{{range $column := $table.Columns -}}
 	{{- $colAlias := $tAlias.Column $column.Name -}}
-	{{$colAlias}} {{$.Dialect}}.Expression
+	{{$colAlias}} {{$tAlias.DownSingular}}Column
 	{{end -}}
 }
 
@@ -97,4 +97,34 @@ func ({{$tAlias.DownSingular}}Columns) AliasedAs(tableName string) {{$tAlias.Dow
 
 func (c {{$tAlias.DownSingular}}Columns) Unqualified() {{$tAlias.DownSingular}}Columns {
   return build{{$tAlias.UpSingular}}Columns("")
+}
+
+func build{{$tAlias.UpSingular}}Column(alias, name string) {{$tAlias.DownSingular}}Column {
+	return {{$tAlias.DownSingular}}Column{
+		Expression: {{$.Dialect}}.Quote(alias, name),
+		alias:      alias,
+		name:       name,
+	}
+}
+
+type {{$tAlias.DownSingular}}Column struct {
+	{{$.Dialect}}.Expression
+	alias string
+	name  string
+}
+
+func (c {{$tAlias.DownSingular}}Column) AliasedAs(alias string) {{$tAlias.DownSingular}}Column {
+	return {{$tAlias.DownSingular}}Column{
+		Expression: {{$.Dialect}}.Quote(alias, c.name),
+		alias:      alias,
+		name:       c.name,
+	}
+}
+
+func (c {{$tAlias.DownSingular}}Column) Alias() string {
+	return c.alias
+}
+
+func (c {{$tAlias.DownSingular}}Column) Name() string {
+	return c.name
 }

--- a/gen/templates/where/table/100_where.bob.go.tpl
+++ b/gen/templates/where/table/100_where.bob.go.tpl
@@ -25,9 +25,9 @@ func build{{$tAlias.UpSingular}}Where[Q {{$.Dialect}}.Filterable](cols {{$tAlias
       {{- $colAlias := $tAlias.Column $column.Name -}}
       {{- $colTyp := $.Types.Get $.CurrentPackage $.Importer $column.Type -}}
 				{{- if $column.Nullable -}}
-					{{$colAlias}}: {{$.Dialect}}.WhereNull[Q, {{$colTyp}}](cols.{{$colAlias}}),
+					{{$colAlias}}: {{$.Dialect}}.WhereNull[Q, {{$colTyp}}](cols.{{$colAlias}}.Expression),
 				{{- else -}}
-					{{$colAlias}}: {{$.Dialect}}.Where[Q, {{$colTyp}}](cols.{{$colAlias}}),
+					{{$colAlias}}: {{$.Dialect}}.Where[Q, {{$colTyp}}](cols.{{$colAlias}}.Expression),
 				{{- end}}
 			{{end -}}
 	}


### PR DESCRIPTION
This PR introduces a new generated column type API for columns.

**Changes**
- Generated column accessors now return a dialect-specific column type that embeds `dialect.Expression`.
- Added helper methods on generated columns:
  - `Alias()`
  - `Name()`
  - `AliasedAs(alias)`
  - `Unqualifed()`

**Breaking change**
Previously, generated column fields returned `dialect.Expression` directly.  
Now they return a column wrapper type that embeds `dialect.Expression`.

Migration is simple: when an API expects an expression, use `.Expression`.

```go
// before
where.EQ(models.Users.Columns.ID, 1)

// after
where.EQ(models.Users.Columns.ID.Expression, 1)
```

If you have a function that expects (for example) `psql.Expression`:

```go
func Contains(field psql.Expression, s string) bob.Expression {
	return field.ILike(psql.Arg(s))
}
```

Update it to accept the more general `bob.Expression` interface:

```go
func Contains(field bob.Expression, str string) bob.Expression {
	return dialect.NewExpression(field).ILike(psql.Arg(s))
}
```

Now it works with both the new column types and any other expression:

```go
// Works with new column type API:
Contains(models.Users.Columns.Email, "%example%")

// Works with legacy expressions:
Contains(models.Users.Columns.Email.Expression, "%example%")
```

**Why `Name()` is useful**
`Name()` is convenient when you need raw column names, for example with `models.Users.Columns.Except(...)` to build dynamic column sets.

```go
excluded := models.Users.Columns.Except(
    models.Users.Columns.ID.Name(),
    models.Users.Columns.CreatedAt.Name(),
)
```

`Alias()`, `AliasedAs(alias)`, `Unqualifed()` the same as for *Columns type.
