### PR TITLE
feat(psql, sqlite): add im.Excluded helper and NoSep constant for expr.Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL `im.ConflictTarget(...)` helper for composing `ON CONFLICT` target items with optional `.Collate(...)` and `.OpClass(...)` modifiers. (thanks @atzedus)
 - Added PostgreSQL UPDATE/MERGE tuple-assignment helper `um.SetCols(columns...)` with `.ToExprs(...)`, `.ToRow(...)`, and `.ToQuery(...)` support. (thanks @atzedus)
 - Added PostgreSQL UPDATE/DELETE `um.WhereCurrentOf(cursor)` modifier to render `WHERE CURRENT OF <cursor>`. (thanks @atzedus)
+- Added `expr.Glue(exprs...)` and `expr.NoSep` sentinel to join expressions without any separator. The existing `expr.Join` default (space) is unchanged. (thanks @atzedus)
+- Added `im.Excluded(column)` helper (PostgreSQL and SQLite) for `ON CONFLICT DO UPDATE` assignments — renders as `EXCLUDED."col"` with no extra space, reused internally by `im.SetExcluded(...)` and available for direct use in `im.SetCol(...).To(...)`. (thanks @atzedus)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL `im.ConflictTarget(...)` helper for composing `ON CONFLICT` target items with optional `.Collate(...)` and `.OpClass(...)` modifiers. (thanks @atzedus)
 - Added PostgreSQL UPDATE/MERGE tuple-assignment helper `um.SetCols(columns...)` with `.ToExprs(...)`, `.ToRow(...)`, and `.ToQuery(...)` support. (thanks @atzedus)
 - Added PostgreSQL UPDATE/DELETE `um.WhereCurrentOf(cursor)` modifier to render `WHERE CURRENT OF <cursor>`. (thanks @atzedus)
-- Added `expr.Glue(exprs...)` and `expr.NoSep` sentinel to join expressions without any separator. The existing `expr.Join` default (space) is unchanged. (thanks @atzedus)
+- Added `expr.NoSep` sentinel to join expressions without any separator. The existing `expr.Join` default (space) is unchanged. (thanks @atzedus)
 - Added `im.Excluded(column)` helper (PostgreSQL and SQLite) for `ON CONFLICT DO UPDATE` assignments — renders as `EXCLUDED."col"` with no extra space, reused internally by `im.SetExcluded(...)` and available for direct use in `im.SetCol(...).To(...)`. (thanks @atzedus)
 
 ### Changed

