### PR TITLE
Add multi-source FROM/USING support for PostgreSQL UPDATE/DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL UPDATE/DELETE `um.WhereCurrentOf(cursor)` modifier to render `WHERE CURRENT OF <cursor>`. (thanks @atzedus)
 - Added `expr.NoSep` sentinel to join expressions without any separator. The existing `expr.Join` default (space) is unchanged. (thanks @atzedus)
 - Added `im.Excluded(column)` helper (PostgreSQL and SQLite) for `ON CONFLICT DO UPDATE` assignments — renders as `EXCLUDED."col"` with no extra space, reused internally by `im.SetExcluded(...)` and available for direct use in `im.SetCol(...).To(...)`. (thanks @atzedus)
+- Added PostgreSQL `psql.TableFunctions(funcs)` and `sm.FromFunction` / `um.FromFunction` / `dm.UsingFunction` helpers that return `bob.Expression` for table-function `from_item` sources (`ROWS FROM (...)` when multiple functions are given). (thanks @atzedus)
+- Added PostgreSQL `um.From(table, joins...)` and `dm.Using(table, joins...)` variadic join arguments so each appended `from_item` can include inline `INNER JOIN`, `LEFT JOIN`, `CROSS JOIN`, etc. (`JoinChain` builders). (thanks @atzedus)
+- Added `bobgen-psql` support for multiple `UPDATE ... FROM` / `DELETE ... USING` sources: sql-to-code emits `AppendTableRef(...)` per parsed `from_item` and resolves column sources from every item. (thanks @atzedus)
 
 ### Changed
 
@@ -32,9 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
 - **BREAKING:** Generated `*Columns` accessor fields now return a dialect-specific wrapper type (e.g., `userColumn`) instead of plain `dialect.Expression`. The wrapper still implements `dialect.Expression` and avoids extra auto-parentheses in expression builders. Use `.Expression` only when you explicitly need the embedded expression value. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `UPDATE ... FROM` and `DELETE ... USING` additional sources now live in `UpdateQuery.FromItems` / `DeleteQuery.UsingItems` instead of the embedded `clause.TableRef` on the query struct. Each `um.From(...)` or `dm.Using(...)` appends one comma-separated `from_item` (last call no longer wins). Use `um.Table(...)` / `dm.From(...)` for the update/delete target table. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `sm.FromFunction` and `um.FromFunction` no longer return `FromChain` or apply `FROM`/`USING` by themselves. They return `bob.Expression` and must be passed to `sm.From(...)` / `um.From(...)` / `dm.Using(...)` — e.g. `sm.From(sm.FromFunction(psql.F("generate_series", 1, 3)()))` instead of `sm.FromFunction(...)`. Aliasing and other table modifiers belong on `sm.From(...)` / `um.From(...)`. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `sm.From` / `FromChain` for `SelectQuery` now set the `FROM` source via `AppendTableRef` (replace semantics) instead of `SetTable` / `SetTableAlias` on a `fromable` interface. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `um` / `dm` join helpers (`InnerJoin`, `LeftJoin`, `CrossJoin`, etc.) now return `JoinChain[any]` and are only valid as variadic arguments to `um.From(table, joins...)` / `dm.Using(table, joins...)`. They are no longer standalone `bob.Mod` values: on `main`, `um.InnerJoin` / `dm.InnerJoin` returned `JoinChain[*UpdateQuery]` / `[*DeleteQuery]` and applied joins through the embedded `clause.TableRef` on those query types, which no longer holds additional `FROM` / `USING` sources. (thanks @atzedus)
+- **BREAKING:** PostgreSQL psql join chain modifiers `.Natural()`, `.On()`, `.OnEQ()`, `.Using()`, and `.UsingAs()` now return `JoinChain` for fluent chaining instead of `bob.Mod`. (thanks @atzedus)
 
 ### Fixed
 
+- Fix PostgreSQL `sm.From` replacing a previous `FROM` without clearing a stale table alias when the new source has no alias. (thanks @atzedus)
 - Fix PostgreSQL `sm.With(...).SearchBreadth(...)` rendering `SEARCH DEPTH` instead of `SEARCH BREADTH` in CTE queries. (thanks @atzedus)
 - Avoid unnecessary imports in generated random factory code when a type has no random expression. (thanks @jay-babu)
 - Fix missing base type imports (e.g. `github.com/google/uuid`) in generated models when using `type_system: "database/sql"` and `uuid_pkg: google`, which could cause compile errors in generated many-to-many relation helpers. (thanks @atzedus)

