### PR TITLE
feat(dialect): add TableName, Schema and ColumnsExpr to View types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `TableName()` method to dialect `View` types (MySQL, PostgreSQL, SQLite). (thanks @atzedus)
+- Added `ColumnsExpr()` method on `psql.View` for parity with MySQL and SQLite views. (thanks @atzedus)
+
 ## [v0.44.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Schema()` method to dialect `View` types (PostgreSQL, SQLite). (thanks @atzedus)
 - Added `TableName()` method to dialect `View` types (MySQL, PostgreSQL, SQLite). (thanks @atzedus)
 - Added `ColumnsExpr()` method on `psql.View` for parity with MySQL and SQLite views. (thanks @atzedus)
 

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -59,7 +59,12 @@ func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
-// Returns a column list
+// TableName returns the table name
+func (v *View[T, Tslice, C]) TableName() string {
+	return v.name
+}
+
+// ColumnsExpr returns a column list
 func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
 	// get the schema
 	return v.allCols

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -77,6 +77,17 @@ func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
+// TableName returns the table name
+func (v *View[T, Tslice, C]) TableName() string {
+	return v.name
+}
+
+// ColumnsExpr returns a column list
+func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
+	// get the schema
+	return v.allCols
+}
+
 // Starts a select query
 func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Tslice] {
 	q := &ViewQuery[T, Tslice]{

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -77,6 +77,11 @@ func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
+// Schema returns the schema name
+func (v *View[T, Tslice, C]) Schema() string {
+	return v.schema
+}
+
 // TableName returns the table name
 func (v *View[T, Tslice, C]) TableName() string {
 	return v.name

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -81,7 +81,12 @@ func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
-// Returns a column list
+// TableName returns the table name
+func (v *View[T, Tslice, C]) TableName() string {
+	return v.name
+}
+
+// ColumnsExpr returns a column list
 func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
 	// get the schema
 	return v.allCols

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -81,6 +81,11 @@ func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
+// Schema returns the schema name
+func (v *View[T, Tslice, C]) Schema() string {
+	return v.schema
+}
+
 // TableName returns the table name
 func (v *View[T, Tslice, C]) TableName() string {
 	return v.name


### PR DESCRIPTION
## Summary

- Add `TableName()` to `mysql.View`, `psql.View`, and `sqlite.View` so views expose the underlying name the same way tables do in generated models and query helpers.
- Add `Schema()` to `psql.View`, and `sqlite.View` so views expose the underlying name the same way tables do in generated models and query helpers.
- Add `ColumnsExpr()` to `psql.View` for parity with MySQL and SQLite views (those dialects already had it).

## Motivation

`View` types were missing a few accessors that make working with views consistent across dialects and with other ORM helpers. `TableName()` makes the view name available without going through `Name()` / quoting, and `ColumnsExpr()` on PostgreSQL closes a small API gap compared to the other dialects.