### PR TITLE
feat(psql): multiple FROM/USING sources, join chains, and table functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PostgreSQL UPDATE/DELETE `um.WhereCurrentOf(cursor)` modifier to render `WHERE CURRENT OF <cursor>`. (thanks @atzedus)
 - Added `expr.NoSep` sentinel to join expressions without any separator. The existing `expr.Join` default (space) is unchanged. (thanks @atzedus)
 - Added `im.Excluded(column)` helper (PostgreSQL and SQLite) for `ON CONFLICT DO UPDATE` assignments — renders as `EXCLUDED."col"` with no extra space, reused internally by `im.SetExcluded(...)` and available for direct use in `im.SetCol(...).To(...)`. (thanks @atzedus)
+- Added PostgreSQL `psql.TableFunctions(funcs)` and `sm.FromFunction` / `um.FromFunction` / `dm.UsingFunction` helpers that return `bob.Expression` for table-function `from_item` sources (`ROWS FROM (...)` when multiple functions are given). (thanks @atzedus)
+- Added PostgreSQL `um.From(table, joins...)` and `dm.Using(table, joins...)` variadic join arguments so each appended `from_item` can include inline `INNER JOIN`, `LEFT JOIN`, `CROSS JOIN`, etc. (`JoinChain` builders). (thanks @atzedus)
+- Added `bobgen-psql` support for multiple `UPDATE ... FROM` / `DELETE ... USING` sources: sql-to-code emits `AppendTableRef(...)` per parsed `from_item` and resolves column sources from every item. (thanks @atzedus)
 
 ### Changed
 
@@ -32,9 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `mm.SetCol()` now returns `mods.Set[*mm.UpdateAction]` instead of a custom `SetChain` type. `.ToExpr(val)` is replaced by `.To(val)`, and `.ToDefault()` is replaced by `.To(psql.Raw("DEFAULT"))`. `.To()` and `.ToArg()` work as before. (thanks @atzedus)
 - **BREAKING:** `mm.Recursive()` has been removed. PostgreSQL does not support `WITH RECURSIVE` in MERGE statements. (thanks @atzedus)
 - **BREAKING:** Generated `*Columns` accessor fields now return a dialect-specific wrapper type (e.g., `userColumn`) instead of plain `dialect.Expression`. The wrapper still implements `dialect.Expression` and avoids extra auto-parentheses in expression builders. Use `.Expression` only when you explicitly need the embedded expression value. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `UPDATE ... FROM` and `DELETE ... USING` additional sources now live in `UpdateQuery.FromItems` / `DeleteQuery.UsingItems` instead of the embedded `clause.TableRef` on the query struct. Each `um.From(...)` or `dm.Using(...)` appends one comma-separated `from_item` (last call no longer wins). Use `um.Table(...)` / `dm.From(...)` for the update/delete target table. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `sm.FromFunction` and `um.FromFunction` no longer return `FromChain` or apply `FROM`/`USING` by themselves. They return `bob.Expression` and must be passed to `sm.From(...)` / `um.From(...)` / `dm.Using(...)` — e.g. `sm.From(sm.FromFunction(psql.F("generate_series", 1, 3)()))` instead of `sm.FromFunction(...)`. Aliasing and other table modifiers belong on `sm.From(...)` / `um.From(...)`. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `sm.From` / `FromChain` for `SelectQuery` now set the `FROM` source via `AppendTableRef` (replace semantics) instead of `SetTable` / `SetTableAlias` on a `fromable` interface. (thanks @atzedus)
+- **BREAKING:** PostgreSQL `um` / `dm` join helpers (`InnerJoin`, `LeftJoin`, `CrossJoin`, etc.) return `JoinChain[*UpdateQuery]` / `JoinChain[*DeleteQuery]`. Use them in `um.From(table, joins...)` / `dm.Using(table, joins...)`, or as standalone mods after `um.From` / `dm.Using` — `AppendJoin` then attaches to the last `FromItems` / `UsingItems` entry. (thanks @atzedus)
+- **BREAKING:** PostgreSQL psql join chain modifiers `.Natural()`, `.On()`, `.OnEQ()`, `.Using()`, and `.UsingAs()` now return `JoinChain` for fluent chaining instead of `bob.Mod`. (thanks @atzedus)
 
 ### Fixed
 
+- Fix PostgreSQL `sm.From` replacing a previous `FROM` without clearing a stale table alias when the new source has no alias. (thanks @atzedus)
 - Fix PostgreSQL `sm.With(...).SearchBreadth(...)` rendering `SEARCH DEPTH` instead of `SEARCH BREADTH` in CTE queries. (thanks @atzedus)
 - Avoid unnecessary imports in generated random factory code when a type has no random expression. (thanks @jay-babu)
 - Fix missing base type imports (e.g. `github.com/google/uuid`) in generated models when using `type_system: "database/sql"` and `uuid_pkg: google`, which could cause compile errors in generated many-to-many relation helpers. (thanks @atzedus)

--- a/dialect/psql/delete_test.go
+++ b/dialect/psql/delete_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
 	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/fm"
 	testutils "github.com/stephenafamo/bob/test/utils"
 )
 
