### PR TITLE
feat(psql): add RETURNING WITH old/new aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `As(alias)` method to `bob.BaseQuery`, allowing queries (e.g. `mysql.Select(...)`) to be aliased directly when used as subqueries in a column list. (thanks @jacobmolby)
 - Added unqualified columns API: generated column structures now provide Alias(), Name(), AliasedAs(alias) and Unqualified() methods for easier column metadata access and aliasing. (thanks @atzedus)
 - Added `bob.ParensOmitter` interface with `ShouldOmitParens() bool` to let expressions opt out of automatic parenthesis wrapping in expression builders. (thanks @atzedus)
+- Added PostgreSQL `RETURNING WITH (OLD AS ..., NEW AS ...)` support for `INSERT`, `UPDATE`, `DELETE`, and `MERGE` query builders, including fluent modifiers: `im/um/dm/mm.Returning(...).WithOldAs(...).WithNewAs(...)`. (thanks @atzedus)
+  - Note: `bobgen-psql` sql-to-code parsing for this syntax is currently blocked by upstream PostgreSQL parser dependency support.
 
 ### Changed
 

--- a/clause/returning.go
+++ b/clause/returning.go
@@ -8,6 +8,8 @@ import (
 )
 
 type Returning struct {
+	OldAlias    string
+	NewAlias    string
 	Expressions []any
 }
 
@@ -15,10 +17,44 @@ func (r *Returning) HasReturning() bool {
 	return len(r.Expressions) > 0
 }
 
+func (r *Returning) SetOldAlias(alias string) {
+	r.OldAlias = alias
+}
+
+func (r *Returning) SetNewAlias(alias string) {
+	r.NewAlias = alias
+}
+
 func (r *Returning) AppendReturning(columns ...any) {
 	r.Expressions = append(r.Expressions, columns...)
 }
 
 func (r Returning) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	return bob.ExpressSlice(ctx, w, d, start, r.Expressions, "RETURNING ", ", ", "")
+	if len(r.Expressions) == 0 {
+		return nil, nil
+	}
+
+	w.WriteString("RETURNING ")
+
+	if r.OldAlias != "" || r.NewAlias != "" {
+		w.WriteString("WITH (")
+
+		if r.OldAlias != "" {
+			w.WriteString("OLD AS ")
+			d.WriteQuoted(w, r.OldAlias)
+		}
+
+		if r.NewAlias != "" {
+			if r.OldAlias != "" {
+				w.WriteString(", ")
+			}
+
+			w.WriteString("NEW AS ")
+			d.WriteQuoted(w, r.NewAlias)
+		}
+
+		w.WriteString(") ")
+	}
+
+	return bob.ExpressSlice(ctx, w, d, start, r.Expressions, "", ", ", "")
 }

--- a/dialect/psql/delete_test.go
+++ b/dialect/psql/delete_test.go
@@ -34,3 +34,22 @@ func TestDelete(t *testing.T) {
 
 	testutils.RunTests(t, examples, formatter)
 }
