### PR TITLE
fix: iterate over all schema constraint errors not just the first

### DIFF
--- a/gen/bobgen-psql/driver/keys.go
+++ b/gen/bobgen-psql/driver/keys.go
@@ -99,7 +99,7 @@ func (d *driver) Constraints(ctx context.Context, _ drivers.ColumnFilter) (drive
 			}
 
 		case "u":
-			ret.Uniques[key] = append(ret.Uniques[c.Table], drivers.Constraint[any]{
+			ret.Uniques[key] = append(ret.Uniques[key], drivers.Constraint[any]{
 				Name:    c.Name,
 				Columns: c.Columns,
 				Comment: c.Comment.String,


### PR DESCRIPTION
Fixes #698

In `gen/bobgen-psql/driver/keys.go`, the unique constraints were being appended using `c.Table` instead of `key` as the lookup key. When a table belongs to a non-shared schema, `key` includes the schema prefix while `c.Table` does not. This caused each subsequent unique constraint to append to a nil slice (since `ret.Uniques[c.Table]` is empty) instead of the existing slice at `ret.Uniques[key]`, effectively overwriting the previous constraint.

Only the last unique constraint was retained, meaning constraint errors would only ever detect at most one constraint violation.