### PR TITLE
fix: FOR UPDATE OF via Quote; unquoted MERGE/SetCols column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** PostgreSQL `sm.ForUpdate`, `sm.ForNoKeyUpdate`, `sm.ForShare`, and `sm.ForKeyShare` now take `tables ...any` instead of `tables ...string`. Pass `psql.Quote(...)` (or another `Expression`) for each locked relation ([#693](https://github.com/stephenafamo/bob/issues/693)). (thanks @atzedus)
+- **BREAKING:** MySQL `sm.ForUpdate` and `sm.ForShare` now take `tables ...any` with the same semantics as PostgreSQL (`mysql.Quote(...)` when needed). (thanks @atzedus)
+- **BREAKING:** `clause.Lock.Tables` is now `[]any` instead of `[]string` (used by `FOR UPDATE` / `FOR SHARE` rendering). (thanks @atzedus)
 - **BREAKING:** `View` / `Table` `Name()` now returns the bare table (or view) name as `string`. In v0.44.0, `Name()` returned a dialect `Expression` (qualified table reference for SQL). That role moved to new methods:
   - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` when schema was generated empty)
   - `NameAsExpr()` — what `NameAs()` did in v0.44.0 (name plus table alias)
@@ -22,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `FOR UPDATE` / `FOR SHARE` `OF` table lists: pass `psql.Quote(...)` / `mysql.Quote(...)` so names with spaces or qualification render correctly ([#693](https://github.com/stephenafamo/bob/issues/693)). (thanks @atzedus)
+- Fixed PostgreSQL `MERGE` `INSERT` column lists (`mm.Columns`): names are written unquoted (not via `WriteQuoted` / `expr.Quote`), so PostgreSQL still folds unquoted identifiers to lowercase and `mm.Columns("Name")` matches a column created as `name`. Quoted identifiers are case-sensitive in PostgreSQL; auto-quoting broke that. Use `psql.Quote(...)` in value expressions when you need a delimited identifier. (thanks @atzedus)
+- Fixed `um.SetCols` / `im.SetCols` / `mm.SetCols` tuple-assignment column lists the same way (unquoted `[]string` names on the left-hand side of `(cols...) = ...`). (thanks @atzedus)
+- Fixed MySQL `sm.From(...).UseIndex` / `ForceIndex` / `IgnoreIndex` (and `*ForJoin` / `*ForOrderBy` / `*ForGroupBy` variants) not appearing in generated SQL because `FromChain.Apply` did not copy `IndexHints` onto the query. (thanks @atzedus)
 - Fixed generated models using the wrong column qualifier when a table was constructed with a non-empty schema. Codegen previously passed `table.Key` into `build*Columns` and `pkEQ` / `pkIN`, but dialect `View` / `Table` types use `schema.table` as `Alias()` whenever `schema` is set at construction. That mismatch produced SQL such as `` `users`.`id` `` in `WHERE` while `FROM` used `` `myapp`.`users` AS `myapp.users` `` (columns and primary-key expressions did not match the table alias from `NameAsExpr()`). Templates now use a `tableColumnAlias` helper: `schema.name` when `schema` is set, otherwise `table.Key`. (thanks @atzedus)
 
 ## [v0.44.0] - 2026-05-21

--- a/clause/lock.go
+++ b/clause/lock.go
@@ -33,7 +33,7 @@ func (f *Locks) AppendLock(lock bob.Expression) {
 
 type Lock struct {
 	Strength string
-	Tables   []string
+	Tables   []any
 	Wait     string
 }
 
@@ -43,9 +43,7 @@ func (f Lock) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, st
 	}
 
 	w.WriteString("FOR ")
-	if f.Strength != "" {
-		w.WriteString(fmt.Sprintf("%s ", f.Strength))
-	}
+	w.WriteString(fmt.Sprintf("%s ", f.Strength))
 
 	args, err := bob.ExpressSlice(ctx, w, d, start, f.Tables, "OF ", ", ", "")
 	if err != nil {

--- a/dialect/mysql/dialect/mods.go
+++ b/dialect/mysql/dialect/mods.go
@@ -44,6 +44,9 @@ func (f FromChain[Q]) Apply(q Q) {
 
 	q.SetLateral(from.Lateral)
 	q.AppendPartition(from.Partitions...)
+	for _, h := range from.IndexHints {
+		q.AppendIndexHint(h)
+	}
 }
 
 func (f FromChain[Q]) As(alias string, columns ...string) FromChain[Q] {

--- a/dialect/mysql/sm/qm.go
+++ b/dialect/mysql/sm/qm.go
@@ -179,7 +179,8 @@ func ExceptAll(q bob.Query) bob.Mod[*dialect.SelectQuery] {
 	}
 }
 
-func ForUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForUpdate locks selected tables. Pass table names as mysql.Quote(...) or another Expression.
+func ForUpdate(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthUpdate,
@@ -188,7 +189,8 @@ func ForUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 	})
 }
 
-func ForShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForShare acquires a shared lock on selected tables.
+func ForShare(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthShare,

--- a/dialect/psql/dialect/merge.go
+++ b/dialect/psql/dialect/merge.go
@@ -202,15 +202,8 @@ func (a MergeAction) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dial
 func (a MergeAction) writeInsert(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
 	w.WriteString("INSERT")
 
-	if len(a.Columns) > 0 {
-		w.WriteString(" (")
-		for i, col := range a.Columns {
-			if i > 0 {
-				w.WriteString(", ")
-			}
-			d.WriteQuoted(w, col)
-		}
-		w.WriteString(")")
+	if _, err := bob.ExpressSlice(ctx, w, d, start, a.Columns, " (", ", ", ")"); err != nil {
+		return nil, err
 	}
 
 	if a.Overriding != "" {
@@ -220,13 +213,7 @@ func (a MergeAction) writeInsert(ctx context.Context, w io.StringWriter, d bob.D
 	}
 
 	if len(a.Values) > 0 {
-		w.WriteString(" VALUES (")
-		args, err := bob.ExpressSlice(ctx, w, d, start, a.Values, "", ", ", "")
-		if err != nil {
-			return nil, err
-		}
-		w.WriteString(")")
-		return args, nil
+		return bob.ExpressSlice(ctx, w, d, start, a.Values, " VALUES (", ", ", ")")
 	}
 
 	w.WriteString(" DEFAULT VALUES")

--- a/dialect/psql/dialect/setcols.go
+++ b/dialect/psql/dialect/setcols.go
@@ -5,36 +5,31 @@ import (
 	"io"
 
 	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/expr"
 	"github.com/stephenafamo/bob/internal"
 )
 
 // columnsAssignment represents (columns...) = [ROW] (values...) or (columns...) = (subquery)
 type columnsAssignment struct {
-	cols   []bob.Expression
+	cols   []string
 	values []any // bob.Expression values or a single bob.Query for subquery
 	isRow  bool
 }
 
 func (a columnsAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-	w.WriteString("(")
-	colArgs, err := bob.ExpressSlice(ctx, w, d, start, a.cols, "", ", ", "")
+	colArgs, err := bob.ExpressSlice(ctx, w, d, start, a.cols, "(", ", ", ") = ")
 	if err != nil {
 		return nil, err
 	}
 
-	w.WriteString(") = ")
-
+	valPrefix := "("
 	if a.isRow {
-		w.WriteString("ROW ")
+		valPrefix = "ROW ("
 	}
 
-	w.WriteString("(")
-	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), a.values, "", ", ", "")
+	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), a.values, valPrefix, ", ", ")")
 	if err != nil {
 		return nil, err
 	}
-	w.WriteString(")")
 
 	return append(colArgs, valArgs...), nil
 }
@@ -52,31 +47,23 @@ func NewSetCols[Q interface{ AppendSet(clauses ...any) }](columns ...string) Set
 	return SetCols[Q]{columns: columns}
 }
 
-func (s SetCols[Q]) colExprs() []bob.Expression {
-	cols := make([]bob.Expression, len(s.columns))
-	for i, c := range s.columns {
-		cols[i] = expr.Quote(c)
-	}
-	return cols
-}
-
 // ToRow sets columns to ROW of expressions: (columns...) = ROW (expressions...)
 func (s SetCols[Q]) ToRow(values ...bob.Expression) bob.Mod[Q] {
 	return bob.ModFunc[Q](func(q Q) {
-		q.AppendSet(columnsAssignment{cols: s.colExprs(), values: internal.ToAnySlice(values), isRow: true})
+		q.AppendSet(columnsAssignment{cols: s.columns, values: internal.ToAnySlice(values), isRow: true})
 	})
 }
 
 // ToExprs sets columns to expressions: (columns...) = (expressions...)
 func (s SetCols[Q]) ToExprs(values ...bob.Expression) bob.Mod[Q] {
 	return bob.ModFunc[Q](func(q Q) {
-		q.AppendSet(columnsAssignment{cols: s.colExprs(), values: internal.ToAnySlice(values)})
+		q.AppendSet(columnsAssignment{cols: s.columns, values: internal.ToAnySlice(values)})
 	})
 }
 
 // ToQuery sets columns from a subquery: (columns...) = (subquery)
 func (s SetCols[Q]) ToQuery(query bob.Query) bob.Mod[Q] {
 	return bob.ModFunc[Q](func(q Q) {
-		q.AppendSet(columnsAssignment{cols: s.colExprs(), values: []any{query}})
+		q.AppendSet(columnsAssignment{cols: s.columns, values: []any{query}})
 	})
 }

--- a/dialect/psql/mm/qm.go
+++ b/dialect/psql/mm/qm.go
@@ -264,7 +264,6 @@ type InsertAction struct {
 }
 
 // Columns specifies the target columns for INSERT action
-// Column names can include subfield names or array subscripts if needed
 func Columns(columns ...string) bob.Mod[*InsertAction] {
 	return bob.ModFunc[*InsertAction](func(i *InsertAction) {
 		i.Columns = append(i.Columns, columns...)

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -387,6 +387,22 @@ WINDOW w AS (PARTITION BY depname ORDER BY salary)`,
 			),
 			ExpectedSQL: `SELECT id, name FROM users FOR UPDATE OF users SKIP LOCKED`,
 		},
