### PR TITLE
fix(psql): correct SearchBreadth CTE order keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix PostgreSQL `sm.With(...).SearchBreadth(...)` rendering `SEARCH DEPTH` instead of `SEARCH BREADTH` in CTE queries. (thanks @atzedus)
 - Avoid unnecessary imports in generated random factory code when a type has no random expression. (thanks @jay-babu)
 - Fix missing base type imports (e.g. `github.com/google/uuid`) in generated models when using `type_system: "database/sql"` and `uuid_pkg: google`, which could cause compile errors in generated many-to-many relation helpers. (thanks @atzedus)
 

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -318,7 +318,7 @@ func (c CTEChain[Q]) Materialized() CTEChain[Q] {
 func (c CTEChain[Q]) SearchBreadth(setCol string, searchCols ...string) CTEChain[Q] {
 	cte := c()
 	cte.Search = clause.CTESearch{
-		Order:   clause.SearchDepth,
+		Order:   clause.SearchBreadth,
 		Columns: searchCols,
 		Set:     setCol,
 	}

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -51,6 +51,10 @@ func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	}
 	args = append(args, withArgs...)
 
+	if len(s.With.CTEs) > 0 {
+		w.WriteString("\n")
+	}
+
 	needsParens := false
 	if len(s.Combines.Queries) > 0 &&
 		(len(s.OrderBy.Expressions) > 0 ||

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -195,6 +195,26 @@ func TestSelect(t *testing.T) {
 				sm.From("c"),
 			),
 		},
+		"CTE with search breadth": {
+			ExpectedSQL: "WITH c(id) AS (SELECT id FROM test1) SEARCH BREADTH FIRST BY id SET order_col SELECT * FROM c",
+			Query: psql.Select(
+				sm.With("c", "id").As(psql.Select(
+					sm.Columns("id"),
+					sm.From("test1"),
+				)).SearchBreadth("order_col", "id"),
+				sm.From("c"),
+			),
+		},
+		"CTE with search depth": {
+			ExpectedSQL: "WITH c(id) AS (SELECT id FROM test1) SEARCH DEPTH FIRST BY id SET order_col SELECT * FROM c",
+			Query: psql.Select(
+				sm.With("c", "id").As(psql.Select(
+					sm.Columns("id"),
+					sm.From("test1"),
+				)).SearchDepth("order_col", "id"),
+				sm.From("c"),
+			),
+		},
 		"Window function over empty frame": {
 			ExpectedSQL: "SELECT row_number() OVER () FROM c",
 			Query: psql.Select(


### PR DESCRIPTION
This PR fixes PostgreSQL CTE rendering so SearchBreadth now emits SEARCH BREADTH instead of SEARCH DEPTH.