### PR TITLE
feat(psql): support JOIN USING alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bob.ParensOmitter` interface with `ShouldOmitParens() bool` to let expressions opt out of automatic parenthesis wrapping in expression builders. (thanks @atzedus)
 - Added PostgreSQL `RETURNING WITH (OLD AS ..., NEW AS ...)` support for `INSERT`, `UPDATE`, `DELETE`, and `MERGE` query builders, including fluent modifiers: `im/um/dm/mm.Returning(...).WithOldAs(...).WithNewAs(...)`. (thanks @atzedus)
   - Note: `bobgen-psql` sql-to-code parsing for this syntax is currently blocked by upstream PostgreSQL parser dependency support.
+- Added PostgreSQL `JOIN ... USING (...) AS alias` support via `UsingAs(alias, cols...)` on psql join chains. (thanks @atzedus)
 
 ### Changed
 

--- a/clause/join.go
+++ b/clause/join.go
@@ -25,6 +25,7 @@ type Join struct {
 	Natural bool
 	On      []bob.Expression
 	Using   []string
+	UsingAs string
 }
 
 func (j Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
@@ -48,7 +49,7 @@ func (j Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, st
 
 	for k, col := range j.Using {
 		if k == 0 {
-			w.WriteString(" USING(")
+			w.WriteString(" USING (")
 		} else {
 			w.WriteString(", ")
 		}
@@ -59,9 +60,13 @@ func (j Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, st
 		}
 
 		if k == len(j.Using)-1 {
-			w.WriteString(") ")
+			w.WriteString(")")
 		}
+	}
 
+	if j.UsingAs != "" {
+		w.WriteString(" AS ")
+		d.WriteQuoted(w, j.UsingAs)
 	}
 
 	return args, nil

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -201,6 +201,14 @@ func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
 	return mods.Join[Q](jo)
 }
 
+func (j JoinChain[Q]) UsingAs(alias string, using ...string) bob.Mod[Q] {
+	jo := j()
+	jo.Using = using
+	jo.UsingAs = alias
+
+	return mods.Join[Q](jo)
+}
+
 type CrossJoinChain[Q Joinable] func() clause.Join
 
 func (j CrossJoinChain[Q]) Apply(q Q) {

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -184,6 +184,14 @@ func TestSelect(t *testing.T) {
 				sm.LeftJoin("test2").Using("id"),
 			),
 		},
+		"join using alias": {
+			ExpectedSQL: `SELECT id FROM test1 LEFT JOIN test2 USING (id) AS "joined_id"`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("test1"),
+				sm.LeftJoin("test2").UsingAs("joined_id", "id"),
+			),
+		},
 		"CTE with column aliases": {
 			ExpectedSQL: "WITH c(id, data) AS (SELECT id FROM test1 LEFT JOIN test2 USING (id)) SELECT * FROM c",
 			Query: psql.Select(

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -298,6 +298,19 @@ func (w *walker) addSourcesOfFromItem(from *pg.Node, fromInfo nodeInfo, sources 
 			joinType: join.Jointype,
 		}
 
+		if join.JoinUsingAlias != nil {
+			joined.usingAlias = join.JoinUsingAlias.Aliasname
+		}
+
+		if len(join.UsingClause) > 0 {
+			joined.usingColumns = make([]string, 0, len(join.UsingClause))
+			for _, using := range join.UsingClause {
+				if node := using.GetString_(); node != nil {
+					joined.usingColumns = append(joined.usingColumns, node.Sval)
+				}
+			}
+		}
+
 		joinedNodes = append(joinedNodes, joined)
 	}
 
@@ -345,6 +358,19 @@ func (w *walker) addSourcesOfFromItem(from *pg.Node, fromInfo nodeInfo, sources 
 		}
 
 		joinSources = append(joinSources, joinSource)
+
+		if j.usingAlias != "" && len(j.usingColumns) > 0 {
+			aliasSource := queryResult{
+				name:    j.usingAlias,
+				columns: make([]col, len(j.usingColumns)),
+			}
+
+			for i, name := range j.usingColumns {
+				aliasSource.columns[i] = col{name: name, nullable: true}
+			}
+
+			joinSources = append(joinSources, aliasSource)
+		}
 	}
 
 	return append(sources, joinSources...)

--- a/gen/bobgen-psql/driver/parser/types.go
+++ b/gen/bobgen-psql/driver/parser/types.go
@@ -30,9 +30,11 @@ func (i position) LitterDump(w io.StringWriter) {
 }
 
 type joinedInfo struct {
-	node     *pg.Node
-	info     nodeInfo
-	joinType pg.JoinType
+	node         *pg.Node
+	info         nodeInfo
+	joinType     pg.JoinType
+	usingAlias   string
+	usingColumns []string
 }
 
 func (j joinedInfo) LitterDump(w io.StringWriter) {


### PR DESCRIPTION
This PR adds PostgreSQL support for JOIN ... USING (...) AS alias in both query building and sql-to-code parsing.

- Added join clause support for USING alias serialization.
- Added fluent API helper: UsingAs(alias, columns...).
- Updated parser source resolution so USING aliases are recognized correctly in generated code.
- Added/updated tests for the new JOIN USING alias behavior.

Example
```go
sm.LeftJoin("test2").UsingAs("joined_id", "id")
```

Generates:
```sql
LEFT JOIN test2 USING (id) AS "joined_id"
```