+		"FOR UPDATE OF quoted table": {
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.ForUpdate(psql.Quote("my table")),
+			),
+			ExpectedSQL: `SELECT id FROM users FOR UPDATE OF "my table"`,
+		},
+		"FOR UPDATE OF qualified table": {
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.ForUpdate(psql.Quote("public", "users")),
+			),
+			ExpectedSQL: `SELECT id FROM users FOR UPDATE OF "public"."users"`,
+		},
 		"Multiple Unions": {
 			Query: psql.Select(
 				sm.Columns("id", "name"),

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -180,7 +180,8 @@ func ExceptAll(q bob.Query) bob.Mod[*dialect.SelectQuery] {
 	}
 }
 
-func ForUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForUpdate locks selected tables. Pass table names as psql.Quote(...) or another Expression.
+func ForUpdate(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthUpdate,
@@ -189,7 +190,8 @@ func ForUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 	})
 }
 
-func ForNoKeyUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForNoKeyUpdate locks selected tables without affecting key columns.
+func ForNoKeyUpdate(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthNoKeyUpdate,
@@ -198,7 +200,8 @@ func ForNoKeyUpdate(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 	})
 }
 
-func ForShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForShare acquires a shared lock on selected tables.
+func ForShare(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthShare,
@@ -207,7 +210,8 @@ func ForShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
 	})
 }
 
