### PR TITLE
feat(psql): add TABLESAMPLE support and parser/query updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bob.ParensOmitter` interface with `ShouldOmitParens() bool` to let expressions opt out of automatic parenthesis wrapping in expression builders. (thanks @atzedus)
 - Added PostgreSQL `RETURNING WITH (OLD AS ..., NEW AS ...)` support for `INSERT`, `UPDATE`, `DELETE`, and `MERGE` query builders, including fluent modifiers: `im/um/dm/mm.Returning(...).WithOldAs(...).WithNewAs(...)`. (thanks @atzedus)
   - Note: `bobgen-psql` sql-to-code parsing for this syntax is currently blocked by upstream PostgreSQL parser dependency support.
+- Added PostgreSQL `TABLESAMPLE ... REPEATABLE ...` support via fluent modifiers on `sm.From(...)` and join chains. (thanks @atzedus)
 
 ### Changed
 

--- a/clause/from.go
+++ b/clause/from.go
@@ -39,12 +39,15 @@ type TableRef struct {
 	Columns []string
 
 	// Dialect specific modifiers
-	Only           bool        // Postgres
-	Lateral        bool        // Postgres & MySQL
-	WithOrdinality bool        // Postgres
-	IndexedBy      *string     // SQLite
-	Partitions     []string    // MySQL
-	IndexHints     []IndexHint // MySQL
+	Only            bool        // Postgres
+	TableSample     string      // Postgres
+	TableSampleArgs []any       // Postgres
+	Repeatable      any         // Postgres
+	Lateral         bool        // Postgres & MySQL
+	WithOrdinality  bool        // Postgres
+	IndexedBy       *string     // SQLite
+	Partitions      []string    // MySQL
+	IndexHints      []IndexHint // MySQL
 
 	// Joins
 	Joins []Join
@@ -61,6 +64,15 @@ func (f *TableRef) SetTableAlias(alias string, columns ...string) {
 
 func (f *TableRef) SetOnly(only bool) {
 	f.Only = only
+}
+
+func (f *TableRef) SetTableSample(method string, args ...any) {
+	f.TableSample = method
+	f.TableSampleArgs = args
+}
+
+func (f *TableRef) SetTableSampleRepeatable(seed any) {
+	f.Repeatable = seed
 }
 
 func (f *TableRef) SetLateral(lateral bool) {
@@ -111,6 +123,20 @@ func (f TableRef) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect
 	if f.WithOrdinality {
 		w.WriteString(" WITH ORDINALITY")
 	}
+
+	tableSampleArgs, err := bob.ExpressSlice(ctx, w, d, start+len(args), f.TableSampleArgs,
+		" TABLESAMPLE "+f.TableSample+"(", ", ", ")")
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, tableSampleArgs...)
+
+	repeatableArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), f.Repeatable,
+		f.Repeatable != nil, " REPEATABLE (", ")")
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, repeatableArgs...)
 
 	_, err = bob.ExpressSlice(ctx, w, d, start, f.Partitions, " PARTITION (", ", ", ")")
 	if err != nil {

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -14,6 +14,11 @@ type Distinct struct {
 	On []any
 }
 
+const (
+	TableSampleMethodSystem    = "SYSTEM"
+	TableSampleMethodBernoulli = "BERNOULLI"
+)
+
 func (di Distinct) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	w.WriteString("DISTINCT")
 	return bob.ExpressSlice(ctx, w, d, start, di.On, " ON (", ", ", ")")
@@ -32,6 +37,8 @@ type fromable interface {
 	SetTable(any)
 	SetTableAlias(alias string, columns ...string)
 	SetOnly(bool)
+	SetTableSample(method string, args ...any)
+	SetTableSampleRepeatable(seed any)
 	SetLateral(bool)
 	SetWithOrdinality(bool)
 }
@@ -53,6 +60,8 @@ func (f FromChain[Q]) Apply(q Q) {
 	}
 
 	q.SetOnly(from.Only)
+	q.SetTableSample(from.TableSample, from.TableSampleArgs...)
+	q.SetTableSampleRepeatable(from.Repeatable)
 	q.SetLateral(from.Lateral)
 	q.SetWithOrdinality(from.WithOrdinality)
 }
@@ -70,6 +79,33 @@ func (f FromChain[Q]) As(alias string, columns ...string) FromChain[Q] {
 func (f FromChain[Q]) Only() FromChain[Q] {
 	fr := f()
 	fr.Only = true
+
+	return FromChain[Q](func() clause.TableRef {
+		return fr
+	})
+}
+
+func (f FromChain[Q]) TableSample(method string, args ...any) FromChain[Q] {
+	fr := f()
+	fr.TableSample = method
+	fr.TableSampleArgs = args
+
+	return FromChain[Q](func() clause.TableRef {
+		return fr
+	})
+}
+
+func (f FromChain[Q]) TableSampleSystem(args ...any) FromChain[Q] {
+	return f.TableSample(TableSampleMethodSystem, args...)
+}
+
+func (f FromChain[Q]) TableSampleBernoulli(args ...any) FromChain[Q] {
+	return f.TableSample(TableSampleMethodBernoulli, args...)
+}
+
+func (f FromChain[Q]) Repeatable(seed any) FromChain[Q] {
+	fr := f()
+	fr.Repeatable = seed
 
 	return FromChain[Q](func() clause.TableRef {
 		return fr
@@ -149,6 +185,33 @@ func (j JoinChain[Q]) As(alias string, columns ...string) JoinChain[Q] {
 func (f JoinChain[Q]) Only() JoinChain[Q] {
 	jo := f()
 	jo.To.Only = true
+
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
+}
+
+func (f JoinChain[Q]) TableSample(method string, args ...any) JoinChain[Q] {
+	jo := f()
+	jo.To.TableSample = method
+	jo.To.TableSampleArgs = args
+
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
+}
+
+func (f JoinChain[Q]) TableSampleSystem(args ...any) JoinChain[Q] {
+	return f.TableSample(TableSampleMethodSystem, args...)
+}
+
+func (f JoinChain[Q]) TableSampleBernoulli(args ...any) JoinChain[Q] {
+	return f.TableSample(TableSampleMethodBernoulli, args...)
+}
+
+func (f JoinChain[Q]) Repeatable(seed any) JoinChain[Q] {
+	jo := f()
+	jo.To.Repeatable = seed
 
 	return JoinChain[Q](func() clause.Join {
 		return jo

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -85,6 +85,38 @@ func TestSelect(t *testing.T) {
 			ExpectedSQL:  `SELECT * FROM generate_series(1, 3) AS "x" ("p", "q", "s")`,
 			ExpectedArgs: nil,
 		},
+		"select from tablesample repeatable": {
+			Query: psql.Select(
+				sm.From("users").TableSample("BERNOULLI", psql.Arg(50)).Repeatable(psql.Arg(7)),
+			),
+			ExpectedSQL:  `SELECT * FROM users TABLESAMPLE BERNOULLI($1) REPEATABLE ($2)`,
+			ExpectedArgs: []any{50, 7},
+		},
+		"select from tablesample repeatable helper": {
+			Query: psql.Select(
+				sm.From("users").TableSampleBernoulli(psql.Arg(50)).Repeatable(psql.Arg(7)),
+			),
+			ExpectedSQL:  `SELECT * FROM users TABLESAMPLE BERNOULLI($1) REPEATABLE ($2)`,
+			ExpectedArgs: []any{50, 7},
+		},
+		"select join with tablesample": {
+			Query: psql.Select(
+				sm.From("users"),
+				sm.InnerJoin("events").TableSample("SYSTEM", 10).On(
+					psql.Quote("users", "id").EQ(psql.Quote("events", "user_id")),
+				),
+			),
+			ExpectedSQL: `SELECT * FROM users INNER JOIN events TABLESAMPLE SYSTEM(10) ON ("users"."id" = "events"."user_id")`,
+		},
+		"select join with tablesample helper": {
+			Query: psql.Select(
+				sm.From("users"),
+				sm.InnerJoin("events").TableSampleSystem(10).On(
+					psql.Quote("users", "id").EQ(psql.Quote("events", "user_id")),
+				),
+			),
+			ExpectedSQL: `SELECT * FROM users INNER JOIN events TABLESAMPLE SYSTEM(10) ON ("users"."id" = "events"."user_id")`,
+		},
 		"with rows from": {
 			Doc: "Select from group of functions. Automatically uses the `ROWS FROM` syntax",
 			Query: psql.Select(

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -59,9 +59,28 @@ func (w *walker) getSource(node *pg.Node, info nodeInfo, sources ...queryResult)
 		}
 		return source
 
+	case *pg.Node_RangeTableSample:
+		if sampleInfo, ok := info.children["RangeTableSample"]; ok {
+			info = sampleInfo
+		}
+		return w.getTableSampleSource(stmt.RangeTableSample, info, cloned...)
+
 	default:
 		return queryResult{}
 	}
+}
+
+func (w *walker) getTableSampleSource(sample *pg.RangeTableSample, info nodeInfo, sources ...queryResult) queryResult {
+	if sample == nil || sample.Relation == nil {
+		return queryResult{}
+	}
+
+	relationInfo, ok := info.children["Relation"]
+	if !ok {
+		return queryResult{}
+	}
+
+	return w.getSource(sample.Relation, relationInfo, sources...)
 }
 
 func (w *walker) getTableSource(sub *pg.RangeVar, info nodeInfo, sources ...queryResult) queryResult {

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -8765,6 +8765,62 @@
 							"mods": "q.AppendSelect(EXPR.subExpr(7, 223))\nq.SetTable(EXPR.subExpr(229, 234))\nq.AppendWhere(EXPR.subExpr(241, 251))\n"
 						},
 						{
+							"type": 1,
+							"name": "SelectUsersTableSample",
+							"raw": "SELECT \"u\".\"id\" AS \"id\", \"u\".\"email_validated\" AS \"email_validated\", \"u\".\"primary_email\" AS \"primary_email\", \"u\".\"parent_id\" AS \"parent_id\", \"u\".\"party_id\" AS \"party_id\", \"u\".\"referrer\" AS \"referrer\" FROM users AS u TABLESAMPLE BERNOULLI(50) REPEATABLE (7)",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "id",
+									"db_name": "id",
+									"nullable": false,
+									"type": "int32",
+									"type_limits": null
+								},
+								{
+									"name": "email_validated",
+									"db_name": "email_validated",
+									"nullable": true,
+									"type": "bool",
+									"type_limits": null
+								},
+								{
+									"name": "primary_email",
+									"db_name": "primary_email",
+									"nullable": true,
+									"type": "string",
+									"type_limits": null
+								},
+								{
+									"name": "parent_id",
+									"db_name": "parent_id",
+									"nullable": true,
+									"type": "int32",
+									"type_limits": null
+								},
+								{
+									"name": "party_id",
+									"db_name": "party_id",
+									"nullable": true,
+									"type": "int32",
+									"type_limits": null
+								},
+								{
+									"name": "referrer",
+									"db_name": "referrer",
+									"nullable": true,
+									"type": "int32",
+									"type_limits": null
+								}
+							],
+							"args": [],
+							"mods": "q.AppendSelect(EXPR.subExpr(7, 199))\nq.SetTable(EXPR.subExpr(205, 256))\n"
+						},
+						{
 							"type": 2,
 							"name": "InsertUser",
 							"raw": "INSERT INTO users (id, primary_email) VALUES ($1, $2)",

--- a/gen/bobgen-psql/driver/queries/users.sql
+++ b/gen/bobgen-psql/driver/queries/users.sql
@@ -2,6 +2,10 @@
 SELECT * FROM users WHERE id IN ($1)
 ;
 
+-- SelectUsersTableSample
+SELECT u.* FROM users AS u TABLESAMPLE BERNOULLI(50) REPEATABLE (7)
+;
+
 -- InsertUser
 INSERT INTO users (id, primary_email) VALUES ($1, $2)
 ;


### PR DESCRIPTION
This PR adds PostgreSQL TABLESAMPLE support.

Added helper methods for standard sampling types:
TableSampleSystem(args...)
TableSampleBernoulli(args...)
TableSample(method, args...) as a universal API for custom or extension methods.

Added parser support for TABLESAMPLE source resolution.

Examples:

```go
// FROM with BERNOULLI + REPEATABLE
sm.From("users").TableSampleBernoulli(psql.Arg(50)).Repeatable(psql.Arg(7))
// SELECT * FROM users TABLESAMPLE BERNOULLI($1) REPEATABLE ($2)

// JOIN with SYSTEM
sm.InnerJoin("events").TableSampleSystem(10).On(...)
// INNER JOIN events TABLESAMPLE SYSTEM(10) ON (...)
```