### PR TITLE
Omit redundant table alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `NameAsExpr()` — what `NameAs()` did in v0.44.0 (name plus table alias)
   Update manual call sites, codegen templates, and generated models: `Users.Name()` in SQL builders → `Users.NameExpr()`, `Users.NameAs()` → `Users.NameAsExpr()`; use `Users.Name()` when you need the unqualified name string. On PostgreSQL and SQLite, `Schema()` still returns the schema when set.
 - Codegen templates and `orm.Preload` now use `NameExpr()` / `NameAsExpr()` instead of `Name()` / `NameAs()`. (thanks @atzedus)
+- `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 
 ### Fixed
 

--- a/dialect/mysql/table_test.go
+++ b/dialect/mysql/table_test.go
@@ -48,7 +48,7 @@ type OptionalWithUnique struct {
 var (
 	table1 = NewTablex[*WithAutoIncr, []*WithAutoIncr, *OptionalWithAutoIncr]("", expr.ColsForStruct[WithAutoIncr](""), nil)
 	table2 = NewTablex[*WithUnique, []*WithUnique, *OptionalWithUnique](
-		"", expr.ColsForStruct[WithUnique](""), []string{"id"}, []string{"title", "author_id"},
+		"books", expr.ColsForStruct[WithUnique]("books"), []string{"id"}, []string{"title", "author_id"},
 	)
 )
 
@@ -204,7 +204,7 @@ func TestGetInsertedUsesExplicitColumns(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	expectedSQL := "SELECT `id`, `title`, `author_id` FROM AS WHERE ((`id` IN ((?))))"
+	expectedSQL := "SELECT `books`.`id` AS `id`, `books`.`title` AS `title`, `books`.`author_id` AS `author_id` FROM `books` WHERE ((`id` IN ((?))))"
 	if diff, err := testutils.QueryDiff(expectedSQL, gotSQL, nil); err != nil {
 		t.Fatalf("QueryDiff: %v", err)
 	} else if diff != "" {

--- a/dialect/mysql/view.go
+++ b/dialect/mysql/view.go
@@ -52,9 +52,13 @@ func (v *View[T, Tslice, C]) NameExpr() Expression {
 	return Quote(v.name)
 }
 
-// NameAsExpr returns the table name as an expression with an alias
+// NameAsExpr returns the table name as an expression with an alias when needed.
 func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
-	return v.NameExpr().As(v.alias)
+	expr := v.NameExpr()
+	if v.alias != v.name {
+		return expr.As(v.alias)
+	}
+	return expr
 }
 
 // Alias returns the alias

--- a/dialect/psql/view.go
+++ b/dialect/psql/view.go
@@ -70,9 +70,13 @@ func (v *View[T, Tslice, C]) NameExpr() Expression {
 	return Expression{}.New(orm.SchemaTable(v.name))
 }
 
-// NameAsExpr returns the table name as an expression with an alias
+// NameAsExpr returns the table name as an expression with an alias when needed.
 func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
-	return v.NameExpr().As(v.alias)
+	expr := v.NameExpr()
+	if v.schema != "" || v.alias != v.name {
+		return expr.As(v.alias)
+	}
+	return expr
 }
 
 // Alias returns the alias

--- a/dialect/psql/view_test.go
+++ b/dialect/psql/view_test.go
@@ -20,6 +20,8 @@ type someStruct struct {
 
 var someStructView = NewView[*someStruct, bob.Expression]("public", "some_struct", expr.ColsForStruct[someStruct]("some_struct"))
 
+var someStructViewNoSchema = NewView[*someStruct, bob.Expression]("", "some_struct", expr.ColsForStruct[someStruct]("some_struct"))
+
 func TestSomeViewName(t *testing.T) {
 	name := someStructView.NameExpr().String()
 	expected := "\"public\".\"some_struct\""
@@ -37,6 +39,15 @@ func TestSomeViewNameAs(t *testing.T) {
 	}
 }
 
+func TestSomeViewNameAsWithoutSchema(t *testing.T) {
+	q := selectToString(t, Select(sm.From(someStructViewNoSchema.NameAsExpr())), 0)
+
+	expected := "SELECT \n*\nFROM \"some_struct\"\n"
+	if q != expected {
+		t.Errorf("someStructViewNoSchema.NameAs() expected '%#v' but got '%#v'", expected, q)
+	}
+}
+
 func TestSomeViewColumns(t *testing.T) {
 	c := someStructView.Columns
 	query := selectToString(t, Select(sm.Columns(c)), 0)
@@ -50,6 +61,16 @@ func TestSomeViewQuery(t *testing.T) {
 	q := someStructView.Query(sm.Where(Quote("id").In(Arg(1, 2, 3))))
 	query := viewToString(t, q)
 	expected := "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"public\".\"some_struct\" AS \"public.some_struct\"\nWHERE (\"id\" IN ($0, $1, $2))\n"
+
+	if query != expected {
+		t.Errorf("Expected '%#v' but got '%#v'", expected, query)
+	}
+}
+
+func TestSomeViewQueryWithoutSchema(t *testing.T) {
+	q := someStructViewNoSchema.Query(sm.Where(Quote("id").In(Arg(1, 2, 3))))
+	query := viewToString(t, q)
+	expected := "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"some_struct\"\nWHERE (\"id\" IN ($0, $1, $2))\n"
 
 	if query != expected {
 		t.Errorf("Expected '%#v' but got '%#v'", expected, query)

--- a/dialect/sqlite/view.go
+++ b/dialect/sqlite/view.go
@@ -74,9 +74,13 @@ func (v *View[T, Tslice, C]) NameExpr() Expression {
 	return Expression{}.New(orm.SchemaTable(v.name))
 }
 
-// NameAsExpr returns the table name as an expression with an alias
+// NameAsExpr returns the table name as an expression with an alias when needed.
 func (v *View[T, Tslice, C]) NameAsExpr() bob.Expression {
-	return v.NameExpr().As(v.alias)
+	expr := v.NameExpr()
+	if v.schema != "" || v.alias != v.name {
+		return expr.As(v.alias)
+	}
+	return expr
 }
 
 // Alias returns the alias

--- a/dialect/sqlite/view_test.go
+++ b/dialect/sqlite/view_test.go
@@ -1,0 +1,60 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/sqlite/dialect"
+	"github.com/stephenafamo/bob/dialect/sqlite/sm"
+	"github.com/stephenafamo/bob/expr"
+)
+
+type someStruct struct {
+	ID    int64  `db:"id,pk"`
+	Name  string `db:"name"`
+	Email string `db:"email"`
+}
+
+var someStructViewNoSchema = NewView[*someStruct, bob.Expression]("", "some_struct", expr.ColsForStruct[someStruct]("some_struct"))
+
+func TestSomeViewNameAsWithoutSchema(t *testing.T) {
+	q := selectToString(t, Select(sm.From(someStructViewNoSchema.NameAsExpr())), 0)
+
+	expected := "SELECT \n*\nFROM \"some_struct\"\n"
+	if q != expected {
+		t.Errorf("someStructViewNoSchema.NameAs() expected '%#v' but got '%#v'", expected, q)
+	}
+}
+
+func TestSomeViewQueryWithoutSchema(t *testing.T) {
+	q := someStructViewNoSchema.Query(sm.Where(Quote("id").In(Arg(1, 2, 3))))
+	query := viewToString(t, q)
+	expected := "SELECT \n\"some_struct\".\"id\" AS \"id\", \"some_struct\".\"name\" AS \"name\", \"some_struct\".\"email\" AS \"email\"\nFROM \"some_struct\"\nWHERE (\"id\" IN (?0, ?1, ?2))\n"
+
+	if query != expected {
+		t.Errorf("Expected '%#v' but got '%#v'", expected, query)
+	}
+}
+
+func selectToString(t *testing.T, query bob.BaseQuery[*dialect.SelectQuery], argsLen int) string {
+	t.Helper()
+	ctx := context.Background()
+	buf := new(bytes.Buffer)
+	args, err := query.WriteQuery(ctx, buf, 0)
+	if err != nil {
+		t.Errorf("Failed to WriteQuery: %v", err)
+		return ""
+	}
+	if len(args) != argsLen {
+		t.Errorf("Expected %d args but got %d", argsLen, len(args))
+		return ""
+	}
+	return buf.String()
+}
+
+func viewToString(t *testing.T, query *ViewQuery[*someStruct, []*someStruct]) string {
+	t.Helper()
+	return selectToString(t, query.BaseQuery, 3)
+}

--- a/website/docs/models/view.md
+++ b/website/docs/models/view.md
@@ -68,7 +68,7 @@ query := psql.Select(sm.From(userView.NameExpr()))
 
 ## NameAsExpr()
 
-Like `NameExpr()`, but includes the table alias (same as `Alias()`). Use in `FROM`, `JOIN`, and other clauses that need a named range variable—for example, PostgreSQL/SQLite `INSERT INTO ... AS alias` or subqueries that reference `Alias()` in `WHERE`.
+Like `NameExpr()`, but adds `AS alias` when the alias differs from the table name (for example when a schema is set at construction, so the alias is `schema.table`). When schema is empty and the alias matches the table name, the redundant `FROM "users" AS "users"` form is omitted; `Alias()` is unchanged for joins and column qualification. Use in `FROM`, `JOIN`, and other clauses that need a named range variable—for example, PostgreSQL/SQLite `INSERT INTO ... AS alias` or subqueries that reference `Alias()` in `WHERE`.
 
 ```go
 import (


### PR DESCRIPTION
- `NameAsExpr()` on PostgreSQL, SQLite, and MySQL `View`/`Table` types no longer emits a redundant `AS` when the alias equals the table name (e.g. `FROM "users"` instead of `FROM "users" AS "users"`).
- When a schema is set at construction, behavior is unchanged: `FROM "public"."users" AS "public.users"`.
- `Alias()` and column qualification are unchanged; only `FROM`/`INSERT`/`UPDATE`/`DELETE` rendering via `NameAsExpr()` is affected.
- Added view tests for sqlite/psql; fixed mysql `table_test` that used an empty table name.