--- a/dialect/psql/delete_test.go
+++ b/dialect/psql/delete_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
 	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/fm"
 	testutils "github.com/stephenafamo/bob/test/utils"
 )
 
@@ -31,6 +32,115 @@ func TestDelete(t *testing.T) {
 			  WHERE (accounts.name = $1)
 			  AND (employees.id = accounts.sales_person)`,
 			ExpectedArgs: []any{"Acme Corporation"},
+		},
+		"with using append": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using and using append": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using append and join": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using append join and alias": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				).As("a"),
+				dm.Where(psql.Quote("a", "dept_id").IsNotNull()),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts AS "a"
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")
+			  WHERE ("a"."dept_id" IS NOT NULL)`,
+		},
+		"with multiple using tables cross join": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments", dm.CrossJoin("regions")),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, (departments
+			  CROSS JOIN regions)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using function": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using(dm.UsingFunction(psql.F("generate_series", 1, 2)())),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING generate_series(1, 2)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using function rows from": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using(dm.UsingFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER))
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
+		},
+		"with multiple using items join rows from and table": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				dm.Using(dm.UsingFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				dm.Using("regions"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING (accounts
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")), ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)), regions
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
 		},
 		"where current of": {
 			Query: psql.Delete(

--- a/dialect/psql/dialect/delete.go
+++ b/dialect/psql/dialect/delete.go
@@ -12,9 +12,9 @@ import (
 // https://www.postgresql.org/docs/current/sql-delete.html
 type DeleteQuery struct {
 	clause.With
-	Only  bool
-	Table clause.TableRef
-	clause.TableRef
+	Only       bool
+	Table      clause.TableRef
+	UsingItems []clause.TableRef
 	clause.WhereCurrentOf
 	clause.Where
 	clause.Returning
@@ -22,6 +22,10 @@ type DeleteQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*DeleteQuery]
+}
+
+func (d *DeleteQuery) AppendTableRef(using clause.TableRef) {
+	d.UsingItems = append(d.UsingItems, using)
 }
 
 func (d DeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, dl bob.Dialect, start int) ([]any, error) {
@@ -51,12 +55,10 @@ func (d DeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, dl bob.Dia
 	}
 	args = append(args, tableArgs...)
 
-	usingArgs, err := bob.ExpressIf(ctx, w, dl, start+len(args), d.TableRef,
-		d.TableRef.Expression != nil, "\nUSING ", "")
+	args, err = writeDeleteUsing(ctx, w, dl, start+len(args), args, d.UsingItems)
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, usingArgs...)
 
 	whereArgs, err := clause.WriteWhereAndCurrentOf(ctx, w, dl, start+len(args), d.Where, d.WhereCurrentOf)
 	if err != nil {
@@ -72,4 +74,17 @@ func (d DeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, dl bob.Dia
 	args = append(args, retArgs...)
 
 	return args, nil
+}
+
+func writeDeleteUsing(
+	ctx context.Context, w io.StringWriter, dl bob.Dialect, start int,
+	args []any, usingItems []clause.TableRef,
+) ([]any, error) {
+	if len(usingItems) == 0 {
+		return args, nil
+	}
+
+	w.WriteString("\nUSING ")
+
+	return writeFromItemList(ctx, w, dl, start, args, usingItems)
 }

--- a/dialect/psql/dialect/from_items.go
+++ b/dialect/psql/dialect/from_items.go
@@ -1,0 +1,43 @@
+package dialect
+
+import (
+	"context"
+	"io"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+)
+
+// needsFromItemParens reports whether a from_item must be parenthesized when
+// written in a comma-separated FROM/USING list. JOIN binds tighter than comma
+// in PostgreSQL, so an item with joins needs parens when other items follow.
+func needsFromItemParens(items []clause.TableRef, item clause.TableRef) bool {
+	return len(items) > 1 && len(item.Joins) > 0
+}
+
+func writeFromItemList(
+	ctx context.Context, w io.StringWriter, d bob.Dialect, start int,
+	args []any, items []clause.TableRef,
+) ([]any, error) {
+	for i, item := range items {
+		if i > 0 {
+			w.WriteString(", ")
+		}
+
+		if needsFromItemParens(items, item) {
+			w.WriteString("(")
+		}
+
+		itemArgs, err := bob.Express(ctx, w, d, start+len(args), item)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, itemArgs...)
+
+		if needsFromItemParens(items, item) {
+			w.WriteString(")")
+		}
+	}
+
+	return args, nil
+}

--- a/dialect/psql/dialect/function.go
+++ b/dialect/psql/dialect/function.go
@@ -120,7 +120,22 @@ func (c columnDef) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialec
 	return nil, nil
 }
 
+// Functions renders ROWS FROM (f1, f2, ...) for multiple table functions in one
+// from_item.
 type Functions []*Function
+
+// TableFunctions returns a FROM/USING expression for table functions: a single
+// function_name(...) or ROWS FROM (...) when multiple are given.
+func TableFunctions(funcs ...*Function) bob.Expression {
+	switch len(funcs) {
+	case 0:
+		return nil
+	case 1:
+		return funcs[0]
+	default:
+		return Functions(funcs)
+	}
+}
 
 func (f Functions) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	if len(f) > 1 {

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/clause"
 	"github.com/stephenafamo/bob/expr"
-	"github.com/stephenafamo/bob/mods"
 )
 
 type Distinct struct {
@@ -33,64 +32,53 @@ func With[Q interface{ AppendCTE(bob.Expression) }](name string, columns ...stri
 	})
 }
 
-type fromable interface {
-	SetTable(any)
-	SetTableAlias(alias string, columns ...string)
-	SetOnly(bool)
-	SetTableSample(method string, args ...any)
-	SetTableSampleRepeatable(seed any)
-	SetLateral(bool)
-	SetWithOrdinality(bool)
+type FromChain[Q any] struct {
+	from  func() clause.TableRef
+	joins func(*clause.TableRef)
+	apply func(Q, clause.TableRef)
 }
 
-func From[Q fromable](table any) FromChain[Q] {
-	return FromChain[Q](func() clause.TableRef {
-		return clause.TableRef{Expression: table}
-	})
+func (f FromChain[Q]) chain(from func() clause.TableRef) FromChain[Q] {
+	return FromChain[Q]{
+		from:  from,
+		joins: f.joins,
+		apply: f.apply,
+	}
 }
-
-type FromChain[Q fromable] func() clause.TableRef
 
 func (f FromChain[Q]) Apply(q Q) {
-	from := f()
-
-	q.SetTable(from.Expression)
-	if from.Alias != "" {
-		q.SetTableAlias(from.Alias, from.Columns...)
+	ref := f.from()
+	if f.joins != nil {
+		f.joins(&ref)
 	}
-
-	q.SetOnly(from.Only)
-	q.SetTableSample(from.TableSample, from.TableSampleArgs...)
-	q.SetTableSampleRepeatable(from.Repeatable)
-	q.SetLateral(from.Lateral)
-	q.SetWithOrdinality(from.WithOrdinality)
+	f.apply(q, ref)
 }
 
 func (f FromChain[Q]) As(alias string, columns ...string) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Alias = alias
 	fr.Columns = columns
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) Only() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Only = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) TableSample(method string, args ...any) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.TableSample = method
 	fr.TableSampleArgs = args
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
@@ -104,35 +92,56 @@ func (f FromChain[Q]) TableSampleBernoulli(args ...any) FromChain[Q] {
 }
 
 func (f FromChain[Q]) Repeatable(seed any) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Repeatable = seed
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) Lateral() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Lateral = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) WithOrdinality() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.WithOrdinality = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
-type Joinable interface{ AppendJoin(clause.Join) }
+type fromAppendable interface{ AppendTableRef(clause.TableRef) }
 
-func Join[Q Joinable](typ string, e any) JoinChain[Q] {
+func From[Q fromAppendable](table any, joins ...JoinChain[any]) FromChain[Q] {
+	return FromChain[Q]{
+		from: func() clause.TableRef {
+			return clause.TableRef{Expression: table}
+		},
+		joins: func(ref *clause.TableRef) {
+			for _, j := range joins {
+				ref.Joins = append(ref.Joins, j())
+			}
+		},
+		apply: func(q Q, ref clause.TableRef) {
+			q.AppendTableRef(ref)
+		},
+	}
+}
+
+// Joinable is a query that accepts standalone JOIN mods (e.g. *SelectQuery via embedded TableRef).
+type Joinable interface {
+	AppendJoin(clause.Join)
+}
+
+func Join[Q any](typ string, e any) JoinChain[Q] {
 	return JoinChain[Q](func() clause.Join {
 		return clause.Join{
 			Type: typ,
@@ -141,35 +150,32 @@ func Join[Q Joinable](typ string, e any) JoinChain[Q] {
 	})
 }
 
-func InnerJoin[Q Joinable](e any) JoinChain[Q] {
+func InnerJoin[Q any](e any) JoinChain[Q] {
 	return Join[Q](clause.InnerJoin, e)
 }
 
-func LeftJoin[Q Joinable](e any) JoinChain[Q] {
+func LeftJoin[Q any](e any) JoinChain[Q] {
 	return Join[Q](clause.LeftJoin, e)
 }
 
-func RightJoin[Q Joinable](e any) JoinChain[Q] {
+func RightJoin[Q any](e any) JoinChain[Q] {
 	return Join[Q](clause.RightJoin, e)
 }
 
-func FullJoin[Q Joinable](e any) JoinChain[Q] {
+func FullJoin[Q any](e any) JoinChain[Q] {
 	return Join[Q](clause.FullJoin, e)
 }
 
-func CrossJoin[Q Joinable](e any) CrossJoinChain[Q] {
-	return CrossJoinChain[Q](func() clause.Join {
-		return clause.Join{
-			Type: clause.CrossJoin,
-			To:   clause.TableRef{Expression: e},
-		}
-	})
+func CrossJoin[Q any](e any) JoinChain[Q] {
+	return Join[Q](clause.CrossJoin, e)
 }
 
-type JoinChain[Q Joinable] func() clause.Join
+type JoinChain[Q any] func() clause.Join
 
 func (j JoinChain[Q]) Apply(q Q) {
-	q.AppendJoin(j())
+	if ja, ok := any(q).(Joinable); ok {
+		ja.AppendJoin(j())
+	}
 }
 
 func (j JoinChain[Q]) As(alias string, columns ...string) JoinChain[Q] {
@@ -236,54 +242,48 @@ func (f JoinChain[Q]) WithOrdinality() JoinChain[Q] {
 	})
 }
 
-func (j JoinChain[Q]) Natural() bob.Mod[Q] {
+func (j JoinChain[Q]) Natural() JoinChain[Q] {
 	jo := j()
 	jo.Natural = true
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) On(on ...bob.Expression) bob.Mod[Q] {
+func (j JoinChain[Q]) On(on ...bob.Expression) JoinChain[Q] {
 	jo := j()
 	jo.On = append(jo.On, on...)
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) OnEQ(a, b bob.Expression) bob.Mod[Q] {
+func (j JoinChain[Q]) OnEQ(a, b bob.Expression) JoinChain[Q] {
 	jo := j()
 	jo.On = append(jo.On, expr.X[Expression, Expression](a).EQ(b))
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
+func (j JoinChain[Q]) Using(using ...string) JoinChain[Q] {
 	jo := j()
 	jo.Using = using
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) UsingAs(alias string, using ...string) bob.Mod[Q] {
+func (j JoinChain[Q]) UsingAs(alias string, using ...string) JoinChain[Q] {
 	jo := j()
 	jo.Using = using
 	jo.UsingAs = alias
 
-	return mods.Join[Q](jo)
-}
-
-type CrossJoinChain[Q Joinable] func() clause.Join
-
-func (j CrossJoinChain[Q]) Apply(q Q) {
-	q.AppendJoin(j())
-}
-
-func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
-	jo := j()
-	jo.To.Alias = alias
-	jo.To.Columns = columns
-
-	return CrossJoinChain[Q](func() clause.Join {
+	return JoinChain[Q](func() clause.Join {
 		return jo
 	})
 }

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -36,6 +36,10 @@ type SelectQuery struct {
 	CombinedOffset clause.Offset
 }
 
+func (s *SelectQuery) AppendTableRef(ref clause.TableRef) {
+	s.TableRef = ref
+}
+
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	var err error
 	var args []any

--- a/dialect/psql/dialect/update.go
+++ b/dialect/psql/dialect/update.go
@@ -15,7 +15,7 @@ type UpdateQuery struct {
 	Only  bool
 	Table clause.TableRef
 	clause.Set
-	clause.TableRef
+	FromItems []clause.TableRef
 	clause.WhereCurrentOf
 	clause.Where
 	clause.Returning
@@ -23,6 +23,10 @@ type UpdateQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*UpdateQuery]
+}
+
+func (u *UpdateQuery) AppendTableRef(from clause.TableRef) {
+	u.FromItems = append(u.FromItems, from)
 }
 
 func (u UpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
@@ -58,12 +62,10 @@ func (u UpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	}
 	args = append(args, setArgs...)
 
-	fromArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), u.TableRef,
-		u.TableRef.Expression != nil, "\nFROM ", "")
+	args, err = writeUpdateFrom(ctx, w, d, start+len(args), args, u.FromItems)
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, fromArgs...)
 
 	whereArgs, err := clause.WriteWhereAndCurrentOf(ctx, w, d, start+len(args), u.Where, u.WhereCurrentOf)
 	if err != nil {
@@ -79,4 +81,17 @@ func (u UpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	args = append(args, retArgs...)
 
 	return args, nil
+}
+
+func writeUpdateFrom(
+	ctx context.Context, w io.StringWriter, d bob.Dialect, start int,
+	args []any, fromItems []clause.TableRef,
+) ([]any, error) {
+	if len(fromItems) == 0 {
+		return args, nil
+	}
+
+	w.WriteString("\nFROM ")
+
+	return writeFromItemList(ctx, w, d, start, args, fromItems)
 }

--- a/dialect/psql/dm/qm.go
+++ b/dialect/psql/dm/qm.go
@@ -38,28 +38,34 @@ func FromAs(name any, alias string) bob.Mod[*dialect.DeleteQuery] {
 	})
 }
 
-func Using(table any) dialect.FromChain[*dialect.DeleteQuery] {
-	return dialect.From[*dialect.DeleteQuery](table)
+func Using(table any, joins ...dialect.JoinChain[any]) dialect.FromChain[*dialect.DeleteQuery] {
+	return dialect.From[*dialect.DeleteQuery](table, joins...)
 }
 
-func InnerJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
-	return dialect.InnerJoin[*dialect.DeleteQuery](e)
+// UsingFunction returns an expression for dm.Using when the source is one or more
+// table functions (ROWS FROM when multiple).
+func UsingFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
-func LeftJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
-	return dialect.LeftJoin[*dialect.DeleteQuery](e)
+func InnerJoin(e any) dialect.JoinChain[any] {
+	return dialect.InnerJoin[any](e)
 }
 
-func RightJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
-	return dialect.RightJoin[*dialect.DeleteQuery](e)
+func LeftJoin(e any) dialect.JoinChain[any] {
+	return dialect.LeftJoin[any](e)
 }
 
-func FullJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
-	return dialect.FullJoin[*dialect.DeleteQuery](e)
+func RightJoin(e any) dialect.JoinChain[any] {
+	return dialect.RightJoin[any](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.DeleteQuery] {
-	return dialect.CrossJoin[*dialect.DeleteQuery](e)
+func FullJoin(e any) dialect.JoinChain[any] {
+	return dialect.FullJoin[any](e)
+}
+
+func CrossJoin(e any) dialect.JoinChain[any] {
+	return dialect.CrossJoin[any](e)
 }
 
 func Where(e bob.Expression) mods.Where[*dialect.DeleteQuery] {

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -30,6 +30,57 @@ func TestSelect(t *testing.T) {
 				sm.Where(psql.Quote("id").In(psql.Arg(100, 200, 300))),
 			),
 		},
+		"from replaces previous alias": {
+			Doc:         "A later From without alias replaces the whole table ref",
+			ExpectedSQL: "SELECT id FROM orders",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users").As("u"),
+				sm.From("orders"),
+			),
+		},
+		"from multiple tables cross join": {
+			Doc:         "Multiple tables in FROM via CROSS JOIN on the primary from_item",
+			ExpectedSQL: "SELECT id FROM users CROSS JOIN orders",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.CrossJoin("orders"),
+			),
+		},
+		"from function": {
+			Doc:         "FROM a single table function via TableFunctions",
+			ExpectedSQL: "SELECT p FROM generate_series(1, 3)",
+			Query: psql.Select(
+				sm.Columns("p"),
+				sm.From(sm.FromFunction(psql.F("generate_series", 1, 3)())),
+			),
+		},
+		"from with join": {
+			Doc:         "FROM with an inline INNER JOIN on the from_item",
+			ExpectedSQL: `SELECT id FROM users INNER JOIN events ON ("users"."id" = "events"."user_id")`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.InnerJoin("events").OnEQ(
+					psql.Quote("users", "id"),
+					psql.Quote("events", "user_id"),
+				),
+			),
+		},
+		"from rows from with cross join": {
+			Doc: "FROM ROWS FROM (...) with an additional table via CROSS JOIN",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From(sm.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				sm.CrossJoin("orders"),
+			),
+			ExpectedSQL:  `SELECT id FROM ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)) CROSS JOIN orders`,
+			ExpectedArgs: []any{`[{"a":1}]`},
+		},
 		"case with else": {
 			ExpectedSQL: `SELECT id, name, (CASE WHEN (id = '1') THEN 'A' ELSE 'B' END) AS "C" FROM users`,
 			Query: psql.Select(
@@ -120,7 +171,7 @@ func TestSelect(t *testing.T) {
 		"with rows from": {
 			Doc: "Select from group of functions. Automatically uses the `ROWS FROM` syntax",
 			Query: psql.Select(
-				sm.FromFunction(
+				sm.From(sm.FromFunction(
 					psql.F(
 						"json_to_recordset",
 						psql.Arg(`[{"a":40,"b":"foo"},{"a":"100","b":"bar"}]`),
@@ -129,7 +180,7 @@ func TestSelect(t *testing.T) {
 						fm.Columns("b", "TEXT"),
 					),
 					psql.F("generate_series", 1, 3)(),
-				).As("x", "p", "q", "s"),
+				)).As("x", "p", "q", "s"),
 				sm.OrderBy("p"),
 			),
 			ExpectedSQL: `SELECT *

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -33,18 +33,10 @@ func From(table any) dialect.FromChain[*dialect.SelectQuery] {
 	return dialect.From[*dialect.SelectQuery](table)
 }
 
-func FromFunction(funcs ...*dialect.Function) dialect.FromChain[*dialect.SelectQuery] {
-	var table any
-
-	if len(funcs) == 1 {
-		table = funcs[0]
-	}
-
-	if len(funcs) > 1 {
-		table = dialect.Functions(funcs)
-	}
-
-	return dialect.From[*dialect.SelectQuery](table)
+// FromFunction returns an expression for sm.From when the source is one or more
+// table functions (ROWS FROM when multiple).
+func FromFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
 func InnerJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
@@ -63,7 +55,7 @@ func FullJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
 	return dialect.FullJoin[*dialect.SelectQuery](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.SelectQuery] {
+func CrossJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
 	return dialect.CrossJoin[*dialect.SelectQuery](e)
 }
 

--- a/dialect/psql/starters.go
+++ b/dialect/psql/starters.go
@@ -28,6 +28,12 @@ func F(name string, args ...any) mods.Moddable[*dialect.Function] {
 	})
 }
 
+// TableFunctions returns a FROM/USING table-function source for sm.From, um.From,
+// or dm.Using (ROWS FROM when multiple functions are given).
+func TableFunctions(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
+}
+
 // S creates a string literal
 // SQL: 'a string'
 // Go: psql.S("a string")

--- a/dialect/psql/um/qm.go
+++ b/dialect/psql/um/qm.go
@@ -54,42 +54,34 @@ func SetCols(columns ...string) dialect.SetCols[*dialect.UpdateQuery] {
 	return dialect.NewSetCols[*dialect.UpdateQuery](columns...)
 }
 
-func From(table any) dialect.FromChain[*dialect.UpdateQuery] {
-	return dialect.From[*dialect.UpdateQuery](table)
+func From(table any, joins ...dialect.JoinChain[any]) dialect.FromChain[*dialect.UpdateQuery] {
+	return dialect.From[*dialect.UpdateQuery](table, joins...)
 }
 
-func FromFunction(funcs ...*dialect.Function) dialect.FromChain[*dialect.UpdateQuery] {
-	var table any
-
-	if len(funcs) == 1 {
-		table = funcs[0]
-	}
-
-	if len(funcs) > 1 {
-		table = dialect.Functions(funcs)
-	}
-
-	return dialect.From[*dialect.UpdateQuery](table)
+// FromFunction returns an expression for um.From when the source is one or more
+// table functions (ROWS FROM when multiple).
+func FromFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
-func InnerJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
-	return dialect.InnerJoin[*dialect.UpdateQuery](e)
+func InnerJoin(e any) dialect.JoinChain[any] {
+	return dialect.InnerJoin[any](e)
 }
 
-func LeftJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
-	return dialect.LeftJoin[*dialect.UpdateQuery](e)
+func LeftJoin(e any) dialect.JoinChain[any] {
+	return dialect.LeftJoin[any](e)
 }
 
-func RightJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
-	return dialect.RightJoin[*dialect.UpdateQuery](e)
+func RightJoin(e any) dialect.JoinChain[any] {
+	return dialect.RightJoin[any](e)
 }
 
-func FullJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
-	return dialect.FullJoin[*dialect.UpdateQuery](e)
+func FullJoin(e any) dialect.JoinChain[any] {
+	return dialect.FullJoin[any](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.UpdateQuery] {
-	return dialect.CrossJoin[*dialect.UpdateQuery](e)
+func CrossJoin(e any) dialect.JoinChain[any] {
+	return dialect.CrossJoin[any](e)
 }
 
 func Where(e bob.Expression) mods.Where[*dialect.UpdateQuery] {

--- a/dialect/psql/update_test.go
+++ b/dialect/psql/update_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/fm"
 	"github.com/stephenafamo/bob/dialect/psql/sm"
 	"github.com/stephenafamo/bob/dialect/psql/um"
 	testutils "github.com/stephenafamo/bob/test/utils"
@@ -34,6 +35,133 @@ func TestUpdate(t *testing.T) {
 			  WHERE (accounts.name = $1)
 			  AND (employees.id = accounts.sales_person)`,
 			ExpectedArgs: []any{"Acme Corporation"},
+		},
+		"with from append": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments"),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from and from append": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments"),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from append and join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts",
+					um.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from append and cross join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts", um.CrossJoin("departments")),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  CROSS JOIN departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from append join and alias": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts",
+					um.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				).As("a"),
+				um.Where(psql.Quote("a", "dept_id").IsNotNull()),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts AS "a"
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")
+			  WHERE ("a"."dept_id" IS NOT NULL)`,
+		},
+		"with multiple from tables cross join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments", um.CrossJoin("regions")),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, (departments
+			  CROSS JOIN regions)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from function": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From(um.FromFunction(psql.F("generate_series", 1, 3)())),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM generate_series(1, 3)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from function rows from": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From(um.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER))
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
+		},
+		"with multiple from items join rows from and table": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("n").To("1"),
+				um.From("accounts",
+					um.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				um.From(um.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				um.From("regions"),
+			),
+			ExpectedSQL: `UPDATE employees SET "n" = 1 FROM (accounts
+			  INNER JOIN departments ON ("accounts"."dept_id" = "departments"."id")), ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)), regions`,
+			ExpectedArgs: []any{`[{"a":1}]`},
 		},
 		"set tuple columns from row": {
 			Query: psql.Update(

--- a/gen/bobgen-psql/driver/parser/mods.go
+++ b/gen/bobgen-psql/driver/parser/mods.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	pg "github.com/pganalyze/pg_query_go/v6"
 	"github.com/stephenafamo/bob/internal"
@@ -26,6 +27,34 @@ func (w *walker) modWithClause(with *pg.WithClause, info nodeInfo) {
 				int(cteInfos.end-1),
 				func(start, end int) error {
 					fmt.Fprintf(w.mods, "q.AppendCTE(EXPR.subExpr(%d, %d))\n", start, end)
+					return nil
+				},
+			)...,
+		)
+	}
+}
+
+func (w *walker) modAppendTableRefItems(clauseInfo nodeInfo, items []*pg.Node) {
+	for i, item := range items {
+		if item == nil {
+			continue
+		}
+
+		itemInfo, ok := clauseInfo.children[strconv.Itoa(i)]
+		if !ok {
+			continue
+		}
+
+		w.editRules = append(w.editRules,
+			internal.RecordPoints(
+				int(itemInfo.start),
+				int(itemInfo.end)-1,
+				func(start, end int) error {
+					fmt.Fprintf(
+						w.mods,
+						"q.AppendTableRef(clause.TableRef{Expression: EXPR.subExpr(%d, %d)})\n",
+						start, end,
+					)
 					return nil
 				},
 			)...,

--- a/gen/bobgen-psql/driver/parser/mods_delete.go
+++ b/gen/bobgen-psql/driver/parser/mods_delete.go
@@ -29,16 +29,7 @@ func (w *walker) modDeleteStatement(stmt *pg.Node_DeleteStmt, info nodeInfo) {
 	}
 
 	if usingInfo, ok := info.children["UsingClause"]; ok {
-		w.editRules = append(w.editRules,
-			internal.RecordPoints(
-				int(usingInfo.start),
-				int(usingInfo.end)-1,
-				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.SetTable(EXPR.subExpr(%d, %d))\n", start, end)
-					return nil
-				},
-			)...,
-		)
+		w.modAppendTableRefItems(usingInfo, stmt.DeleteStmt.UsingClause)
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {

--- a/gen/bobgen-psql/driver/parser/mods_update.go
+++ b/gen/bobgen-psql/driver/parser/mods_update.go
@@ -42,16 +42,7 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if fromInfo, ok := info.children["FromClause"]; ok {
-		w.editRules = append(w.editRules,
-			internal.RecordPoints(
-				int(fromInfo.start),
-				int(fromInfo.end)-1,
-				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.SetTable(EXPR.subExpr(%d, %d))\n", start, end)
-					return nil
-				},
-			)...,
-		)
+		w.modAppendTableRefItems(fromInfo, stmt.UpdateStmt.FromClause)
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -197,9 +197,10 @@ func (w *walker) getUpdateSource(stmt *pg.UpdateStmt, info nodeInfo, sources ...
 		)
 	}
 
-	from := stmt.FromClause[0]
-	fromInfo := info.children["FromClause"].children["0"]
-	sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	for i, from := range stmt.FromClause {
+		fromInfo := info.children["FromClause"].children[strconv.Itoa(i)]
+		sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	}
 
 	return w.getSourceFromTargets(
 		stmt.ReturningList,
@@ -222,9 +223,10 @@ func (w *walker) getDeleteSource(stmt *pg.DeleteStmt, info nodeInfo, sources ...
 		)
 	}
 
-	from := stmt.UsingClause[0]
-	fromInfo := info.children["UsingClause"].children["0"]
-	sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	for i, from := range stmt.UsingClause {
+		fromInfo := info.children["UsingClause"].children[strconv.Itoa(i)]
+		sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	}
 
 	return w.getSourceFromTargets(
 		stmt.ReturningList,

--- a/gen/bobgen-psql/driver/parser/verify.go
+++ b/gen/bobgen-psql/driver/parser/verify.go
@@ -23,20 +23,12 @@ func verifyUpdateStatement(stmt *pg.UpdateStmt, _ nodeInfo) error {
 		return fmt.Errorf("nil statement")
 	}
 
-	if len(stmt.FromClause) > 1 {
-		return fmt.Errorf("multiple FROM tables are not supported, convert to a CROSS JOIN")
-	}
-
 	return nil
 }
 
 func verifyDeleteStatement(stmt *pg.DeleteStmt, _ nodeInfo) error {
 	if stmt == nil {
 		return fmt.Errorf("nil statement")
-	}
-
-	if len(stmt.UsingClause) > 1 {
-		return fmt.Errorf("multiple USING tables are not supported, convert to a CROSS JOIN")
 	}
 
 	return nil

--- a/website/docs/query-builder/psql/examples/select.md
+++ b/website/docs/query-builder/psql/examples/select.md
@@ -160,7 +160,7 @@ Code:
 
 ```go
 psql.Select(
-  sm.FromFunction(
+  sm.From(sm.FromFunction(
     psql.F(
       "json_to_recordset",
       psql.Arg(`[{"a":40,"b":"foo"},{"a":"100","b":"bar"}]`),
@@ -169,7 +169,7 @@ psql.Select(
       fm.Columns("b", "TEXT"),
     ),
     psql.F("generate_series", 1, 3)(),
-  ).As("x", "p", "q", "s"),
+  )).As("x", "p", "q", "s"),
   sm.OrderBy("p"),
 )
 ```


### PR DESCRIPTION
This PR adds support for multiple `from_item` sources in PostgreSQL `UPDATE ... FROM` and `DELETE ... USING` via new append-style modifiers, without breaking existing API.

#### Features

- New: `um.FromAppend(...)` and `dm.UsingAppend(...)` allow adding multiple sources to the `FROM`/`USING` clause.
- Existing `um.From(...)` and `dm.Using(...)` keep their override (last call wins) behavior.
- Mixed usage is supported: calling `From/Using` after append resets the list; calling append after `From/Using` extends it.

#### Examples

```go
// Multiple FROM sources in UPDATE
psql.Update(
    um.Table("t"),
    um.SetCol("x").ToArg(1),
    um.FromAppend("a").As("a1"),
    um.FromAppend("b"),
)
// SQL: UPDATE t SET x = $1 FROM a AS a1, b

// Mixed: override after append
psql.Update(
    um.Table("t"),
    um.FromAppend("a"),
    um.From("b"),
)
// SQL: UPDATE t FROM b

// Multiple USING sources in DELETE
psql.Delete(
    dm.From("t"),
    dm.UsingAppend("a"),
    dm.UsingAppend("b").Only(),
)
// SQL: DELETE FROM t USING a, ONLY b
```

All existing usages of `From`/`Using` remain fully compatible. 