--- a/dialect/psql/im/qm.go
+++ b/dialect/psql/im/qm.go
@@ -100,7 +100,12 @@ func SetCols(columns ...string) dialect.SetCols[*clause.ConflictClause] {
 //	SQL: EXCLUDED."col"
 //	Go: im.Excluded("col")
 func Excluded(column string) dialect.Expression {
-	return dialect.NewExpression(expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column)))
+	return dialect.NewExpression(
+		expr.Join{
+			Exprs: []bob.Expression{expr.Raw("EXCLUDED."), expr.Quote(column)},
+			Sep:   expr.NoSep,
+		},
+	)
 }
 
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {

--- a/dialect/psql/im/qm.go
+++ b/dialect/psql/im/qm.go
@@ -99,8 +99,8 @@ func SetCols(columns ...string) dialect.SetCols[*clause.ConflictClause] {
 //
 //	SQL: EXCLUDED."col"
 //	Go: im.Excluded("col")
-func Excluded(column string) bob.Expression {
-	return expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column))
+func Excluded(column string) dialect.Expression {
+	return dialect.NewExpression(expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column)))
 }
 
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {

--- a/dialect/psql/im/qm.go
+++ b/dialect/psql/im/qm.go
@@ -95,22 +95,25 @@ func SetCols(columns ...string) dialect.SetCols[*clause.ConflictClause] {
 	return dialect.NewSetCols[*clause.ConflictClause](columns...)
 }
 
+// Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.
+//
+//	SQL: EXCLUDED."col"
+//	Go: im.Excluded("col")
+func Excluded(column string) bob.Expression {
+	return expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column))
+}
+
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {
-	exprs := make([]any, 0, len(cols))
+	exprs := make([]bob.Expression, 0, len(cols))
 	for _, col := range cols {
 		if col == "" {
 			continue
 		}
-		exprs = append(exprs,
-			expr.Join{Exprs: []bob.Expression{
-				expr.Quote(col), expr.Raw("= EXCLUDED."), expr.Quote(col),
-			}},
-		)
+
+		exprs = append(exprs, expr.OP("=", expr.Quote(col), Excluded(col)))
 	}
 
-	return bob.ModFunc[*clause.ConflictClause](func(c *clause.ConflictClause) {
-		c.Set.Set = append(c.Set.Set, exprs...)
-	})
+	return Set(exprs...)
 }
 
 func Where(e bob.Expression) bob.Mod[*clause.ConflictClause] {

--- a/dialect/psql/insert_test.go
+++ b/dialect/psql/insert_test.go
@@ -260,6 +260,18 @@ func TestInsert(t *testing.T) {
 			ExpectedSQL:  `INSERT INTO users ("id", "first_name", "last_name") VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET ("first_name", "last_name") = (SELECT first_name, last_name FROM archived_users WHERE archived_users.id = EXCLUDED.id)`,
 			ExpectedArgs: []any{1, "Thomas", "Anderson"},
 		},
+		"insert with excluded in where": {
+			Query: psql.Insert(
+				im.Into("films"),
+				im.Values(psql.Arg("UA502", "Bananas")),
+				im.OnConflict("id").DoUpdate(
+					im.SetExcluded("title"),
+					im.Where(im.Excluded("id").EQ(psql.Arg(1))),
+				),
+			),
+			ExpectedSQL:  `INSERT INTO films VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title WHERE EXCLUDED.id = $3`,
+			ExpectedArgs: []any{"UA502", "Bananas", 1},
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/psql/insert_test.go
+++ b/dialect/psql/insert_test.go
@@ -104,8 +104,23 @@ func TestInsert(t *testing.T) {
 			ExpectedSQL: `INSERT INTO distributors AS "d" ("did", "dname")
 				VALUES ($1, $2), ($3, $4)
 				ON CONFLICT ON CONSTRAINT distributors_pkey DO UPDATE
-				SET "dname" = EXCLUDED. "dname"
+				SET dname = EXCLUDED.dname
 				WHERE (d.zipcode <> '21201')`,
+			ExpectedArgs: []any{8, "Anvil Distribution", 9, "Sentry Distribution"},
+		},
+		"upsert using excluded helper in set": {
+			Query: psql.Insert(
+				im.IntoAs("distributors", "d", "did", "dname"),
+				im.Values(psql.Arg(8, "Anvil Distribution")),
+				im.Values(psql.Arg(9, "Sentry Distribution")),
+				im.OnConflict("did").DoUpdate(
+					im.SetCol("dname").To(im.Excluded("dname")),
+				),
+			),
+			ExpectedSQL: `INSERT INTO distributors AS "d" ("did", "dname")
+			   VALUES ($1, $2), ($3, $4)
+			   ON CONFLICT (did) DO UPDATE
+			   SET dname = EXCLUDED.dname`,
 			ExpectedArgs: []any{8, "Anvil Distribution", 9, "Sentry Distribution"},
 		},
 		"insert overriding system value": {

--- a/dialect/sqlite/im/qm.go
+++ b/dialect/sqlite/im/qm.go
@@ -94,8 +94,8 @@ func SetCol(from string) mods.Set[*clause.ConflictClause] {
 }
 
 // Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.
-func Excluded(column string) bob.Expression {
-	return expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column))
+func Excluded(column string) dialect.Expression {
+	return dialect.Expression{}.New(expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column)))
 }
 
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {

--- a/dialect/sqlite/im/qm.go
+++ b/dialect/sqlite/im/qm.go
@@ -95,7 +95,12 @@ func SetCol(from string) mods.Set[*clause.ConflictClause] {
 
 // Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.
 func Excluded(column string) dialect.Expression {
-	return dialect.Expression{}.New(expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column)))
+	return dialect.Expression{}.New(
+		expr.Join{
+			Exprs: []bob.Expression{expr.Raw("EXCLUDED."), expr.Quote(column)},
+			Sep:   expr.NoSep,
+		},
+	)
 }
 
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {

--- a/dialect/sqlite/im/qm.go
+++ b/dialect/sqlite/im/qm.go
@@ -93,22 +93,21 @@ func SetCol(from string) mods.Set[*clause.ConflictClause] {
 	return mods.Set[*clause.ConflictClause]{from}
 }
 
+// Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.
+func Excluded(column string) bob.Expression {
+	return expr.Glue(expr.Raw("EXCLUDED."), expr.Quote(column))
+}
+
 func SetExcluded(cols ...string) bob.Mod[*clause.ConflictClause] {
-	exprs := make([]any, 0, len(cols))
+	exprs := make([]bob.Expression, 0, len(cols))
 	for _, col := range cols {
 		if col == "" {
 			continue
 		}
-		exprs = append(exprs,
-			expr.Join{Exprs: []bob.Expression{
-				expr.Quote(col), expr.Raw("= EXCLUDED."), expr.Quote(col),
-			}},
-		)
+		exprs = append(exprs, expr.OP("=", expr.Quote(col), Excluded(col)))
 	}
 
-	return bob.ModFunc[*clause.ConflictClause](func(c *clause.ConflictClause) {
-		c.Set.Set = append(c.Set.Set, exprs...)
-	})
+	return Set(exprs...)
 }
 
 func Where(e bob.Expression) bob.Mod[*clause.ConflictClause] {

--- a/dialect/sqlite/insert_test.go
+++ b/dialect/sqlite/insert_test.go
@@ -66,7 +66,7 @@ func TestInsert(t *testing.T) {
 			ExpectedSQL: `INSERT INTO distributors AS "d" ("did", "dname")
 				VALUES (?1, ?2), (?3, ?4)
 				ON CONFLICT (did) DO UPDATE
-				SET "dname" = EXCLUDED. "dname"
+				SET "dname" = EXCLUDED."dname"
 				WHERE ("d"."zipcode" <> '21201')`,
 			ExpectedArgs: []any{8, "Anvil Distribution", 9, "Sentry Distribution"},
 		},

--- a/expr/operators.go
+++ b/expr/operators.go
@@ -61,11 +61,3 @@ func (s Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, st
 
 	return bob.ExpressSlice(ctx, w, d, start, s.Exprs, "", sep, "")
 }
-
-// Glue joins expressions with no separator between them.
-//
-//	SQL: EXCLUDED."col"
-//	Go: expr.Glue(expr.Raw("EXCLUDED."), expr.Quote("col"))
-func Glue(exprs ...bob.Expression) Join {
-	return Join{Exprs: exprs, Sep: NoSep}
-}

--- a/expr/operators.go
+++ b/expr/operators.go
@@ -40,7 +40,11 @@ func OP(operator string, left, right any) bob.Expression {
 	}
 }
 
-// If no separator, a space is used
+// NoSep can be assigned to Join.Sep to join expressions with no separator at all.
+// The zero value of Sep (empty string) still defaults to a single space for backward compatibility.
+const NoSep = "\x00"
+
+// If Sep is empty, a space is used. Set Sep to NoSep to use no separator.
 type Join struct {
 	Exprs []bob.Expression
 	Sep   string
@@ -48,9 +52,20 @@ type Join struct {
 
 func (s Join) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	sep := s.Sep
-	if sep == "" {
+	switch sep {
+	case NoSep:
+		sep = ""
+	case "":
 		sep = " "
 	}
 
 	return bob.ExpressSlice(ctx, w, d, start, s.Exprs, "", sep, "")
+}
+
+// Glue joins expressions with no separator between them.
+//
+//	SQL: EXCLUDED."col"
+//	Go: expr.Glue(expr.Raw("EXCLUDED."), expr.Quote("col"))
+func Glue(exprs ...bob.Expression) Join {
+	return Join{Exprs: exprs, Sep: NoSep}
 }


### PR DESCRIPTION
This pull request introduces the `Excluded` helper for PostgreSQL and SQLite. These changes ensure correct handling of `EXCLUDED.<col>` expressions and improve code reusability.

#### Problem
Unwanted spaces in concatenated SQL expressions caused incorrect rendering, particularly for `EXCLUDED.<col>` constructs.

#### Solution
1. **New Helper**: `Excluded` simplifies generating `EXCLUDED.<col>` expressions.
   - Example:
     ```go
     psql.Insert(
       im.OnConflict("did").DoUpdate(
         im.SetCol("dname").To(im.Excluded("dname")),
       ),
     )     
     // Renders: EXCLUDED.dname
     ```
     
     ```go
     im.OnConflict("id").DoUpdate(
         im.SetExcluded("title"),
         im.Where(im.Excluded("id").EQ(psql.Arg(1))),
     ),
     // Renders: ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title WHERE EXCLUDED.id = $1
     ```

2. **Refactoring**:
   - Updated PostgreSQL and SQLite helpers to use `Excluded` and `expr.Join` with expr.NoSep.