+
+func TestDeleteReturningWith(t *testing.T) {
+	examples := testutils.Testcases{
+		"returning with old alias": {
+			Query: psql.Delete(
+				dm.From("users"),
+				dm.Where(psql.Quote("id").EQ(psql.Arg(42))),
+				dm.Returning(
+					psql.Quote("before", "id"),
+					psql.Quote("before", "primary_email"),
+				).WithOldAs("before"),
+			),
+			ExpectedSQL:  `DELETE FROM users WHERE ("id" = $1) RETURNING WITH (OLD AS "before") "before"."id", "before"."primary_email"`,
+			ExpectedArgs: []any{42},
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}

--- a/dialect/psql/dm/qm.go
+++ b/dialect/psql/dm/qm.go
@@ -66,6 +66,6 @@ func Where(e bob.Expression) mods.Where[*dialect.DeleteQuery] {
 	return mods.Where[*dialect.DeleteQuery]{E: e}
 }
 
-func Returning(clauses ...any) bob.Mod[*dialect.DeleteQuery] {
+func Returning(clauses ...any) mods.Returning[*dialect.DeleteQuery] {
 	return mods.Returning[*dialect.DeleteQuery](clauses)
 }

--- a/dialect/psql/im/qm.go
+++ b/dialect/psql/im/qm.go
@@ -84,7 +84,7 @@ func OnConflictOnConstraint(constraint string) mods.Conflict[*dialect.InsertQuer
 	})
 }
 
-func Returning(clauses ...any) bob.Mod[*dialect.InsertQuery] {
+func Returning(clauses ...any) mods.Returning[*dialect.InsertQuery] {
 	return mods.Returning[*dialect.InsertQuery](clauses)
 }
 

--- a/dialect/psql/insert_test.go
+++ b/dialect/psql/insert_test.go
@@ -95,3 +95,22 @@ func TestInsert(t *testing.T) {
 
 	testutils.RunTests(t, examples, formatter)
 }
+
+func TestInsertReturningWith(t *testing.T) {
+	examples := testutils.Testcases{
+		"returning with old and new aliases": {
+			Query: psql.Insert(
+				im.Into("users"),
+				im.Values(psql.Arg(1, "neo@example.com")),
+				im.Returning(
+					psql.Quote("before", "id"),
+					psql.Quote("after", "primary_email"),
+				).WithOldAs("before").WithNewAs("after"),
+			),
+			ExpectedSQL:  `INSERT INTO users VALUES ($1, $2) RETURNING WITH (OLD AS "before", NEW AS "after") "before"."id", "after"."primary_email"`,
+			ExpectedArgs: []any{1, "neo@example.com"},
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}

--- a/dialect/psql/merge_test.go
+++ b/dialect/psql/merge_test.go
@@ -411,3 +411,29 @@ func TestMerge(t *testing.T) {
 
 	testutils.RunTests(t, examples, formatter)
 }
+
+func TestMergeReturningWith(t *testing.T) {
+	examples := testutils.Testcases{
+		"returning with new alias": {
+			Query: psql.Merge(
+				mm.Into("products"),
+				mm.Using("updates").As("u").On(
+					psql.Quote("u", "id").EQ(psql.Quote("products", "id")),
+				),
+				mm.WhenMatched().ThenUpdate(
+					mm.SetCol("price").To(psql.Quote("u", "price")),
+				),
+				mm.Returning(
+					psql.Quote("after", "id"),
+					psql.Quote("after", "price"),
+				).WithNewAs("after"),
+			),
+			ExpectedSQL: `MERGE INTO products
+				USING updates AS "u" ON ("u"."id" = "products"."id")
+				WHEN MATCHED THEN UPDATE SET "price" = "u"."price"
+				RETURNING WITH (NEW AS "after") "after"."id", "after"."price"`,
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}

--- a/dialect/psql/mm/qm.go
+++ b/dialect/psql/mm/qm.go
@@ -365,6 +365,6 @@ func OverridingUser() bob.Mod[*InsertAction] {
 }
 
 // Returning adds a RETURNING clause
-func Returning(clauses ...any) bob.Mod[*dialect.MergeQuery] {
+func Returning(clauses ...any) mods.Returning[*dialect.MergeQuery] {
 	return mods.Returning[*dialect.MergeQuery](clauses)
 }

--- a/dialect/psql/um/qm.go
+++ b/dialect/psql/um/qm.go
@@ -91,6 +91,6 @@ func Where(e bob.Expression) mods.Where[*dialect.UpdateQuery] {
 	return mods.Where[*dialect.UpdateQuery]{E: e}
 }
 
-func Returning(clauses ...any) bob.Mod[*dialect.UpdateQuery] {
+func Returning(clauses ...any) mods.Returning[*dialect.UpdateQuery] {
 	return mods.Returning[*dialect.UpdateQuery](clauses)
 }

--- a/dialect/psql/update_test.go
+++ b/dialect/psql/update_test.go
@@ -51,3 +51,23 @@ func TestUpdate(t *testing.T) {
 
 	testutils.RunTests(t, examples, formatter)
 }
+
+func TestUpdateReturningWith(t *testing.T) {
+	examples := testutils.Testcases{
+		"returning with old and new aliases": {
+			Query: psql.Update(
+				um.Table("users"),
+				um.SetCol("primary_email").ToArg("new@example.com"),
+				um.Where(psql.Quote("id").EQ(psql.Arg(1))),
+				um.Returning(
+					psql.Quote("before", "primary_email"),
+					psql.Quote("after", "primary_email"),
+				).WithOldAs("before").WithNewAs("after"),
+			),
+			ExpectedSQL:  `UPDATE users SET "primary_email" = $1 WHERE ("id" = $2) RETURNING WITH (OLD AS "before", NEW AS "after") "before"."primary_email", "after"."primary_email"`,
+			ExpectedArgs: []any{"new@example.com", 1},
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}

--- a/gen/bobgen-psql/driver/parser/parser.go
+++ b/gen/bobgen-psql/driver/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync/atomic"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/stephenafamo/bob/internal"
 	pgparse "github.com/wasilibs/go-pgquery"
 )
+
+var returningWithClauseRegex = regexp.MustCompile(`(?is)\breturning\s+with\s*\(`)
 
 func New(db *sql.DB, t tables, sharedSchema string, translator *Translator) *Parser {
 	return &Parser{
@@ -40,7 +43,7 @@ func (p *Parser) ParseFolders(ctx context.Context, paths ...string) ([]drivers.Q
 func (p *Parser) ParseQueries(ctx context.Context, s string) ([]drivers.Query, error) {
 	stmts, err := pgparse.Parse(s)
 	if err != nil {
-		return nil, fmt.Errorf("parse formatted: %w", err)
+		return nil, wrapParseErrorWithReturningWithHint("parse formatted", s, err)
 	}
 
 	if len(stmts.Stmts) == 0 {
@@ -82,7 +85,7 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 
 	parseResult, err := pgparse.Parse(input)
 	if err != nil {
-		return drivers.Query{}, fmt.Errorf("parse single: %w", err)
+		return drivers.Query{}, wrapParseErrorWithReturningWithHint("parse single", input, err)
 	}
 
 	if len(parseResult.Stmts) != 1 {
@@ -188,6 +191,29 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 	}
 
 	return query, nil
+}
+
+func wrapParseErrorWithReturningWithHint(stage, sql string, err error) error {
+	wrapped := fmt.Errorf("%s: %w", stage, err)
+
+	if !isReturningWithParseError(sql, err) {
+		return wrapped
+	}
+
+	return fmt.Errorf("%w: RETURNING WITH (OLD|NEW AS ...) is not yet supported by the current sql parser dependency (github.com/wasilibs/go-pgquery)", wrapped)
+}
+
+func isReturningWithParseError(sql string, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if !returningWithClauseRegex.MatchString(sql) {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "syntax error at or near \"with\"")
 }
 
 func getQueryType(stmt *pg.Node) bob.QueryType {

--- a/gen/bobgen-psql/driver/parser/returning_with_test.go
+++ b/gen/bobgen-psql/driver/parser/returning_with_test.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestIsReturningWithParseError(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("syntax error at or near \"WITH\"")
+
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			name: "returning with clause and with syntax error",
+			sql:  `UPDATE users SET name = $1 RETURNING WITH (OLD AS o, NEW AS n) o.*, n.*`,
+			want: true,
+		},
+		{
+			name: "query without returning with clause",
+			sql:  `UPDATE users SET name = $1 RETURNING id`,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isReturningWithParseError(tc.sql, err); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestWrapParseErrorWithReturningWithHint(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("syntax error at or near \"WITH\"")
+	wrapped := wrapParseErrorWithReturningWithHint(
+		"parse single",
+		`DELETE FROM users WHERE id = $1 RETURNING WITH (OLD AS before) before.*`,
+		baseErr,
+	)
+
+	msg := wrapped.Error()
+	if !strings.Contains(msg, "RETURNING WITH (OLD|NEW AS ...)") {
+		t.Fatalf("expected RETURNING WITH hint in error, got: %s", msg)
+	}
+
+	if !strings.Contains(msg, "parse single") {
+		t.Fatalf("expected stage prefix in error, got: %s", msg)
+	}
+}

--- a/mods/mods.go
+++ b/mods/mods.go
@@ -161,6 +161,52 @@ func (s Returning[Q]) Apply(q Q) {
 	q.AppendReturning(s...)
 }
 
+func (s Returning[Q]) WithOldAs(alias string) returningWithAliases[Q] {
+	return returningWithAliases[Q]{
+		clauses:  append([]any(nil), s...),
+		oldAlias: alias,
+	}
+}
+
+func (s Returning[Q]) WithNewAs(alias string) returningWithAliases[Q] {
+	return returningWithAliases[Q]{
+		clauses:  append([]any(nil), s...),
+		newAlias: alias,
+	}
+}
+
+type returningWithAliases[Q interface{ AppendReturning(vals ...any) }] struct {
+	clauses  []any
+	oldAlias string
+	newAlias string
+}
+
+func (s returningWithAliases[Q]) Apply(q Q) {
+	q.AppendReturning(s.clauses...)
+
+	if s.oldAlias != "" {
+		if setter, ok := any(q).(interface{ SetOldAlias(string) }); ok {
+			setter.SetOldAlias(s.oldAlias)
+		}
+	}
+
+	if s.newAlias != "" {
+		if setter, ok := any(q).(interface{ SetNewAlias(string) }); ok {
+			setter.SetNewAlias(s.newAlias)
+		}
+	}
+}
+
+func (s returningWithAliases[Q]) WithOldAs(alias string) returningWithAliases[Q] {
+	s.oldAlias = alias
+	return s
+}
+
+func (s returningWithAliases[Q]) WithNewAs(alias string) returningWithAliases[Q] {
+	s.newAlias = alias
+	return s
+}
+
 type Set[Q interface{ AppendSet(clauses ...any) }] []string
 
 func (s Set[Q]) To(to any) bob.Mod[Q] {


### PR DESCRIPTION
**Added support for PostgreSQL `RETURNING WITH (OLD AS ..., NEW AS ...)` syntax to the Builder API**

**What's included:**
- Extended `RETURNING` clause: support for `OLD`/`NEW` aliases
- Added fluent API for `RETURNING`:
  - `WithOldAs(...)`
  - `WithNewAs(...)`
- Updated tests for `INSERT`/`UPDATE`/`DELETE`/`MERGE` statements
- Added an explicit diagnostic hint to the SQL-to-code parser indicating that `RETURNING WITH` support is currently limited by the underlying parser dependency

**Short examples:**
```go
q := psql.Update(
    um.Table("users"),
    um.SetCol("email").ToArg("new@example.com"),
    um.Returning(
        psql.Quote("before", "email"),
        psql.Quote("after", "email"),
    ).WithOldAs("before").WithNewAs("after"),
)
```