### PR TITLE
feat(dialect): add NameExpr/NameAsExpr and fix schema column qualifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Schema()` method to dialect `View` types (PostgreSQL, SQLite). (thanks @atzedus)
-- Added `TableName()` method to dialect `View` types (MySQL, PostgreSQL, SQLite). (thanks @atzedus)
 - Added `ColumnsExpr()` method on `psql.View` for parity with MySQL and SQLite views. (thanks @atzedus)
+
+### Changed
+
+- **BREAKING:** `View` / `Table` `Name()` now returns the bare table (or view) name as `string`. In v0.44.0, `Name()` returned a dialect `Expression` (qualified table reference for SQL). That role moved to new methods:
+  - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` when schema was generated empty)
+  - `NameAsExpr()` — what `NameAs()` did in v0.44.0 (name plus table alias)
+  Update manual call sites, codegen templates, and generated models: `Users.Name()` in SQL builders → `Users.NameExpr()`, `Users.NameAs()` → `Users.NameAsExpr()`; use `Users.Name()` when you need the unqualified name string. On PostgreSQL and SQLite, `Schema()` still returns the schema when set.
+- Codegen templates and `orm.Preload` now use `NameExpr()` / `NameAsExpr()` instead of `Name()` / `NameAs()`. (thanks @atzedus)
+
+### Fixed
+
+- Fixed generated models using the wrong column qualifier when a table was constructed with a non-empty schema. Codegen previously passed `table.Key` into `build*Columns` and `pkEQ` / `pkIN`, but dialect `View` / `Table` types use `schema.table` as `Alias()` whenever `schema` is set at construction. That mismatch produced SQL such as `` `users`.`id` `` in `WHERE` while `FROM` used `` `myapp`.`users` AS `myapp.users` `` (columns and primary-key expressions did not match the table alias from `NameAsExpr()`). Templates now use a `tableColumnAlias` helper: `schema.name` when `schema` is set, otherwise `table.Key`. (thanks @atzedus)
 
 ## [v0.44.0] - 2026-05-21
 

