### PR TITLE
fix(psql): preserve standalone joins before FROM/USING and support join chains in sm.From

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 
+### Fixed
+
+- Fixed PostgreSQL `um` / `dm` standalone join mods (`InnerJoin`, `LeftJoin`, etc.) applied before `um.From(...)` / `dm.Using(...)`: the join is now preserved and attached to the next `FROM` / `USING` from_item instead of being dropped. (thanks @atzedus)
+- Fixed/extended PostgreSQL `sm.From(...)`: it now accepts variadic join chains (`sm.From(table, joins...)`), and inline joins are merged with already attached standalone joins when replacing the primary `FROM` source. (thanks @atzedus)
+
 ## [v0.45.0] - 2026-05-28
 
 ### Added

--- a/dialect/psql/delete_test.go
+++ b/dialect/psql/delete_test.go
@@ -75,6 +75,21 @@ func TestDelete(t *testing.T) {
 			  WHERE (employees.id = $1)`,
 			ExpectedArgs: []any{1},
 		},
+		"standalone inner join before using": {
+			Query: psql.Delete(
+				dm.From("employees"),
+				dm.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				dm.Using("accounts"),
+				dm.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `DELETE FROM employees USING accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
 		"standalone inner join on last using item": {
 			Query: psql.Delete(
 				dm.From("employees"),

--- a/dialect/psql/dialect/delete.go
+++ b/dialect/psql/dialect/delete.go
@@ -24,17 +24,31 @@ type DeleteQuery struct {
 	bob.ContextualModdable[*DeleteQuery]
 }
 
+// AppendTableRef sets the primary USING from_item on the query.
+// If the query has no UsingItems, the new TableRef is set as the primary USING from_item.
+// If the query has one UsingItem and it is empty, the new TableRef is set as the primary USING from_item.
+// If the query has one UsingItem and it is not empty, the new TableRef is appended to the last UsingItem.
 func (d *DeleteQuery) AppendTableRef(using clause.TableRef) {
+	if len(d.UsingItems) == 1 && d.UsingItems[0].Expression == nil {
+		if len(d.UsingItems[0].Joins) > 0 {
+			using.Joins = append(d.UsingItems[0].Joins, using.Joins...)
+		}
+		d.UsingItems[0] = using
+
+		return
+	}
+
 	d.UsingItems = append(d.UsingItems, using)
 }
 
 // AppendJoin satisfies Joinable for JoinChain[*DeleteQuery].
-// When UsingItems is non-empty, the join is appended to the last USING item (e.g. after dm.Using).
-// Otherwise it is ignored; prefer dm.Using(table, joins...) for joins on a new from_item.
+// When UsingItems is non-empty, the join is appended to the last USING item (e.g. after um.From).
+// Otherwise the new UsingItem is appended with an empty TableRef and the join is appended to it.
 func (d *DeleteQuery) AppendJoin(j clause.Join) {
 	if len(d.UsingItems) == 0 {
-		return
+		d.UsingItems = append(d.UsingItems, clause.TableRef{})
 	}
+
 	d.UsingItems[len(d.UsingItems)-1].AppendJoin(j)
 }
 

--- a/dialect/psql/dialect/update.go
+++ b/dialect/psql/dialect/update.go
@@ -25,17 +25,31 @@ type UpdateQuery struct {
 	bob.ContextualModdable[*UpdateQuery]
 }
 
+// AppendTableRef sets the primary FROM from_item on the query.
+// If the query has no FromItems, the new TableRef is set as the primary FROM from_item.
+// If the query has one FromItem and it is empty, the new TableRef is set as the primary FROM from_item.
+// If the query has one FromItem and it is not empty, the new TableRef is appended to the last FromItem.
 func (u *UpdateQuery) AppendTableRef(from clause.TableRef) {
+	if len(u.FromItems) == 1 && u.FromItems[0].Expression == nil {
+		if len(u.FromItems[0].Joins) > 0 {
+			from.Joins = append(u.FromItems[0].Joins, from.Joins...)
+		}
+		u.FromItems[0] = from
+
+		return
+	}
+
 	u.FromItems = append(u.FromItems, from)
 }
 
 // AppendJoin satisfies Joinable for JoinChain[*UpdateQuery].
 // When FromItems is non-empty, the join is appended to the last FROM item (e.g. after um.From).
-// Otherwise it is ignored; prefer um.From(table, joins...) for joins on a new from_item.
+// Otherwise the new FromItem is appended with an empty TableRef and the join is appended to it.
 func (u *UpdateQuery) AppendJoin(j clause.Join) {
 	if len(u.FromItems) == 0 {
-		return
+		u.FromItems = append(u.FromItems, clause.TableRef{})
 	}
+
 	u.FromItems[len(u.FromItems)-1].AppendJoin(j)
 }
 

--- a/dialect/psql/dm/qm.go
+++ b/dialect/psql/dm/qm.go
@@ -40,7 +40,7 @@ func FromAs(name any, alias string) bob.Mod[*dialect.DeleteQuery] {
 }
 
 func Using(table any, joins ...dialect.JoinChain[*dialect.DeleteQuery]) dialect.FromChain[*dialect.DeleteQuery] {
-	return dialect.From[*dialect.DeleteQuery](table, joins...)
+	return dialect.From(table, joins...)
 }
 
 // UsingFunction returns an expression for dm.Using when the source is one or more

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -93,6 +93,41 @@ func TestSelect(t *testing.T) {
 				),
 			),
 		},
+		"from with inline inner join": {
+			Doc:         "FROM with INNER JOIN attached inline",
+			ExpectedSQL: `SELECT id FROM users INNER JOIN events ON ("users"."id" = "events"."user_id")`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.From("users", sm.InnerJoin("events").OnEQ(
+					psql.Quote("users", "id"),
+					psql.Quote("events", "user_id"),
+				)),
+			),
+		},
+		"from inline joins keep existing standalone joins": {
+			Doc:         "Replacing FROM with inline joins preserves already attached standalone joins",
+			ExpectedSQL: `SELECT id FROM users CROSS JOIN events INNER JOIN admins ON ("users"."id" = "admins"."user_id")`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.CrossJoin("events"),
+				sm.From("users", sm.InnerJoin("admins").OnEQ(
+					psql.Quote("users", "id"),
+					psql.Quote("admins", "user_id"),
+				)),
+			),
+		},
+		"standalone inner join before from": {
+			Doc:         "INNER JOIN applied as a standalone mod before From",
+			ExpectedSQL: `SELECT id FROM users INNER JOIN events ON ("users"."id" = "events"."user_id")`,
+			Query: psql.Select(
+				sm.Columns("id"),
+				sm.InnerJoin("events").OnEQ(
+					psql.Quote("users", "id"),
+					psql.Quote("events", "user_id"),
+				),
+				sm.From("users"),
+			),
+		},
 		"from rows from with cross join": {
 			Doc: "FROM ROWS FROM (...) with an additional table via CROSS JOIN",
 			Query: psql.Select(

--- a/dialect/psql/sm/qm.go
+++ b/dialect/psql/sm/qm.go
@@ -32,8 +32,9 @@ func Columns(clauses ...any) bob.Mod[*dialect.SelectQuery] {
 
 // From sets the query source. Pass a table name as a string (unquoted literal) or use
 // psql.Quote(...) / a subquery Expression for quoted or qualified names.
-func From(table any) dialect.FromChain[*dialect.SelectQuery] {
-	return dialect.From[*dialect.SelectQuery](table)
+// Optional joins are attached to this from_item.
+func From(table any, joins ...dialect.JoinChain[*dialect.SelectQuery]) dialect.FromChain[*dialect.SelectQuery] {
+	return dialect.From(table, joins...)
 }
 
 // FromFunction returns an expression for sm.From when the source is one or more

--- a/dialect/psql/update_test.go
+++ b/dialect/psql/update_test.go
@@ -123,6 +123,22 @@ func TestUpdate(t *testing.T) {
 			  WHERE (employees.id = $1)`,
 			ExpectedArgs: []any{1},
 		},
+		"standalone inner join before from": {
+			Query: psql.Update(
+				um.Table("employees"),
+				um.SetCol("sales_count").To("sales_count + 1"),
+				um.InnerJoin("departments").OnEQ(
+					psql.Quote("accounts", "dept_id"),
+					psql.Quote("departments", "id"),
+				),
+				um.From("accounts"),
+				um.Where(psql.Quote("employees", "id").EQ(psql.Arg(1))),
+			),
+			ExpectedSQL: `UPDATE employees SET "sales_count" = sales_count + 1 FROM accounts
+			  INNER JOIN departments ON (accounts.dept_id = departments.id)
+			  WHERE (employees.id = $1)`,
+			ExpectedArgs: []any{1},
+		},
 		"standalone inner join on last from item": {
 			Query: psql.Update(
 				um.Table("employees"),


### PR DESCRIPTION
Fixes PostgreSQL query builder behavior when joins are applied **before** the primary `FROM` / `USING` source, and extends `sm.From` to accept inline join chains.

- **UPDATE (`um`) / DELETE (`dm`)**: Standalone join mods (`InnerJoin`, `LeftJoin`, etc.) applied before `um.From(...)` or `dm.Using(...)` are no longer dropped. `AppendJoin` now creates a placeholder `from_item` when none exists yet; `AppendTableRef` fills that slot and merges any accumulated joins into the real table ref.
- **SELECT (`sm`)**: `sm.From(table, joins...)` now accepts optional join chains (aligned with `um.From` / `dm.Using`). Inline joins passed to `From` are merged with joins already attached via standalone mods (e.g. `CrossJoin` then `From(..., InnerJoin(...))`).

## Problem

Previously, patterns like:

```go
psql.Select(
    sm.InnerJoin("events").OnEQ(...),
    sm.From("users"),
)
```

or UPDATE/DELETE with a join mod before `From`/`Using` silently omitted the join. `sm.From` also could not attach joins inline in a single mod.

## Solution

- `UpdateQuery` / `DeleteQuery`: mirror the join-placeholder + merge-on-`AppendTableRef` pattern already used for `SelectQuery`.
- `sm.From`: variadic `JoinChain` args, same as other `From` helpers.
- Regression tests for SELECT, UPDATE, and DELETE covering join-before-from/using and inline/merged join chains.