### PR TITLE
Remove Unqualified() method from generated *Columns structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL `RETURNING WITH (OLD AS ..., NEW AS ...)` support for `INSERT`, `UPDATE`, `DELETE`, and `MERGE` query builders, including fluent modifiers: `im/um/dm/mm.Returning(...).WithOldAs(...).WithNewAs(...)`. (thanks @atzedus)
   - Note: `bobgen-psql` sql-to-code parsing for this syntax is currently blocked by upstream PostgreSQL parser dependency support.
 
+### Removed
+
+- Removed the `Unqualified()` method from generated `*Columns` (plural) structs. It is superseded by the per-column API introduced in the unqualified columns API entry above: use `Column.Unqualified()` for a single column to build an unqualified reference. (thanks @jacobmolby)
+
 ### Changed
 
 - **BREAKING:** Renamed the generated `ThenLoadCount` variable to `SelectThenLoadCount` for naming consistency with `SelectThenLoad`/`InsertThenLoad`/`UpdateThenLoad`. Update call sites from `models.ThenLoadCount.X.Y` to `models.SelectThenLoadCount.X.Y`. (thanks @jacobmolby)

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -78,7 +78,7 @@ func build{{$tAlias.UpSingular}}Columns(alias string) {{$tAlias.DownSingular}}Co
   return {{$tAlias.DownSingular}}Columns{
     ColumnsExpr: expr.NewColumnsExpr(
       {{range $column := $table.Columns -}}{{quote $column.Name}},{{end}}
-    ).WithParent({{quote $table.Key}}),
+    ).WithParent(alias),
     tableAlias: alias,
     {{range $column := $table.Columns -}}
     {{- $colAlias := $tAlias.Column $column.Name -}}

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -74,19 +74,15 @@ type {{$tAlias.DownSingular}}R{{$.RelationLoadedName}} struct {
 
 {{$.Importer.Import "github.com/stephenafamo/bob/expr"}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s" $.Dialect)}}
-func build{{$tAlias.UpSingular}}Columns(tableName string) {{$tAlias.DownSingular}}Columns {
-  columnsExpr := expr.NewColumnsExpr(
-    {{range $column := $table.Columns -}}{{quote $column.Name}},{{end}}
-  )
-  if tableName != "" {
-    columnsExpr = columnsExpr.WithParent(tableName)
-  }
+func build{{$tAlias.UpSingular}}Columns(alias string) {{$tAlias.DownSingular}}Columns {
   return {{$tAlias.DownSingular}}Columns{
-    ColumnsExpr: columnsExpr,
-    tableAlias: tableName,
+    ColumnsExpr: expr.NewColumnsExpr(
+      {{range $column := $table.Columns -}}{{quote $column.Name}},{{end}}
+    ).WithParent({{quote $table.Key}}),
+    tableAlias: alias,
     {{range $column := $table.Columns -}}
     {{- $colAlias := $tAlias.Column $column.Name -}}
-    {{$colAlias}}: build{{$tAlias.UpSingular}}Column(tableName, {{quote $column.Name}}),
+    {{$colAlias}}: build{{$tAlias.UpSingular}}Column(alias, {{quote $column.Name}}),
     {{end -}}
   }
 }
@@ -105,14 +101,9 @@ func (c {{$tAlias.DownSingular}}Columns) Alias() string {
   return c.tableAlias
 }
 
-// AliasedAs returns a copy of the columns set qualified by tableName.
-func ({{$tAlias.DownSingular}}Columns) AliasedAs(tableName string) {{$tAlias.DownSingular}}Columns {
-  return build{{$tAlias.UpSingular}}Columns(tableName)
-}
-
-// Unqualified returns a copy of the columns set without table qualification.
-func (c {{$tAlias.DownSingular}}Columns) Unqualified() {{$tAlias.DownSingular}}Columns {
-  return build{{$tAlias.UpSingular}}Columns("")
+// AliasedAs returns a copy of the columns set qualified by alias.
+func ({{$tAlias.DownSingular}}Columns) AliasedAs(alias string) {{$tAlias.DownSingular}}Columns {
+  return build{{$tAlias.UpSingular}}Columns(alias)
 }
 
 func build{{$tAlias.UpSingular}}Column(alias, name string) {{$tAlias.DownSingular}}Column {


### PR DESCRIPTION
Since #675 was merged, the changes made in #625 are no longer needed.

I think it's better to remove it sooner, rather than later so two almost identical APIs don't need to be supported for ever.

This PR basically reverts #625.