@@ -31,6 +32,156 @@ func TestDelete(t *testing.T) {
 			  WHERE (accounts.name = $1)
 			  AND (employees.id = accounts.sales_person)`,
 			ExpectedArgs: []any{"Acme Corporation"},
+		},
+		"with multiple using items": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"using item with inner join": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"using then standalone inner join": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"standalone inner join on last using item": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments"),
+				dm.InnerJoin("regions").OnEQ(
+					psql.Quote("departments", "id"),
+					psql.Quote("regions", "dept_id"),
+				),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, (departments
+			  INNER JOIN regions ON (departments.id = regions.dept_id))
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"interleaved using and standalone joins": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				dm.Using("regions"),
+				dm.LeftJoin("countries").OnEQ(
+					psql.Quote("regions", "country_id"),
+					psql.Quote("countries", "id"),
+				),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING (accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)), (regions
+			  LEFT JOIN countries ON (regions.country_id = countries.id))
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"using item with left join and alias": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				).As("a"),
+				dm.Where(psql.Quote("a", "dept_id").IsNotNull()),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts AS "a"
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")
+			  WHERE ("a"."dept_id" IS NOT NULL)`,
+		},
+		"multiple using items with cross join on second": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts"),
+				dm.Using("departments", dm.CrossJoin("regions")),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts, (departments
+			  CROSS JOIN regions)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using function": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using(dm.UsingFunction(psql.F("generate_series", 1, 2)())),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING generate_series(1, 2)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with using function rows from": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using(dm.UsingFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER))
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
+		},
+		"with multiple using items join rows from and table": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.Using("accounts",
+					dm.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				dm.Using(dm.UsingFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				dm.Using("regions"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING (accounts
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")), ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)), regions
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
 		},
 		"where current of": {
 			Query: psql.Delete(

--- a/dialect/psql/dialect/delete.go
+++ b/dialect/psql/dialect/delete.go
@@ -12,9 +12,9 @@ import (
 // https://www.postgresql.org/docs/current/sql-delete.html
 type DeleteQuery struct {
 	clause.With
-	Only  bool
-	Table clause.TableRef
-	clause.TableRef
+	Only       bool
+	Table      clause.TableRef
+	UsingItems []clause.TableRef
 	clause.WhereCurrentOf
 	clause.Where
 	clause.Returning
@@ -22,6 +22,20 @@ type DeleteQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*DeleteQuery]
+}
+
+func (d *DeleteQuery) AppendTableRef(using clause.TableRef) {
+	d.UsingItems = append(d.UsingItems, using)
+}
+
+// AppendJoin satisfies Joinable for JoinChain[*DeleteQuery].
+// When UsingItems is non-empty, the join is appended to the last USING item (e.g. after dm.Using).
+// Otherwise it is ignored; prefer dm.Using(table, joins...) for joins on a new from_item.
+func (d *DeleteQuery) AppendJoin(j clause.Join) {
+	if len(d.UsingItems) == 0 {
+		return
+	}
+	d.UsingItems[len(d.UsingItems)-1].AppendJoin(j)
 }
 
 func (d DeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, dl bob.Dialect, start int) ([]any, error) {
@@ -51,12 +65,14 @@ func (d DeleteQuery) WriteSQL(ctx context.Context, w io.StringWriter, dl bob.Dia
 	}
 	args = append(args, tableArgs...)
 
-	usingArgs, err := bob.ExpressIf(ctx, w, dl, start+len(args), d.TableRef,
-		d.TableRef.Expression != nil, "\nUSING ", "")
-	if err != nil {
-		return nil, err
+	if len(d.UsingItems) > 0 {
+		w.WriteString("\nUSING ")
+
+		args, err = writeFromItemList(ctx, w, dl, start+len(args), args, d.UsingItems)
+		if err != nil {
+			return nil, err
+		}
 	}
-	args = append(args, usingArgs...)
 
 	whereArgs, err := clause.WriteWhereAndCurrentOf(ctx, w, dl, start+len(args), d.Where, d.WhereCurrentOf)
 	if err != nil {

--- a/dialect/psql/dialect/from_items.go
+++ b/dialect/psql/dialect/from_items.go
@@ -1,0 +1,43 @@
+package dialect
+
+import (
+	"context"
+	"io"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
+)
+
+// needsFromItemParens reports whether a from_item must be parenthesized when
+// written in a comma-separated FROM/USING list. JOIN binds tighter than comma
+// in PostgreSQL, so an item with joins needs parens when other items follow.
+func needsFromItemParens(items []clause.TableRef, item clause.TableRef) bool {
+	return len(items) > 1 && len(item.Joins) > 0
+}
+
+func writeFromItemList(
+	ctx context.Context, w io.StringWriter, d bob.Dialect, start int,
+	args []any, items []clause.TableRef,
+) ([]any, error) {
+	for i, item := range items {
+		if i > 0 {
+			w.WriteString(", ")
+		}
+
+		if needsFromItemParens(items, item) {
+			w.WriteString("(")
+		}
+
+		itemArgs, err := bob.Express(ctx, w, d, start+len(args), item)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, itemArgs...)
+
+		if needsFromItemParens(items, item) {
+			w.WriteString(")")
+		}
+	}
+
+	return args, nil
+}

--- a/dialect/psql/dialect/function.go
+++ b/dialect/psql/dialect/function.go
@@ -120,7 +120,22 @@ func (c columnDef) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialec
 	return nil, nil
 }
 
+// Functions renders ROWS FROM (f1, f2, ...) for multiple table functions in one
+// from_item.
 type Functions []*Function
+
+// TableFunctions returns a FROM/USING expression for table functions: a single
+// function_name(...) or ROWS FROM (...) when multiple are given.
+func TableFunctions(funcs ...*Function) bob.Expression {
+	switch len(funcs) {
+	case 0:
+		return nil
+	case 1:
+		return funcs[0]
+	default:
+		return Functions(funcs)
+	}
+}
 
 func (f Functions) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	if len(f) > 1 {

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/clause"
 	"github.com/stephenafamo/bob/expr"
-	"github.com/stephenafamo/bob/mods"
 )
 
 type Distinct struct {
@@ -33,64 +32,53 @@ func With[Q interface{ AppendCTE(bob.Expression) }](name string, columns ...stri
 	})
 }
 
-type fromable interface {
-	SetTable(any)
-	SetTableAlias(alias string, columns ...string)
-	SetOnly(bool)
-	SetTableSample(method string, args ...any)
-	SetTableSampleRepeatable(seed any)
-	SetLateral(bool)
-	SetWithOrdinality(bool)
+type FromChain[Q any] struct {
+	from  func() clause.TableRef
+	joins func(*clause.TableRef)
+	apply func(Q, clause.TableRef)
 }
 
-func From[Q fromable](table any) FromChain[Q] {
-	return FromChain[Q](func() clause.TableRef {
-		return clause.TableRef{Expression: table}
-	})
+func (f FromChain[Q]) chain(from func() clause.TableRef) FromChain[Q] {
+	return FromChain[Q]{
+		from:  from,
+		joins: f.joins,
+		apply: f.apply,
+	}
 }
-
-type FromChain[Q fromable] func() clause.TableRef
 
 func (f FromChain[Q]) Apply(q Q) {
-	from := f()
-
-	q.SetTable(from.Expression)
-	if from.Alias != "" {
-		q.SetTableAlias(from.Alias, from.Columns...)
+	ref := f.from()
+	if f.joins != nil {
+		f.joins(&ref)
 	}
-
-	q.SetOnly(from.Only)
-	q.SetTableSample(from.TableSample, from.TableSampleArgs...)
-	q.SetTableSampleRepeatable(from.Repeatable)
-	q.SetLateral(from.Lateral)
-	q.SetWithOrdinality(from.WithOrdinality)
+	f.apply(q, ref)
 }
 
 func (f FromChain[Q]) As(alias string, columns ...string) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Alias = alias
 	fr.Columns = columns
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) Only() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Only = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) TableSample(method string, args ...any) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.TableSample = method
 	fr.TableSampleArgs = args
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
@@ -104,33 +92,59 @@ func (f FromChain[Q]) TableSampleBernoulli(args ...any) FromChain[Q] {
 }
 
 func (f FromChain[Q]) Repeatable(seed any) FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Repeatable = seed
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) Lateral() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.Lateral = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
 func (f FromChain[Q]) WithOrdinality() FromChain[Q] {
-	fr := f()
+	fr := f.from()
 	fr.WithOrdinality = true
 
-	return FromChain[Q](func() clause.TableRef {
+	return f.chain(func() clause.TableRef {
 		return fr
 	})
 }
 
-type Joinable interface{ AppendJoin(clause.Join) }
+type fromAppendable interface {
+	Joinable
+	AppendTableRef(clause.TableRef)
+}
+
+func From[Q fromAppendable](table any, joins ...JoinChain[Q]) FromChain[Q] {
+	return FromChain[Q]{
+		from: func() clause.TableRef {
+			return clause.TableRef{Expression: table}
+		},
+		joins: func(ref *clause.TableRef) {
+			for _, j := range joins {
+				ref.Joins = append(ref.Joins, j())
+			}
+		},
+		apply: func(q Q, ref clause.TableRef) {
+			q.AppendTableRef(ref)
+		},
+	}
+}
+
+// Joinable is implemented by query types that JoinChain[Q] can target.
+// *SelectQuery appends to the embedded FROM TableRef; *UpdateQuery and *DeleteQuery
+// append to the last FromItems / UsingItems entry when present.
+type Joinable interface {
+	AppendJoin(clause.Join)
+}
 
 func Join[Q Joinable](typ string, e any) JoinChain[Q] {
 	return JoinChain[Q](func() clause.Join {
@@ -157,13 +171,8 @@ func FullJoin[Q Joinable](e any) JoinChain[Q] {
 	return Join[Q](clause.FullJoin, e)
 }
 
-func CrossJoin[Q Joinable](e any) CrossJoinChain[Q] {
-	return CrossJoinChain[Q](func() clause.Join {
-		return clause.Join{
-			Type: clause.CrossJoin,
-			To:   clause.TableRef{Expression: e},
-		}
-	})
+func CrossJoin[Q Joinable](e any) JoinChain[Q] {
+	return Join[Q](clause.CrossJoin, e)
 }
 
 type JoinChain[Q Joinable] func() clause.Join
@@ -236,54 +245,48 @@ func (f JoinChain[Q]) WithOrdinality() JoinChain[Q] {
 	})
 }
 
-func (j JoinChain[Q]) Natural() bob.Mod[Q] {
+func (j JoinChain[Q]) Natural() JoinChain[Q] {
 	jo := j()
 	jo.Natural = true
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) On(on ...bob.Expression) bob.Mod[Q] {
+func (j JoinChain[Q]) On(on ...bob.Expression) JoinChain[Q] {
 	jo := j()
 	jo.On = append(jo.On, on...)
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) OnEQ(a, b bob.Expression) bob.Mod[Q] {
+func (j JoinChain[Q]) OnEQ(a, b bob.Expression) JoinChain[Q] {
 	jo := j()
 	jo.On = append(jo.On, expr.X[Expression, Expression](a).EQ(b))
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) Using(using ...string) bob.Mod[Q] {
+func (j JoinChain[Q]) Using(using ...string) JoinChain[Q] {
 	jo := j()
 	jo.Using = using
 
-	return mods.Join[Q](jo)
+	return JoinChain[Q](func() clause.Join {
+		return jo
+	})
 }
 
-func (j JoinChain[Q]) UsingAs(alias string, using ...string) bob.Mod[Q] {
+func (j JoinChain[Q]) UsingAs(alias string, using ...string) JoinChain[Q] {
 	jo := j()
 	jo.Using = using
 	jo.UsingAs = alias
 
-	return mods.Join[Q](jo)
-}
-
-type CrossJoinChain[Q Joinable] func() clause.Join
-
-func (j CrossJoinChain[Q]) Apply(q Q) {
-	q.AppendJoin(j())
-}
-
-func (j CrossJoinChain[Q]) As(alias string, columns ...string) bob.Mod[Q] {
-	jo := j()
-	jo.To.Alias = alias
-	jo.To.Columns = columns
-
-	return CrossJoinChain[Q](func() clause.Join {
+	return JoinChain[Q](func() clause.Join {
 		return jo
 	})
 }

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -36,6 +36,10 @@ type SelectQuery struct {
 	CombinedOffset clause.Offset
 }
 
+func (s *SelectQuery) AppendTableRef(ref clause.TableRef) {
+	s.TableRef = ref
+}
+
 func (s SelectQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	var err error
 	var args []any

--- a/dialect/psql/dialect/update.go
+++ b/dialect/psql/dialect/update.go
@@ -15,7 +15,7 @@ type UpdateQuery struct {
 	Only  bool
 	Table clause.TableRef
 	clause.Set
-	clause.TableRef
+	FromItems []clause.TableRef
 	clause.WhereCurrentOf
 	clause.Where
 	clause.Returning
@@ -23,6 +23,20 @@ type UpdateQuery struct {
 	bob.Load
 	bob.EmbeddedHook
 	bob.ContextualModdable[*UpdateQuery]
+}
+
+func (u *UpdateQuery) AppendTableRef(from clause.TableRef) {
+	u.FromItems = append(u.FromItems, from)
+}
+
+// AppendJoin satisfies Joinable for JoinChain[*UpdateQuery].
+// When FromItems is non-empty, the join is appended to the last FROM item (e.g. after um.From).
+// Otherwise it is ignored; prefer um.From(table, joins...) for joins on a new from_item.
+func (u *UpdateQuery) AppendJoin(j clause.Join) {
+	if len(u.FromItems) == 0 {
+		return
+	}
+	u.FromItems[len(u.FromItems)-1].AppendJoin(j)
 }
 
 func (u UpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
@@ -58,12 +72,14 @@ func (u UpdateQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 	}
 	args = append(args, setArgs...)
 
-	fromArgs, err := bob.ExpressIf(ctx, w, d, start+len(args), u.TableRef,
-		u.TableRef.Expression != nil, "\nFROM ", "")
-	if err != nil {
-		return nil, err
+	if len(u.FromItems) > 0 {
+		w.WriteString("\nFROM ")
+
+		args, err = writeFromItemList(ctx, w, d, start+len(args), args, u.FromItems)
+		if err != nil {
+			return nil, err
+		}
 	}
-	args = append(args, fromArgs...)
 
 	whereArgs, err := clause.WriteWhereAndCurrentOf(ctx, w, d, start+len(args), u.Where, u.WhereCurrentOf)
 	if err != nil {

--- a/dialect/psql/dm/qm.go
+++ b/dialect/psql/dm/qm.go
@@ -38,8 +38,14 @@ func FromAs(name any, alias string) bob.Mod[*dialect.DeleteQuery] {
 	})
 }
 
-func Using(table any) dialect.FromChain[*dialect.DeleteQuery] {
-	return dialect.From[*dialect.DeleteQuery](table)
+func Using(table any, joins ...dialect.JoinChain[*dialect.DeleteQuery]) dialect.FromChain[*dialect.DeleteQuery] {
+	return dialect.From[*dialect.DeleteQuery](table, joins...)
+}
+
+// UsingFunction returns an expression for dm.Using when the source is one or more
+// table functions (ROWS FROM when multiple).
+func UsingFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
 func InnerJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
@@ -58,7 +64,7 @@ func FullJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
 	return dialect.FullJoin[*dialect.DeleteQuery](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.DeleteQuery] {
+func CrossJoin(e any) dialect.JoinChain[*dialect.DeleteQuery] {
 	return dialect.CrossJoin[*dialect.DeleteQuery](e)
 }
 

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -30,6 +30,57 @@ func TestSelect(t *testing.T) {
 				sm.Where(psql.Quote("id").In(psql.Arg(100, 200, 300))),
 			),
 		},
+		"from replaces previous alias": {
+			Doc:         "A later From without alias replaces the whole table ref",
+			ExpectedSQL: "SELECT id FROM orders",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users").As("u"),
+				sm.From("orders"),
+			),
+		},
+		"from multiple tables cross join": {
+			Doc:         "Multiple tables in FROM via CROSS JOIN on the primary from_item",
+			ExpectedSQL: "SELECT id FROM users CROSS JOIN orders",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.CrossJoin("orders"),
+			),
+		},
+		"from function": {
+			Doc:         "FROM a single table function via TableFunctions",
+			ExpectedSQL: "SELECT p FROM generate_series(1, 3)",
+			Query: psql.Select(
+				sm.Columns("p"),
+				sm.From(sm.FromFunction(psql.F("generate_series", 1, 3)())),
+			),
+		},
+		"from then standalone inner join": {
+			Doc:         "FROM with INNER JOIN applied as a standalone mod after From",
+			ExpectedSQL: `SELECT id FROM users INNER JOIN events ON ("users"."id" = "events"."user_id")`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.InnerJoin("events").OnEQ(
+					psql.Quote("users", "id"),
+					psql.Quote("events", "user_id"),
+				),
+			),
+		},
+		"from rows from with cross join": {
+			Doc: "FROM ROWS FROM (...) with an additional table via CROSS JOIN",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From(sm.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				sm.CrossJoin("orders"),
+			),
+			ExpectedSQL:  `SELECT id FROM ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)) CROSS JOIN orders`,
+			ExpectedArgs: []any{`[{"a":1}]`},
+		},
 		"case with else": {
 			ExpectedSQL: `SELECT id, name, (CASE WHEN (id = '1') THEN 'A' ELSE 'B' END) AS "C" FROM users`,
 			Query: psql.Select(
@@ -120,7 +171,7 @@ func TestSelect(t *testing.T) {
 		"with rows from": {
 			Doc: "Select from group of functions. Automatically uses the `ROWS FROM` syntax",
 			Query: psql.Select(
-				sm.FromFunction(
+				sm.From(sm.FromFunction(
 					psql.F(
 						"json_to_recordset",
 						psql.Arg(`[{"a":40,"b":"foo"},{"a":"100","b":"bar"}]`),
@@ -129,7 +180,7 @@ func TestSelect(t *testing.T) {
 						fm.Columns("b", "TEXT"),
 					),
 					psql.F("generate_series", 1, 3)(),
-				).As("x", "p", "q", "s"),
+				)).As("x", "p", "q", "s"),
 				sm.OrderBy("p"),
 			),
 			ExpectedSQL: `SELECT *

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -33,18 +33,10 @@ func From(table any) dialect.FromChain[*dialect.SelectQuery] {
 	return dialect.From[*dialect.SelectQuery](table)
 }
 
-func FromFunction(funcs ...*dialect.Function) dialect.FromChain[*dialect.SelectQuery] {
-	var table any
-
-	if len(funcs) == 1 {
-		table = funcs[0]
-	}
-
-	if len(funcs) > 1 {
-		table = dialect.Functions(funcs)
-	}
-
-	return dialect.From[*dialect.SelectQuery](table)
+// FromFunction returns an expression for sm.From when the source is one or more
+// table functions (ROWS FROM when multiple).
+func FromFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
 func InnerJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
@@ -63,7 +55,7 @@ func FullJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
 	return dialect.FullJoin[*dialect.SelectQuery](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.SelectQuery] {
+func CrossJoin(e any) dialect.JoinChain[*dialect.SelectQuery] {
 	return dialect.CrossJoin[*dialect.SelectQuery](e)
 }
 

--- a/dialect/psql/starters.go
+++ b/dialect/psql/starters.go
@@ -28,6 +28,12 @@ func F(name string, args ...any) mods.Moddable[*dialect.Function] {
 	})
 }
 
+// TableFunctions returns a FROM/USING table-function source for sm.From, um.From,
+// or dm.Using (ROWS FROM when multiple functions are given).
+func TableFunctions(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
+}
+
 // S creates a string literal
 // SQL: 'a string'
 // Go: psql.S("a string")

--- a/dialect/psql/um/qm.go
+++ b/dialect/psql/um/qm.go
@@ -54,22 +54,14 @@ func SetCols(columns ...string) dialect.SetCols[*dialect.UpdateQuery] {
 	return dialect.NewSetCols[*dialect.UpdateQuery](columns...)
 }
 
-func From(table any) dialect.FromChain[*dialect.UpdateQuery] {
-	return dialect.From[*dialect.UpdateQuery](table)
+func From(table any, joins ...dialect.JoinChain[*dialect.UpdateQuery]) dialect.FromChain[*dialect.UpdateQuery] {
+	return dialect.From[*dialect.UpdateQuery](table, joins...)
 }
 
-func FromFunction(funcs ...*dialect.Function) dialect.FromChain[*dialect.UpdateQuery] {
-	var table any
-
-	if len(funcs) == 1 {
-		table = funcs[0]
-	}
-
-	if len(funcs) > 1 {
-		table = dialect.Functions(funcs)
-	}
-
-	return dialect.From[*dialect.UpdateQuery](table)
+// FromFunction returns an expression for um.From when the source is one or more
+// table functions (ROWS FROM when multiple).
+func FromFunction(funcs ...*dialect.Function) bob.Expression {
+	return dialect.TableFunctions(funcs...)
 }
 
 func InnerJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
@@ -88,7 +80,7 @@ func FullJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
 	return dialect.FullJoin[*dialect.UpdateQuery](e)
 }
 
-func CrossJoin(e any) dialect.CrossJoinChain[*dialect.UpdateQuery] {
+func CrossJoin(e any) dialect.JoinChain[*dialect.UpdateQuery] {
 	return dialect.CrossJoin[*dialect.UpdateQuery](e)
 }
 

--- a/dialect/psql/update_test.go
+++ b/dialect/psql/update_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/fm"
 	"github.com/stephenafamo/bob/dialect/psql/sm"
 	"github.com/stephenafamo/bob/dialect/psql/um"
 	testutils "github.com/stephenafamo/bob/test/utils"
@@ -34,6 +35,176 @@ func TestUpdate(t *testing.T) {
 			  WHERE (accounts.name = $1)
 			  AND (employees.id = accounts.sales_person)`,
 			ExpectedArgs: []any{"Acme Corporation"},
+		},
+		"with multiple from items": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments"),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"from item with inner join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts",
+					um.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"from then standalone inner join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"standalone inner join on last from item": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments"),
+				um.InnerJoin("regions").OnEQ(
+					psql.Quote("departments", "id"),
+					psql.Quote("regions", "dept_id"),
+				),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, (departments
+			  INNER JOIN regions ON (departments.id = regions.dept_id))
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"interleaved from and standalone joins": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				um.From("regions"),
+				um.LeftJoin("countries").OnEQ(
+					psql.Quote("regions", "country_id"),
+					psql.Quote("countries", "id"),
+				),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM (accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)), (regions
+			  LEFT JOIN countries ON (regions.country_id = countries.id))
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"from item with cross join": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts", um.CrossJoin("departments")),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  CROSS JOIN departments
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"from item with left join and alias": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts",
+					um.LeftJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				).As("a"),
+				um.Where(psql.Quote("a", "dept_id").IsNotNull()),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts AS "a"
+			  LEFT JOIN departments ON ("accounts"."dept_id" = "departments"."id")
+			  WHERE ("a"."dept_id" IS NOT NULL)`,
+		},
+		"multiple from items with cross join on second": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From("accounts"),
+				um.From("departments", um.CrossJoin("regions")),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, (departments
+			  CROSS JOIN regions)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from function": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From(um.FromFunction(psql.F("generate_series", 1, 3)())),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM generate_series(1, 3)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
+		"with from function rows from": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.From(um.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER))
+			  WHERE (employees.id = $2)`,
+			ExpectedArgs: []any{`[{"a":1}]`, 1},
+		},
+		"with multiple from items join rows from and table": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("n").To("1"),
+				um.From("accounts",
+					um.InnerJoin("departments").OnEQ(
+						psql.Quote("accounts", "dept_id"),
+						psql.Quote("departments", "id"),
+					),
+				),
+				um.From(um.FromFunction(
+					psql.F("generate_series", 1, 1)(),
+					psql.F("json_to_recordset", psql.Arg(`[{"a":1}]`))(fm.Columns("a", "INTEGER")),
+				)),
+				um.From("regions"),
+			),
+			ExpectedSQL: `UPDATE employees SET "n" = 1 FROM (accounts
+			  INNER JOIN departments ON ("accounts"."dept_id" = "departments"."id")), ROWS FROM (generate_series(1, 1), json_to_recordset($1) AS (a INTEGER)), regions`,
+			ExpectedArgs: []any{`[{"a":1}]`},
 		},
 		"set tuple columns from row": {
 			Query: psql.Update(

--- a/gen/bobgen-psql/driver/parser/mods.go
+++ b/gen/bobgen-psql/driver/parser/mods.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	pg "github.com/pganalyze/pg_query_go/v6"
 	"github.com/stephenafamo/bob/internal"
@@ -26,6 +27,34 @@ func (w *walker) modWithClause(with *pg.WithClause, info nodeInfo) {
 				int(cteInfos.end-1),
 				func(start, end int) error {
 					fmt.Fprintf(w.mods, "q.AppendCTE(EXPR.subExpr(%d, %d))\n", start, end)
+					return nil
+				},
+			)...,
+		)
+	}
+}
+
+func (w *walker) modAppendTableRefItems(clauseInfo nodeInfo, items []*pg.Node) {
+	for i, item := range items {
+		if item == nil {
+			continue
+		}
+
+		itemInfo, ok := clauseInfo.children[strconv.Itoa(i)]
+		if !ok {
+			continue
+		}
+
+		w.editRules = append(w.editRules,
+			internal.RecordPoints(
+				int(itemInfo.start),
+				int(itemInfo.end)-1,
+				func(start, end int) error {
+					fmt.Fprintf(
+						w.mods,
+						"q.AppendTableRef(clause.TableRef{Expression: EXPR.subExpr(%d, %d)})\n",
+						start, end,
+					)
 					return nil
 				},
 			)...,

--- a/gen/bobgen-psql/driver/parser/mods_delete.go
+++ b/gen/bobgen-psql/driver/parser/mods_delete.go
@@ -29,16 +29,7 @@ func (w *walker) modDeleteStatement(stmt *pg.Node_DeleteStmt, info nodeInfo) {
 	}
 
 	if usingInfo, ok := info.children["UsingClause"]; ok {
-		w.editRules = append(w.editRules,
-			internal.RecordPoints(
-				int(usingInfo.start),
-				int(usingInfo.end)-1,
-				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.SetTable(EXPR.subExpr(%d, %d))\n", start, end)
-					return nil
-				},
-			)...,
-		)
+		w.modAppendTableRefItems(usingInfo, stmt.DeleteStmt.UsingClause)
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {

--- a/gen/bobgen-psql/driver/parser/mods_update.go
+++ b/gen/bobgen-psql/driver/parser/mods_update.go
@@ -42,16 +42,7 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if fromInfo, ok := info.children["FromClause"]; ok {
-		w.editRules = append(w.editRules,
-			internal.RecordPoints(
-				int(fromInfo.start),
-				int(fromInfo.end)-1,
-				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.SetTable(EXPR.subExpr(%d, %d))\n", start, end)
-					return nil
-				},
-			)...,
-		)
+		w.modAppendTableRefItems(fromInfo, stmt.UpdateStmt.FromClause)
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -197,9 +197,10 @@ func (w *walker) getUpdateSource(stmt *pg.UpdateStmt, info nodeInfo, sources ...
 		)
 	}
 
-	from := stmt.FromClause[0]
-	fromInfo := info.children["FromClause"].children["0"]
-	sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	for i, from := range stmt.FromClause {
+		fromInfo := info.children["FromClause"].children[strconv.Itoa(i)]
+		sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	}
 
 	return w.getSourceFromTargets(
 		stmt.ReturningList,
@@ -222,9 +223,10 @@ func (w *walker) getDeleteSource(stmt *pg.DeleteStmt, info nodeInfo, sources ...
 		)
 	}
 
-	from := stmt.UsingClause[0]
-	fromInfo := info.children["UsingClause"].children["0"]
-	sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	for i, from := range stmt.UsingClause {
+		fromInfo := info.children["UsingClause"].children[strconv.Itoa(i)]
+		sources = w.addSourcesOfFromItem(from, fromInfo, sources...)
+	}
 
 	return w.getSourceFromTargets(
 		stmt.ReturningList,

--- a/gen/bobgen-psql/driver/parser/verify.go
+++ b/gen/bobgen-psql/driver/parser/verify.go
@@ -23,20 +23,12 @@ func verifyUpdateStatement(stmt *pg.UpdateStmt, _ nodeInfo) error {
 		return fmt.Errorf("nil statement")
 	}
 
-	if len(stmt.FromClause) > 1 {
-		return fmt.Errorf("multiple FROM tables are not supported, convert to a CROSS JOIN")
-	}
-
 	return nil
 }
 
 func verifyDeleteStatement(stmt *pg.DeleteStmt, _ nodeInfo) error {
 	if stmt == nil {
 		return fmt.Errorf("nil statement")
-	}
-
-	if len(stmt.UsingClause) > 1 {
-		return fmt.Errorf("multiple USING tables are not supported, convert to a CROSS JOIN")
 	}
 
 	return nil

--- a/website/docs/query-builder/psql/examples/select.md
+++ b/website/docs/query-builder/psql/examples/select.md
@@ -160,7 +160,7 @@ Code:
 
 ```go
 psql.Select(
-  sm.FromFunction(
+  sm.From(sm.FromFunction(
     psql.F(
       "json_to_recordset",
       psql.Arg(`[{"a":40,"b":"foo"},{"a":"100","b":"bar"}]`),
@@ -169,7 +169,7 @@ psql.Select(
       fm.Columns("b", "TEXT"),
     ),
     psql.F("generate_series", 1, 3)(),
-  ).As("x", "p", "q", "s"),
+  )).As("x", "p", "q", "s"),
   sm.OrderBy("p"),
 )
 ```


### PR DESCRIPTION
This is a reworked version resulting from https://github.com/stephenafamo/bob/pull/689

Extends the PostgreSQL query builder for `UPDATE ... FROM` and `DELETE ... USING` so multiple comma-separated `from_item` sources are supported, with inline and standalone joins, table functions, and matching `bobgen-psql` codegen.

### UPDATE / DELETE

- Additional `FROM` / `USING` sources live in `UpdateQuery.FromItems` and `DeleteQuery.UsingItems` (not the embedded `TableRef` on the query struct).
- The update/delete **target** table is set with `um.Table(...)` / `dm.From(...)`; extra sources use `um.From(...)` / `dm.Using(...)`.
- Each `um.From(...)` or `dm.Using(...)` call **appends** one comma-separated `from_item` (repeated calls build `a, b, (c JOIN d)`).
- `um.From(table, joins...)` and `dm.Using(table, joins...)` accept optional `JoinChain` arguments (`InnerJoin`, `LeftJoin`, `CrossJoin`, etc.) on that source.
- Standalone join mods (`um.InnerJoin`, `dm.LeftJoin`, …) attach to the **last** `from_item` when `FromItems` / `UsingItems` is non-empty.
- When a `from_item` has joins and more items follow, the writer parenthesizes it (PostgreSQL: comma binds looser than `JOIN`).

### Table functions

- `um.FromFunction`, `dm.UsingFunction`, and `sm.FromFunction` return `bob.Expression` (single function or `ROWS FROM (...)` for multiple).
- Pass the expression into `um.From` / `dm.Using` / `sm.From`; aliasing and table modifiers stay on the `From` / `Using` chain (`.As(...)`, `.Only()`, etc.).

### SELECT (related)

- `sm.FromFunction` no longer returns `FromChain` or applies `FROM` by itself — use `sm.From(sm.FromFunction(...))`.
- `sm.From` uses `AppendTableRef` (replace semantics); fixes stale alias when replacing `FROM` without a new alias.
- Join helpers (`.On()`, `.Using()`, `.Natural()`, …) return `JoinChain` for fluent chaining instead of `bob.Mod`.
- `CrossJoin` is unified under `JoinChain` (no separate `CrossJoinChain`).

### Codegen

- `bobgen-psql` parses multiple `UPDATE ... FROM` / `DELETE ... USING` items and emits `AppendTableRef(...)` per item; column resolution considers every source.

## Breaking changes

- `UPDATE`/`DELETE` extra sources moved from embedded `clause.TableRef` to `FromItems` / `UsingItems`; use `um.Table` / `dm.From` for the target table.
- `um.FromFunction` / `sm.FromFunction` return `bob.Expression` and must be wrapped in `From` / `Using`.
- `um` / `dm` join helpers return `JoinChain[*UpdateQuery]` / `JoinChain[*DeleteQuery]`; `.On()`, `.Using()`, etc. return `JoinChain` instead of `bob.Mod`.

## Examples

```go
// Multiple FROM sources
psql.Update(
    um.Table("employees"),
    um.SetCol("sales_count").To("sales_count + 1"),
    um.From("accounts"),
    um.From("departments"),
)
// UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, departments

// Inline join on a from_item
psql.Update(
    um.Table("employees"),
    um.SetCol("sales_count").To("sales_count + 1"),
    um.From("accounts",
        um.InnerJoin("departments").OnEQ(
            psql.Quote("accounts", "dept_id"),
            psql.Quote("departments", "id"),
        ),
    ),
)
// UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
//   INNER JOIN departments ON (accounts.dept_id = departments.id)

// Standalone join on the last from_item (parentheses when needed)
psql.Update(
    um.Table("employees"),
    um.SetCol("sales_count").To("sales_count + 1"),
    um.From("accounts"),
    um.From("departments"),
    um.InnerJoin("regions").OnEQ(
        psql.Quote("departments", "id"),
        psql.Quote("regions", "dept_id"),
    ),
)
// UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts, (departments
//   INNER JOIN regions ON (departments.id = regions.dept_id))

// Table function
psql.Update(
    um.Table("employees"),
    um.SetCol("sales_count").To("sales_count + 1"),
    um.From(um.FromFunction(psql.F("generate_series", 1, 3)())),
)
// UPDATE employees SET "sales_count" = sales_count + 1 FROM generate_series(1, 3)

// Multiple USING sources
psql.Delete(
    dm.From("employees"),
    dm.Using("accounts"),
    dm.Using("departments", dm.CrossJoin("regions")),
    dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
)
// DELETE FROM employees USING accounts, (departments CROSS JOIN regions)
//   WHERE (employees.id = $1)

// SELECT: FromFunction via sm.From
psql.Select(
    sm.Columns("p"),
    sm.From(sm.FromFunction(psql.F("generate_series", 1, 3)())),
)
// SELECT p FROM generate_series(1, 3)
