### PR TITLE
fix(psql): CRITICAL. Merge existing joins in SelectQuery.AppendTableRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed PostgreSQL `sm.From` clearing joins already on the `FROM` from_item (e.g. `sm.CrossJoin` before `sm.From`) because `SelectQuery.AppendTableRef` replaced the entire embedded `FROM` table ref. Existing joins are merged into the new primary table ref. (thanks @atzedus)
 - Fixed `FOR UPDATE` / `FOR SHARE` `OF` table lists: pass `psql.Quote(...)` / `mysql.Quote(...)` so names with spaces or qualification render correctly ([#693](https://github.com/stephenafamo/bob/issues/693)). (thanks @atzedus)
 - Fixed PostgreSQL `MERGE` `INSERT` column lists (`mm.Columns`): names are written unquoted (not via `WriteQuoted` / `expr.Quote`), so PostgreSQL still folds unquoted identifiers to lowercase and `mm.Columns("Name")` matches a column created as `name`. Quoted identifiers are case-sensitive in PostgreSQL; auto-quoting broke that. Use `psql.Quote(...)` in value expressions when you need a delimited identifier. (thanks @atzedus)
 - Fixed `um.SetCols` / `im.SetCols` / `mm.SetCols` tuple-assignment column lists the same way (unquoted `[]string` names on the left-hand side of `(cols...) = ...`). (thanks @atzedus)

--- a/dialect/psql/dialect/select.go
+++ b/dialect/psql/dialect/select.go
@@ -36,7 +36,11 @@ type SelectQuery struct {
 	CombinedOffset clause.Offset
 }
 
+// AppendTableRef sets the primary FROM from_item on the query.
 func (s *SelectQuery) AppendTableRef(ref clause.TableRef) {
+	if len(s.TableRef.Joins) > 0 {
+		ref.Joins = append(s.TableRef.Joins, ref.Joins...)
+	}
 	s.TableRef = ref
 }
 

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -39,6 +39,16 @@ func TestSelect(t *testing.T) {
 				sm.From("orders"),
 			),
 		},
+		"from keeps existing joins": {
+			Doc:         "A later From replaces the primary table but keeps joins already on the from_item",
+			ExpectedSQL: "SELECT id FROM orders CROSS JOIN events",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.CrossJoin("events"),
+				sm.From("orders"),
+			),
+		},
 		"from multiple tables cross join": {
 			Doc:         "Multiple tables in FROM via CROSS JOIN on the primary from_item",
 			ExpectedSQL: "SELECT id FROM users CROSS JOIN orders",
@@ -46,6 +56,15 @@ func TestSelect(t *testing.T) {
 				sm.Columns("id"),
 				sm.From("users"),
 				sm.CrossJoin("orders"),
+			),
+		},
+		"from multiple tables cross join unordered calls": {
+			Doc:         "Multiple tables in FROM via CROSS JOIN on the primary from_item",
+			ExpectedSQL: "SELECT id FROM users CROSS JOIN orders",
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.CrossJoin("orders"),
+				sm.From("users"),
 			),
 		},
 		"from function": {


### PR DESCRIPTION
Fixes PostgreSQL `SELECT` queries where join mods run before `sm.From`, or where a later `sm.From` should keep joins already attached to the embedded `FROM` `from_item`.

This fix affects both standard sm helpers like sm.InnerJoin and sm.LeftJoin, as well as codegen-generated ones (e.g., Preloads).

`SelectQuery.AppendTableRef` (used by `sm.From` / `FromChain`) used to assign `s.TableRef = ref` wholesale, so any joins added earlier via `sm.CrossJoin`, `sm.InnerJoin`, etc. were dropped.

## What broke

After `sm.From` was wired through `AppendTableRef` (replacing the old `SetTable` / `SetTableAlias` path), the primary `FROM` table ref was always replaced as a whole. Join mods only append to `TableRef.Joins`; they do not set `Expression`. If `sm.From` ran after them, those joins were lost.

### Join before `From` (mod order)

```go
psql.Select(
    sm.Columns("id"),
    sm.CrossJoin("orders"),
    sm.From("users"),
)
```

**Expected:** `SELECT id FROM users CROSS JOIN orders`  
**Got:** `SELECT id FROM users`

### Join after first `From`, then second `From`

```go
psql.Select(
    sm.Columns("id"),
    sm.From("users"),
    sm.CrossJoin("events"),
    sm.From("orders"),
)
```

**Expected:** `SELECT id FROM orders CROSS JOIN events`  
**Got:** `SELECT id FROM orders`

The usual order (`sm.From` then `sm.CrossJoin`) still worked; only reordering or a second `From` exposed the bug.

## Fix

`AppendTableRef` now merges existing `Joins` into the incoming ref before assignment:

```go
if len(s.TableRef.Joins) > 0 {
    ref.Joins = append(s.TableRef.Joins, ref.Joins...)
}
s.TableRef = ref
```

Primary table fields (`Expression`, alias, `ONLY`, `TABLESAMPLE`, etc.) still come from the latest `sm.From`; only `Joins` are preserved/merged.

New cases for unit-test: `from multiple tables cross join unordered calls`, `from keeps existing joins`.