### PR TITLE
feat(psql): add grouping-element helpers for GROUP BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note: `bobgen-psql` sql-to-code parsing for this syntax is currently blocked by upstream PostgreSQL parser dependency support.
 - Added PostgreSQL `TABLESAMPLE ... REPEATABLE ...` support via fluent modifiers on `sm.From(...)` and join chains. (thanks @atzedus)
 - Added PostgreSQL `JOIN ... USING (...) AS alias` support via `UsingAs(alias, cols...)` on psql join chains. (thanks @atzedus)
+- Added PostgreSQL GROUP BY grouping-element helpers: `sm.Grouping(...)`, `sm.Rollup(...)`, `sm.Cube(...)`, and `sm.GroupingSets(...)`. (thanks @atzedus)
 
 ### Changed
 

--- a/clause/group_by.go
+++ b/clause/group_by.go
@@ -56,8 +56,8 @@ func (g GroupBy) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect,
 }
 
 type GroupingSet struct {
-	Groups []bob.Expression
-	Type   string // GROUPING SET | CUBE | ROLLUP
+	Groups []any
+	Type   string // GROUPING SETS | CUBE | ROLLUP
 }
 
 func (g GroupingSet) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
@@ -68,4 +68,12 @@ func (g GroupingSet) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	}
 
 	return args, nil
+}
+
+type Grouping struct {
+	Groups []any
+}
+
+func (g Grouping) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	return bob.ExpressSlice(ctx, w, d, start, g.Groups, "(", ", ", ")")
 }

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -197,6 +197,30 @@ func TestSelect(t *testing.T) {
 			ExpectedSQL:  "SELECT id, name FROM users WHERE (id, employee_id) IN (($1, $2), ($3, $4))",
 			ExpectedArgs: []any{100, 200, 300, 400},
 		},
+		"group by grouped expression list": {
+			Query: psql.Select(
+				sm.Columns("region", psql.Raw("COUNT(*)")),
+				sm.From("sales"),
+				sm.GroupBy(sm.Grouping("region", "product")),
+			),
+			ExpectedSQL: `SELECT region, COUNT(*) FROM sales GROUP BY (region, product)`,
+		},
+		"group by rollup with nested group": {
+			Query: psql.Select(
+				sm.Columns("region", "product", psql.Raw("COUNT(*)")),
+				sm.From("sales"),
+				sm.GroupBy(sm.Rollup("region", sm.Grouping("product", "segment"))),
+			),
+			ExpectedSQL: `SELECT region, product, COUNT(*) FROM sales GROUP BY ROLLUP (region, (product, segment))`,
+		},
+		"group by grouping sets": {
+			Query: psql.Select(
+				sm.Columns("region", "product", psql.Raw("COUNT(*)")),
+				sm.From("sales"),
+				sm.GroupBy(sm.GroupingSets("region", sm.Grouping("product", "segment"), "()")),
+			),
+			ExpectedSQL: `SELECT region, product, COUNT(*) FROM sales GROUP BY GROUPING SETS (region, (product, segment), ())`,
+		},
 		"simple limit offset arg": {
 			Doc:          "Simple select with limit and offset as argument",
 			ExpectedSQL:  "SELECT id, name FROM users LIMIT $1 OFFSET $2",

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -85,6 +85,22 @@ func GroupByDistinct(distinct bool) bob.Mod[*dialect.SelectQuery] {
 	return mods.GroupByDistinct[*dialect.SelectQuery](distinct)
 }
 
+func Grouping(groups ...any) clause.Grouping {
+	return clause.Grouping{Groups: groups}
+}
+
+func Rollup(groups ...any) clause.GroupingSet {
+	return clause.GroupingSet{Type: "ROLLUP", Groups: groups}
+}
+
+func Cube(groups ...any) clause.GroupingSet {
+	return clause.GroupingSet{Type: "CUBE", Groups: groups}
+}
+
+func GroupingSets(groups ...any) clause.GroupingSet {
+	return clause.GroupingSet{Type: "GROUPING SETS", Groups: groups}
+}
+
 func Window(name string, winMods ...bob.Mod[*clause.Window]) bob.Mod[*dialect.SelectQuery] {
 	w := clause.Window{}
 	for _, mod := range winMods {


### PR DESCRIPTION
This PR adds PostgreSQL grouping-element helpers for GROUP BY: grouped tuple, ROLLUP, CUBE, and GROUPING SETS.
It extends clause primitives and psql helpers, with focused select tests for each grouping form.