--- a/dialect/mysql/table.go
+++ b/dialect/mysql/table.go
@@ -87,7 +87,7 @@ func (t *Table[T, Tslice, Tset, C]) PrimaryKey() expr.ColumnsExpr {
 func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) *insertQuery[T, Tslice, Tset, C] {
 	q := &insertQuery[T, Tslice, Tset, C]{
 		ExecQuery: orm.ExecQuery[*dialect.InsertQuery]{
-			BaseQuery: Insert(im.Into(t.Name(), t.nonGeneratedCols...)),
+			BaseQuery: Insert(im.Into(t.NameExpr(), t.nonGeneratedCols...)),
 			Hooks:     &t.InsertQueryHooks,
 		},
 		table: t,
@@ -101,7 +101,7 @@ func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQ
 // Starts an update query for this table
 func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) *orm.ExecQuery[*dialect.UpdateQuery] {
 	q := &orm.ExecQuery[*dialect.UpdateQuery]{
-		BaseQuery: Update(um.Table(t.NameAs())),
+		BaseQuery: Update(um.Table(t.NameAsExpr())),
 		Hooks:     &t.UpdateQueryHooks,
 	}
 	q.Apply(queryMods...)
@@ -112,7 +112,7 @@ func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQ
 // Starts a delete query for this table
 func (t *Table[T, Tslice, Tset, C]) Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) *orm.ExecQuery[*dialect.DeleteQuery] {
 	q := &orm.ExecQuery[*dialect.DeleteQuery]{
-		BaseQuery: Delete(dm.From(t.NameAs())),
+		BaseQuery: Delete(dm.From(t.NameAsExpr())),
 		Hooks:     &t.DeleteQueryHooks,
 	}
 
@@ -239,7 +239,7 @@ func (t *insertQuery[T, Tslice, Tset, C]) getInserted(vals []clause.Value, resul
 		return nil, retrievalErr
 	}
 
-	query := Select(sm.Columns(t.table.ColumnsExpr()), sm.From(t.table.NameAs()))
+	query := Select(sm.Columns(t.table.ColumnsExpr()), sm.From(t.table.NameAsExpr()))
 
 	// Change query type to Insert so that the correct hooks are run
 	query.QueryType = bob.QueryTypeInsert

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -47,35 +47,37 @@ type View[T any, Tslice ~[]T, C bob.Expression] struct {
 	SelectQueryHooks bob.Hooks[*dialect.SelectQuery, bob.SkipQueryHooksKey]
 }
 
-func (v *View[T, Tslice, C]) Name() Expression {
+// NameExpr returns the table name as an expression
+func (v *View[T, Tslice, C]) NameExpr() Expression {
 	return Quote(v.name)
 }
 
-func (v *View[T, Tslice, C]) NameAs() bob.Expression {
-	return v.Name().As(v.alias)
+// NameAsExpr returns the table name as an expression with an alias
+func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
+	return v.NameExpr().As(v.alias)
 }
 
+// Alias returns the alias
 func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
-// TableName returns the table name
-func (v *View[T, Tslice, C]) TableName() string {
+// Name returns the view (table/view) name
+func (v *View[T, Tslice, C]) Name() string {
 	return v.name
 }
 
-// ColumnsExpr returns a column list
+// ColumnsExpr returns a column list expression
 func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
-	// get the schema
 	return v.allCols
 }
 
-// Adds table name et al
+// Query starts a select query on the view
 func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Tslice] {
 	q := &ViewQuery[T, Tslice]{
 		Query: orm.Query[*dialect.SelectQuery, T, Tslice, bob.SliceTransformer[T, Tslice]]{
 			ExecQuery: orm.ExecQuery[*dialect.SelectQuery]{
-				BaseQuery: Select(sm.From(v.NameAs())),
+				BaseQuery: Select(sm.From(v.NameAsExpr())),
 				Hooks:     &v.SelectQueryHooks,
 			},
 			Scanner: v.scanner,

--- a/dialect/psql/table.go
+++ b/dialect/psql/table.go
@@ -76,7 +76,7 @@ func (t *Table[T, Tslice, Tset, C]) PrimaryKey() expr.ColumnsExpr {
 func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) *ormInsertQuery[T, Tslice] {
 	q := &ormInsertQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.InsertQuery]{
-			BaseQuery: Insert(im.Into(t.NameAs(), t.nonGeneratedCols...)),
+			BaseQuery: Insert(im.Into(t.NameAsExpr(), t.nonGeneratedCols...)),
 			Hooks:     &t.InsertQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -100,7 +100,7 @@ func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQ
 func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) *ormUpdateQuery[T, Tslice] {
 	q := &ormUpdateQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.UpdateQuery]{
-			BaseQuery: Update(um.Table(t.NameAs())),
+			BaseQuery: Update(um.Table(t.NameAsExpr())),
 			Hooks:     &t.UpdateQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -124,7 +124,7 @@ func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQ
 func (t *Table[T, Tslice, Tset, C]) Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) *ormDeleteQuery[T, Tslice] {
 	q := &ormDeleteQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.DeleteQuery]{
-			BaseQuery: Delete(dm.From(t.NameAs())),
+			BaseQuery: Delete(dm.From(t.NameAsExpr())),
 			Hooks:     &t.DeleteQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -152,7 +152,7 @@ func (t *Table[T, Tslice, Tset, C]) Delete(queryMods ...bob.Mod[*dialect.DeleteQ
 func (t *Table[T, Tslice, Tset, C]) Merge(queryMods ...bob.Mod[*dialect.MergeQuery]) *ormMergeQuery[T, Tslice] {
 	q := &ormMergeQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.MergeQuery]{
-			BaseQuery: Merge(mm.Into(t.NameAs())),
+			BaseQuery: Merge(mm.Into(t.NameAsExpr())),
 			Hooks:     &t.MergeQueryHooks,
 		},
 		Scanner: t.scanner,

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -60,7 +60,8 @@ type View[T any, Tslice ~[]T, C bob.Expression] struct {
 	SelectQueryHooks bob.Hooks[*dialect.SelectQuery, bob.SkipQueryHooksKey]
 }
 
-func (v *View[T, Tslice, C]) Name() Expression {
+// NameExpr returns the table name as an expression
+func (v *View[T, Tslice, C]) NameExpr() Expression {
 	// schema is not empty, never override
 	if v.schema != "" {
 		return Quote(v.schema, v.name)
@@ -69,36 +70,38 @@ func (v *View[T, Tslice, C]) Name() Expression {
 	return Expression{}.New(orm.SchemaTable(v.name))
 }
 
-func (v *View[T, Tslice, C]) NameAs() bob.Expression {
-	return v.Name().As(v.alias)
+// NameAsExpr returns the table name as an expression with an alias
+func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
+	return v.NameExpr().As(v.alias)
 }
 
+// Alias returns the alias
 func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
-// Schema returns the schema name
+// Schema returns the schema name for the view
 func (v *View[T, Tslice, C]) Schema() string {
 	return v.schema
 }
 
-// TableName returns the table name
-func (v *View[T, Tslice, C]) TableName() string {
+// Name returns the view (table/view) name
+func (v *View[T, Tslice, C]) Name() string {
 	return v.name
 }
 
-// ColumnsExpr returns a column list
+// ColumnsExpr returns a column list expression
 func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
 	// get the schema
 	return v.allCols
 }
 
-// Starts a select query
+// Query starts a select query on the view
 func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Tslice] {
 	q := &ViewQuery[T, Tslice]{
 		Query: orm.Query[*dialect.SelectQuery, T, Tslice, bob.SliceTransformer[T, Tslice]]{
 			ExecQuery: orm.ExecQuery[*dialect.SelectQuery]{
-				BaseQuery: Select(sm.From(v.NameAs())),
+				BaseQuery: Select(sm.From(v.NameAsExpr())),
 				Hooks:     &v.SelectQueryHooks,
 			},
 			Scanner: v.scanner,

--- a/dialect/psql/view_test.go
+++ b/dialect/psql/view_test.go
@@ -21,7 +21,7 @@ type someStruct struct {
 var someStructView = NewView[*someStruct, bob.Expression]("public", "some_struct", expr.ColsForStruct[someStruct]("some_struct"))
 
 func TestSomeViewName(t *testing.T) {
-	name := someStructView.Name().String()
+	name := someStructView.NameExpr().String()
 	expected := "\"public\".\"some_struct\""
 	if name != expected {
 		t.Errorf("someStructView.Name() expected '%s' but got '%s'", expected, name)
@@ -29,7 +29,7 @@ func TestSomeViewName(t *testing.T) {
 }
 
 func TestSomeViewNameAs(t *testing.T) {
-	q := selectToString(t, Select(sm.From(someStructView.NameAs())), 0)
+	q := selectToString(t, Select(sm.From(someStructView.NameAsExpr())), 0)
 
 	expected := "SELECT \n*\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\n"
 	if q != expected {

--- a/dialect/sqlite/table.go
+++ b/dialect/sqlite/table.go
@@ -67,7 +67,7 @@ func (t *Table[T, Tslice, Tset, C]) PrimaryKey() expr.ColumnsExpr {
 func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQuery]) *ormInsertQuery[T, Tslice] {
 	q := &ormInsertQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.InsertQuery]{
-			BaseQuery: Insert(im.Into(t.NameAs())),
+			BaseQuery: Insert(im.Into(t.NameAsExpr())),
 			Hooks:     &t.InsertQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -91,7 +91,7 @@ func (t *Table[T, Tslice, Tset, C]) Insert(queryMods ...bob.Mod[*dialect.InsertQ
 func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQuery]) *ormUpdateQuery[T, Tslice] {
 	q := &ormUpdateQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.UpdateQuery]{
-			BaseQuery: Update(um.Table(t.NameAs())),
+			BaseQuery: Update(um.Table(t.NameAsExpr())),
 			Hooks:     &t.UpdateQueryHooks,
 		},
 		Scanner: t.scanner,
@@ -115,7 +115,7 @@ func (t *Table[T, Tslice, Tset, C]) Update(queryMods ...bob.Mod[*dialect.UpdateQ
 func (t *Table[T, Tslice, Tset, C]) Delete(queryMods ...bob.Mod[*dialect.DeleteQuery]) *ormDeleteQuery[T, Tslice] {
 	q := &ormDeleteQuery[T, Tslice]{
 		ExecQuery: orm.ExecQuery[*dialect.DeleteQuery]{
-			BaseQuery: Delete(dm.From(t.NameAs())),
+			BaseQuery: Delete(dm.From(t.NameAsExpr())),
 			Hooks:     &t.DeleteQueryHooks,
 		},
 		Scanner: t.scanner,

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -64,7 +64,8 @@ type View[T any, Tslice ~[]T, C bob.Expression] struct {
 	SelectQueryHooks bob.Hooks[*dialect.SelectQuery, bob.SkipQueryHooksKey]
 }
 
-func (v *View[T, Tslice, C]) Name() Expression {
+// NameExpr returns the table name as an expression
+func (v *View[T, Tslice, C]) NameExpr() Expression {
 	// schema is not empty, never override
 	if v.schema != "" {
 		return Quote(v.schema, v.name)
@@ -73,36 +74,38 @@ func (v *View[T, Tslice, C]) Name() Expression {
 	return Expression{}.New(orm.SchemaTable(v.name))
 }
 
-func (v *View[T, Tslice, C]) NameAs() bob.Expression {
-	return v.Name().As(v.alias)
+// NameAsExpr returns the table name as an expression with an alias
+func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
+	return v.NameExpr().As(v.alias)
 }
 
+// Alias returns the alias
 func (v *View[T, Tslice, C]) Alias() string {
 	return v.alias
 }
 
-// Schema returns the schema name
+// Schema returns the schema name for the view
 func (v *View[T, Tslice, C]) Schema() string {
 	return v.schema
 }
 
-// TableName returns the table name
-func (v *View[T, Tslice, C]) TableName() string {
+// Name returns the view (table/view) name
+func (v *View[T, Tslice, C]) Name() string {
 	return v.name
 }
 
-// ColumnsExpr returns a column list
+// ColumnsExpr returns a column list expression
 func (v *View[T, Tslice, C]) ColumnsExpr() expr.ColumnsExpr {
 	// get the schema
 	return v.allCols
 }
 
-// Starts a select query
+// Query starts a select query on the view
 func (v *View[T, Tslice, C]) Query(queryMods ...bob.Mod[*dialect.SelectQuery]) *ViewQuery[T, Tslice] {
 	q := &ViewQuery[T, Tslice]{
 		Query: orm.Query[*dialect.SelectQuery, T, Tslice, bob.SliceTransformer[T, Tslice]]{
 			ExecQuery: orm.ExecQuery[*dialect.SelectQuery]{
-				BaseQuery: Select(sm.From(v.NameAs())),
+				BaseQuery: Select(sm.From(v.NameAsExpr())),
 				Hooks:     &v.SelectQueryHooks,
 			},
 			Scanner: v.scanner,

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -182,6 +182,16 @@ var templateFunctions = template.FuncMap{
 	},
 	"isPrimitiveType":    isPrimitiveType,
 	"relQueryMethodName": relQueryMethodName,
+	"tableColumnAlias":   tableColumnAlias,
+}
+
+// tableColumnAlias returns the column qualifier used by dialect View/Table types.
+// When schema is set it matches View.Alias() ("schema.table"); otherwise it uses the table key.
+func tableColumnAlias(schema, name, key string) string {
+	if schema != "" {
+		return fmt.Sprintf("%s.%s", schema, name)
+	}
+	return key
 }
 
 func enumValNormalize(val string) string {

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -69,7 +69,7 @@ func build{{$tAlias.UpSingular}}CountPreloader() {{$tAlias.DownSingular}}CountPr
 					sm.Columns({{$.Dialect}}.Raw("count(*)")),
 					{{- if eq (len $rel.Sides) 1}}
 					{{/* Simple one-hop relationship */}}
-					sm.From({{$fAlias.UpPlural}}.Name()),
+					sm.From({{$fAlias.UpPlural}}.NameAsExpr()),
 					{{- range $index, $fromCol := $firstSide.FromColumns -}}
 					{{- $toCol := index $firstSide.ToColumns $index}}
 					sm.Where({{$.Dialect}}.Quote({{$fAlias.UpPlural}}.Alias(), {{quote $toCol}}).EQ({{$.Dialect}}.Quote(parent, {{quote $fromCol}}))),
@@ -77,7 +77,7 @@ func build{{$tAlias.UpSingular}}CountPreloader() {{$tAlias.DownSingular}}CountPr
 					{{- else}}
 					{{/* Multi-hop relationship - need to join through intermediate tables */}}
 					{{- $firstSideToAlias := $.Aliases.Table $firstSide.To}}
-					sm.From({{$firstSideToAlias.UpPlural}}.Name()),
+					sm.From({{$firstSideToAlias.UpPlural}}.NameAsExpr()),
 					{{- range $index, $fromCol := $firstSide.FromColumns -}}
 					{{- $toCol := index $firstSide.ToColumns $index}}
 					sm.Where({{$.Dialect}}.Quote({{$firstSideToAlias.UpPlural}}.Alias(), {{quote $toCol}}).EQ({{$.Dialect}}.Quote(parent, {{quote $fromCol}}))),
@@ -86,7 +86,7 @@ func build{{$tAlias.UpSingular}}CountPreloader() {{$tAlias.DownSingular}}CountPr
 					{{- if eq $sideIndex 0 -}}{{continue}}{{- end}}
 					{{- $sideFromAlias := $.Aliases.Table $side.From -}}
 					{{- $sideToAlias := $.Aliases.Table $side.To}}
-					sm.InnerJoin({{$sideToAlias.UpPlural}}.Name()).On(
+					sm.InnerJoin({{$sideToAlias.UpPlural}}.NameAsExpr()).On(
 						{{- range $index, $fromCol := $side.FromColumns -}}
 						{{- $toCol := index $side.ToColumns $index}}
 						{{$.Dialect}}.Quote({{$sideToAlias.UpPlural}}.Alias(), {{quote $toCol}}).EQ({{$.Dialect}}.Quote({{$sideFromAlias.UpPlural}}.Alias(), {{quote $fromCol}})),
@@ -235,14 +235,14 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		),
 		{{if eq (len $rel.Sides) 1 -}}
 		// Single-hop: FROM related table directly
-		sm.From({{$fAlias.UpPlural}}.NameAs()),
+		sm.From({{$fAlias.UpPlural}}.NameAsExpr()),
 		{{range $where := $firstSide.ToWhere -}}
 		{{$whereColAlias := index $firstTo.Columns $where.Column -}}
 		sm.Where({{$firstTo.UpPlural}}.Columns.{{$whereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
 		{{end -}}
 		{{- else -}}
 		// Multi-hop: FROM first join table, JOIN through to final related table
-		sm.From({{$firstTo.UpPlural}}.NameAs()),
+		sm.From({{$firstTo.UpPlural}}.NameAsExpr()),
 		{{range $where := $firstSide.ToWhere -}}
 		{{$whereColAlias := index $firstTo.Columns $where.Column -}}
 		sm.Where({{$firstTo.UpPlural}}.Columns.{{$whereColAlias}}.EQ({{$.Dialect}}.Arg({{quote $where.SQLValue}}))),
@@ -251,7 +251,7 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		{{if eq $sideIndex 0 -}}{{continue}}{{end -}}
 		{{$sideFrom := $.Aliases.Table $side.From -}}
 		{{$sideTo := $.Aliases.Table $side.To -}}
-		sm.InnerJoin({{$sideTo.UpPlural}}.NameAs()).On(
+		sm.InnerJoin({{$sideTo.UpPlural}}.NameAsExpr()).On(
 			{{range $i, $fromColKey := $side.FromColumns -}}
 			{{$toColKey := index $side.ToColumns $i -}}
 			{{$sideToColAlias := index $sideTo.Columns $toColKey -}}

--- a/gen/templates/joins/table/120_joins.go.tpl
+++ b/gen/templates/joins/table/120_joins.go.tpl
@@ -45,7 +45,7 @@
               {{if ne $index (sub (len $rel.Sides) 1) -}}
               to := {{$toCols}}.AliasedAs({{$toCols}}.Alias() + random)
               {{end -}}
-              mods = append(mods, dialect.Join[Q](typ, {{$to.UpPlural}}.Name().As(to.Alias())).On(
+              mods = append(mods, dialect.Join[Q](typ, {{$to.UpPlural}}.NameExpr().As(to.Alias())).On(
                   {{range $i, $local := $side.FromColumns -}}
                     {{- $fromCol := index $from.Columns $local -}}
                     {{- $toCol := index $to.Columns (index $side.ToColumns $i) -}}

--- a/gen/templates/models/table/001_types.go.tpl
+++ b/gen/templates/models/table/001_types.go.tpl
@@ -33,12 +33,12 @@ type {{$tAlias.UpSingular}}Slice []*{{$tAlias.UpSingular}}
 {{$tAlias := .Aliases.Table $table.Key -}}
 {{if not $table.Constraints.Primary -}}
 	// {{$tAlias.UpPlural}} contains methods to work with the {{$table.Name}} view
-	var {{$tAlias.UpPlural}} = {{$.Dialect}}.NewViewx[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice]("{{$table.Schema}}","{{$table.Name}}",build{{$tAlias.UpSingular}}Columns({{quote $table.Key}}))
+	var {{$tAlias.UpPlural}} = {{$.Dialect}}.NewViewx[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice]("{{$table.Schema}}","{{$table.Name}}",build{{$tAlias.UpSingular}}Columns({{quote (tableColumnAlias $table.Schema $table.Name $table.Key)}}))
 	// {{$tAlias.UpPlural}}Query is a query on the {{$table.Name}} view
 	type {{$tAlias.UpPlural}}Query = *{{$.Dialect}}.ViewQuery[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice]
 {{- else -}}
 	// {{$tAlias.UpPlural}} contains methods to work with the {{$table.Name}} table
-	var {{$tAlias.UpPlural}} = {{$.Dialect}}.NewTablex[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice, *{{$tAlias.UpSingular}}Setter]("{{$table.Schema}}","{{$table.Name}}",build{{$tAlias.UpSingular}}Columns({{quote $table.Key}}))
+	var {{$tAlias.UpPlural}} = {{$.Dialect}}.NewTablex[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice, *{{$tAlias.UpSingular}}Setter]("{{$table.Schema}}","{{$table.Name}}",build{{$tAlias.UpSingular}}Columns({{quote (tableColumnAlias $table.Schema $table.Name $table.Key)}}))
 	// {{$tAlias.UpPlural}}Query is a query on the {{$table.Name}} table
 	type {{$tAlias.UpPlural}}Query = *{{$.Dialect}}.ViewQuery[*{{$tAlias.UpSingular}}, {{$tAlias.UpSingular}}Slice]
 {{- end}}

--- a/gen/templates/models/table/005_one_methods.go.tpl
+++ b/gen/templates/models/table/005_one_methods.go.tpl
@@ -47,7 +47,7 @@ func (o *{{$tAlias.UpSingular}}) primaryKeyVals() bob.Expression {
 {{$pkCols := $table.Constraints.Primary.Columns}}
 {{$multiPK := gt (len $pkCols) 1}}
 func (o *{{$tAlias.UpSingular}}) pkEQ() dialect.Expression {
-   return {{if $multiPK}}{{$.Dialect}}.Group({{end}}{{- range $i, $col := $pkCols -}}{{if gt $i 0}}, {{end}}{{$.Dialect}}.Quote("{{$table.Key}}", "{{$col}}"){{end}}{{if $multiPK}}){{end -}}
+   return {{if $multiPK}}{{$.Dialect}}.Group({{end}}{{- range $i, $col := $pkCols -}}{{if gt $i 0}}, {{end}}{{$.Dialect}}.Quote("{{tableColumnAlias $table.Schema $table.Name $table.Key}}", "{{$col}}"){{end}}{{if $multiPK}}){{end -}}
     .EQ(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
       return o.primaryKeyVals().WriteSQL(ctx, w, d, start)
     }))

--- a/gen/templates/models/table/007_slice_methods.go.tpl
+++ b/gen/templates/models/table/007_slice_methods.go.tpl
@@ -39,7 +39,7 @@ func (o {{$tAlias.UpSingular}}Slice) pkIN() dialect.Expression {
     return {{$.Dialect}}.Raw("NULL")
   }
 
-  return {{if $multiPK}}{{$.Dialect}}.Group({{end}}{{- range $i, $col := $pkCols -}}{{if gt $i 0}}, {{end}}{{$.Dialect}}.Quote("{{$table.Key}}", "{{$col}}"){{end}}{{if $multiPK}}){{end -}}
+  return {{if $multiPK}}{{$.Dialect}}.Group({{end}}{{- range $i, $col := $pkCols -}}{{if gt $i 0}}, {{end}}{{$.Dialect}}.Quote("{{tableColumnAlias $table.Schema $table.Name $table.Key}}", "{{$col}}"){{end}}{{if $multiPK}}){{end -}}
     .In(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
       pkPairs := make([]bob.Expression, len(o))
       for i, row := range o {

--- a/gen/templates/models/table/009_rel_query.go.tpl
+++ b/gen/templates/models/table/009_rel_query.go.tpl
@@ -19,7 +19,7 @@ func (o *{{$tAlias.UpSingular}}) {{relQueryMethodName $tAlias $relAlias}}(mods .
 		{{- $to := $.Aliases.Table $side.To -}}
 		{{- $fromTable := $.Tables.Get $side.From -}}
 		{{- if gt $index 0 -}}
-		sm.InnerJoin({{$from.UpPlural}}.NameAs()).On(
+		sm.InnerJoin({{$from.UpPlural}}.NameAsExpr()).On(
 		{{end -}}
 			{{range $i, $local := $side.FromColumns -}}
 				{{- $fromCol := index $from.Columns $local -}}
@@ -107,7 +107,7 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
 		{{- $to := $.Aliases.Table $side.To -}}
 		{{- $fromTable := $.Tables.Get $side.From -}}
 		{{- if gt $index 0 -}}
-		sm.InnerJoin({{$from.UpPlural}}.NameAs()).On(
+		sm.InnerJoin({{$from.UpPlural}}.NameAsExpr()).On(
 			{{range $i, $local := $side.FromColumns -}}
 				{{- $foreign := index $side.ToColumns $i -}}
 				{{- $fromCol := index $from.Columns $local -}}

--- a/orm/load.go
+++ b/orm/load.go
@@ -195,7 +195,7 @@ type PreloadRel[E bob.Expression] struct {
 }
 
 type nameable[E bob.Expression] interface {
-	Name() E
+	NameExpr() E
 	Alias() string
 }
 
@@ -270,7 +270,7 @@ func Preload[T Preloadable, Ts ~[]T, E bob.Expression, Q PreloadableQuery](rel P
 			queryMods = append(queryMods, mods.Join[Q](clause.Join{
 				Type: clause.LeftJoin,
 				To: clause.TableRef{
-					Expression: side.To.Name(),
+					Expression: side.To.NameExpr(),
 					Alias:      alias,
 				},
 				On: on,
@@ -403,7 +403,7 @@ func (v *wrapper) Scan(value any) error {
 //         ...
 //         gen.Things.Columns.WithPrefix("thing.")),
 //      sm.From(...),
-//		sm.LeftJoin(gen.Things.Name()).As("thing").On(
+//		sm.LeftJoin(gen.Things.NameExpr()).As("thing").On(
 //			gen.Things.Columns.AliasedAs("thing").ID.EQ(...),
 //		),
 // 	), scan.StructMapper[myRow](scan.WithTypeConverter(orm.NullTypeConverter{})))

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -1252,7 +1252,7 @@ func TestQueryWithJoin(t *testing.T) {
 	// Query videos with join to users
 	{{$.Importer.Import "sm" "github.com/stephenafamo/bob/dialect/mysql/sm"}}
 	videos, err := models.Videos.Query(
-		sm.InnerJoin(models.Users.Name()).On(
+		sm.InnerJoin(models.Users.NameAsExpr()).On(
 			models.Videos.Columns.UserID.EQ(models.Users.Columns.ID),
 		),
 		models.SelectWhere.Users.ID.EQ(user.ID),

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -1252,7 +1252,7 @@ func TestQueryWithJoin(t *testing.T) {
 	// Query videos with join to users
 	{{$.Importer.Import "sm" "github.com/stephenafamo/bob/dialect/psql/sm"}}
 	videos, err := models.Videos.Query(
-		sm.InnerJoin(models.Users.Name()).On(
+		sm.InnerJoin(models.Users.NameAsExpr()).On(
 			models.Videos.Columns.UserID.EQ(models.Users.Columns.ID),
 		),
 		models.SelectWhere.Users.ID.EQ(user.ID),

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -1231,7 +1231,7 @@ func TestQueryWithJoin(t *testing.T) {
 	// Query videos with join to users
 	{{$.Importer.Import "sm" "github.com/stephenafamo/bob/dialect/sqlite/sm"}}
 	videos, err := models.Videos.Query(
-		sm.InnerJoin(models.Users.Name()).On(
+		sm.InnerJoin(models.Users.NameAsExpr()).On(
 			models.Videos.Columns.UserID.EQ(models.Users.Columns.ID),
 		),
 		models.SelectWhere.Users.ID.EQ(user.ID),
@@ -1488,7 +1488,7 @@ func TestSelectJoins(t *testing.T) {
 	// SQLite uses a different approach than MySQL/PostgreSQL
 	{{$.Importer.Import "sm" "github.com/stephenafamo/bob/dialect/sqlite/sm"}}
 	videos, err := models.Videos.Query(
-		sm.InnerJoin(models.Users.Name()).On(
+		sm.InnerJoin(models.Users.NameAsExpr()).On(
 			models.Videos.Columns.UserID.EQ(models.Users.Columns.ID),
 		),
 		models.SelectWhere.Users.ID.EQ(user1.ID),

--- a/website/docs/code-generation/usage.md
+++ b/website/docs/code-generation/usage.md
@@ -326,7 +326,7 @@ For even more control, expressions are generated for every column to be used in 
 // ORDER BY "jets"."pilot_id"
 psql.Select(
     sm.Columns(models.JetColumns.Name, "count(1)"),
-    sm.From(models.JetsTable.Name()),
+    sm.From(models.JetsTable.NameExpr()),
     sm.Where(models.JetColumns.ID.Between(50, 5000)),
     sm.OrderBy(models.JetColumns.PilotID),
 )

--- a/website/docs/models/table.md
+++ b/website/docs/models/table.md
@@ -7,7 +7,7 @@ description: Easily query and modify a database table
 
 :::info
 
-Table models have all the capabilities of [View models](./view). This page will only focus on the additional capabilities.
+Table models have all the capabilities of [View models](./view) (`Name()`, `NameExpr()`, `NameAsExpr()`, `Alias()`, `Query()`, and columns; PostgreSQL and SQLite also have `Schema()`). This page focuses only on insert/update/delete and related APIs.
 
 :::
 

--- a/website/docs/models/view.md
+++ b/website/docs/models/view.md
@@ -35,19 +35,55 @@ A View model provides the following methods:
 
 ## Name()
 
-This returns a properly quoted name of the table and can be used as a bob [expression](../query-builder/building-queries#expressions). e.g. `"public"."users"`
+Returns the bare table or view name as a `string` (no schema prefix). For example, `"users"`.
 
-## NameAs()
+Use this when you need the identifier as data (logging, map keys, etc.), not when building SQL.
 
-Similar to `Name()`, but adds an alias. e.g. `"public"."users" as "public.users"`. It should be used as a modifier to a query:
+## Schema()
+
+PostgreSQL and SQLite only. Returns the schema name the model was constructed with, or `""` if none was set at codegen time.
+
+When the schema is empty, pass a schema at runtime with `psql.UseSchema` or `sqlite.UseSchema` so `NameExpr()` can qualify the table in SQL.
+
+## Alias()
+
+Returns the alias used for generated columns and for `NameAsExpr()`. When a schema is set at construction, this is usually `schema.table` (e.g. `"public.users"`). Otherwise it matches the table name.
+
+## NameExpr()
+
+Returns the table or view as a bob [expression](../query-builder/building-queries#expressions) for query builders (`sm.From`, `im.Into`, joins, etc.).
+
+- PostgreSQL/SQLite with schema at construction: qualified name, e.g. `"public"."users"`.
+- PostgreSQL/SQLite with empty schema: uses `UseSchema` from context when present; otherwise the unqualified table name.
+- MySQL: the quoted table name (MySQL models do not use schema/database qualification).
 
 ```go
 import (
 	"github.com/stephenafamo/bob/dialect/psql"
 	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
-query := psql.Select(sm.From(userView.NameAs()))
+
+query := psql.Select(sm.From(userView.NameExpr()))
 ```
+
+## NameAsExpr()
+
+Like `NameExpr()`, but includes the table alias (same as `Alias()`). Use in `FROM`, `JOIN`, and other clauses that need a named range variable—for example, PostgreSQL/SQLite `INSERT INTO ... AS alias` or subqueries that reference `Alias()` in `WHERE`.
+
+```go
+import (
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+query := psql.Select(sm.From(userView.NameAsExpr()))
+```
+
+:::note
+
+MySQL does not support a table alias on the `INSERT` target (`INSERT INTO t AS alias`). Generated MySQL `Table.Insert()` uses `NameExpr()` only; use row aliases in `ON DUPLICATE KEY UPDATE` when needed.
+
+:::
 
 ## Columns
 


### PR DESCRIPTION
This PR completes the View/Table naming API started in #691 and fixes a codegen bug where generated column prefixes could disagree with the table alias used in SQL.

- **BREAKING:** `View` / `Table` `Name()` now returns the bare table or view name as a `string`. SQL builders should use `NameExpr()` (formerly `Name()`) and `NameAsExpr()` (formerly `NameAs()`).
- **Added:** `Schema()` on PostgreSQL and SQLite `View` types (MySQL is unchanged — no schema/database qualification on models).
- **Fixed:** Introduced `tableColumnAlias` in codegen so `build*Columns`, `pkEQ`, and `pkIN` use the same qualifier as `View.Alias()` when `schema` is set at construction (`schema.table` instead of a bare `table.Key` such as `users`).
- Updated codegen templates, `orm.Preload`, factory test templates, CHANGELOG, and view/table docs.

## Codegen fix: column qualifiers vs table alias

The bug is not about renaming columns or tables — it is about **which prefix** codegen attaches to the same `users.id` when the model is built with a schema.

Assume the same table everywhere:

| Field | Value |
|-------|--------|
| Table | `users` |
| Column | `id` |
| Generated model | `models.Users` |

Only the **schema** at construction differs.

### Case A — `shared_schema` (schema empty at codegen)

Codegen emits:

```go
var Users = psql.NewTablex(..., "", "users", buildUsersColumns("users"), ...)
```

Runtime:

| | Value |
|--|--------|
| `Users.Schema()` | `""` |
| `Users.Name()` | `"users"` |
| `Users.Alias()` | `"users"` |
| `Users.Columns.ID` | `"users"."id"` |
| `Users.NameAsExpr()` | `"users" AS "users"` |

Manual query:

```go
psql.Select(
    sm.From(models.Users.NameAsExpr()),
    sm.Where(models.Users.Columns.ID.EQ(1)),
)
```

```sql
SELECT "users"."id"
FROM "users" AS "users"
WHERE ("users"."id" = $1)
```

Prefix `users` is consistent everywhere. **No bug** — `table.Key` (`"users"`) matches `Alias()`.

---

### Case B — non-shared schema (schema `billing` at codegen)

Codegen emits:

```go
var Users = psql.NewTablex(..., "billing", "users", buildUsersColumns(...), ...)
```

Runtime (dialect):

| | Value |
|--|--------|
| `Users.Schema()` | `"billing"` |
| `Users.Name()` | `"users"` |
| `Users.Alias()` | `"billing.users"` |
| `Users.NameAsExpr()` | `"billing"."users" AS "billing.users"` |
| `Users.Query()` columns (via `View.ColumnsExpr`) | `"billing.users"."id"` |

**Before this PR** — codegen passed `table.Key` (`"users"`) into `buildUsersColumns` and `pkEQ`:

| | Value |
|--|--------|
| `buildUsersColumns("users")` | `"users"."id"` |
| `pkEQ()` | `Quote("users", "id")` |

Manual query with the **same** `models.Users` and **same** `id`:

```go
psql.Select(
    sm.From(models.Users.NameAsExpr()),
    sm.Where(models.Users.Columns.ID.EQ(1)),
)
```

```sql
SELECT "users"."id"
FROM "billing"."users" AS "billing.users"
WHERE ("users"."id" = $1)
```

`Users.Query()` alone looked fine (it uses `View.ColumnsExpr` with parent `"billing.users"`), but `Users.Columns.ID` and `pkEQ()` pointed at `"users"."id"` while the SQL alias was `"billing.users"`.

**After this PR** — `tableColumnAlias("billing", "users", "users")` → `"billing.users"`:

```go
var Users = psql.NewTablex(..., "billing", "users",
    buildUsersColumns("billing.users"), ...)
```

| | Value |
|--|--------|
| `Users.Columns.ID` | `"billing.users"."id"` |
| `pkEQ()` | `Quote("billing.users", "id")` |

Same manual query:

```sql
SELECT "billing.users"."id"
FROM "billing"."users" AS "billing.users"
WHERE ("billing.users"."id" = $1)
```

Same table `users`, same column `id` — only the schema argument changes the prefix, and codegen now matches `View.Alias()`.

### Migration

| Before (v0.44.0) | After |
|------------------|--------|
| `Users.Name()` in `sm.From`, joins, etc. | `Users.NameExpr()` |
| `Users.NameAs()` | `Users.NameAsExpr()` |
| Need qualified name as `Expression` | `NameExpr()` / `NameAsExpr()` |
| Need unqualified name string | `Users.Name()` |
| Schema on psql/sqlite | `Users.Schema()` |

Regenerate models after upgrading bobgen.