-func ForKeyShare(tables ...string) dialect.LockChain[*dialect.SelectQuery] {
+// ForKeyShare acquires a key-share lock on selected tables.
+func ForKeyShare(tables ...any) dialect.LockChain[*dialect.SelectQuery] {
 	return dialect.LockChain[*dialect.SelectQuery](func() clause.Lock {
 		return clause.Lock{
 			Strength: clause.LockStrengthKeyShare,

--- a/gen/bobgen-psql/driver/parser/mods_select.go
+++ b/gen/bobgen-psql/driver/parser/mods_select.go
@@ -252,7 +252,7 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 
 		if len(lock.LockingClause.LockedRels) > 0 {
 			lockInfo := info.children["LockingClause"].children[strconv.Itoa(i)]
-			bobLock.Tables = []string{w.input[lockInfo.start:lockInfo.end]}
+			bobLock.Tables = []any{w.input[lockInfo.start:lockInfo.end]}
 		}
 
 		w.imports = append(w.imports, []string{"github.com/stephenafamo/bob/clause"})


### PR DESCRIPTION
Fixes [#693](https://github.com/stephenafamo/bob/issues/693): `FOR UPDATE` / `FOR SHARE` `OF` targets can use `psql.Quote(...)` / `mysql.Quote(...)` for table names with spaces or schema qualification.

Also fixes PostgreSQL **MERGE** `INSERT` column lists and **SetCols** tuple assignments so column names stay **unquoted**, preserving PostgreSQL’s normal identifier case folding. Removes mistaken `WriteQuoted` / `expr.Quote` on those name lists (quoted identifiers are case-sensitive and broke cases like `mm.Columns("Name")` vs a `name` column).

Includes a small MySQL bugfix: `FromChain.Apply` now copies `IndexHints` onto the query.

Closes #693

## Breaking changes

| API | Before | After | Migration |
|-----|--------|-------|-----------|
| `clause.Lock.Tables` | `[]string` | `[]any` | Pass `psql.Quote("my table")` or `psql.Quote("public", "users")` per relation |
| PostgreSQL `sm.ForUpdate`, `ForNoKeyUpdate`, `ForShare`, `ForKeyShare` | `tables ...string` | `tables ...any` | Same as above |
| MySQL `sm.ForUpdate`, `sm.ForShare` | `tables ...string` | `tables ...any` | `mysql.Quote(...)` when quoting is needed |

Plain strings in lock helpers are still emitted as-is (no automatic quoting). Use `Quote` when the name needs delimiters or exact case.

## Fixes (non-breaking behavior)

| Area | Change | Rationale |
|------|--------|-----------|
| `MERGE` `INSERT` (`mm.Columns`) | Column names via `bob.ExpressSlice` on `[]string` (unquoted) | Replaces `WriteQuoted` per column; unquoted names fold to lowercase in PostgreSQL |
| `um` / `im` / `mm` `SetCols` | LHS column list is `[]string`, rendered unquoted | Same; removes `expr.Quote` on assignment column names |
| MySQL `FromChain.Apply` | Copies `IndexHints` from `FromChain` | `USE` / `FORCE` / `IGNORE INDEX` modifiers were dropped before |

**Explicit quoting:** For delimited or case-sensitive identifiers in MERGE/SetCols values, use `psql.Quote(...)` in the expression side (e.g. `mm.Values(psql.Quote("s", "my col"))`), not in `mm.Columns("my col")` alone.
