### PR TITLE
fix: rollback transaction on panic in RunInTx

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -64,11 +64,26 @@ func (d DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
 // RunInTx runs the provided function in a transaction.
 // If the function returns an error, the transaction is rolled back.
 // Otherwise, the transaction is committed.
+// If the function panics, the transaction is rolled back and the panic is re-raised.
 func (d DB) RunInTx(ctx context.Context, txOptions *sql.TxOptions, fn func(context.Context, Executor) error) error {
 	tx, err := d.BeginTx(ctx, txOptions)
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
 	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			rbErr := tx.Rollback(ctx)
+			if rbErr != nil {
+				if pErr, ok := p.(error); ok {
+					panic(errors.Join(pErr, rbErr))
+				}
+				// p is not an error (e.g. string or int), so the rollback error
+				// cannot be surfaced without changing the panic value type.
+			}
+			panic(p)
+		}
+	}()
 
 	if err := fn(ctx, tx); err != nil {
 		err = fmt.Errorf("call: %w", err)

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -1,5 +1,13 @@
 package bob
 
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+)
+
 var (
 	_ Preparer[StdPrepared] = DB{}
 	_ Executor              = DB{}
@@ -18,3 +26,109 @@ var (
 	_ Transaction            = Tx{}
 	_ txForStmt[StdPrepared] = Tx{}
 )
+
+// ─── mock driver ─────────────────────────────────────────────────────────────
+
+type mockConnector struct{ rollbackErr error }
+
+func (c mockConnector) Connect(_ context.Context) (driver.Conn, error) {
+	return mockConn{rollbackErr: c.rollbackErr}, nil
+}
+func (c mockConnector) Driver() driver.Driver { return nil }
+
+type mockConn struct{ rollbackErr error }
+
+func (c mockConn) Prepare(_ string) (driver.Stmt, error) { return nil, nil }
+func (c mockConn) Close() error                           { return nil }
+func (c mockConn) Begin() (driver.Tx, error)              { return mockTx{rollbackErr: c.rollbackErr}, nil }
+
+type mockTx struct{ rollbackErr error }
+
+func (t mockTx) Commit() error   { return nil }
+func (t mockTx) Rollback() error { return t.rollbackErr }
+
+func newMockDB(rollbackErr error) DB {
+	return NewDB(sql.OpenDB(mockConnector{rollbackErr: rollbackErr}))
+}
+
+// ─── RunInTx panic tests ──────────────────────────────────────────────────────
+
+// TestRunInTxPanicPropagates verifies that a panic inside fn is re-raised after
+// the transaction has been rolled back.
+func TestRunInTxPanicPropagates(t *testing.T) {
+	t.Parallel()
+
+	panicValue := errors.New("forced panic")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic to propagate, but it did not")
+		}
+		if r != panicValue {
+			t.Fatalf("got panic value %v, want %v", r, panicValue)
+		}
+	}()
+
+	_ = newMockDB(nil).RunInTx(context.Background(), nil, func(_ context.Context, _ Executor) error {
+		panic(panicValue)
+	})
+
+	t.Fatal("RunInTx should not return normally after a panic")
+}
+
+// TestRunInTxPanicErrorJoinsRollbackErr verifies that when fn panics with an
+// error value and rollback also fails, both errors are joined and re-panicked.
+func TestRunInTxPanicErrorJoinsRollbackErr(t *testing.T) {
+	t.Parallel()
+
+	panicErr := errors.New("forced panic")
+	rollbackErr := errors.New("rollback failed")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic to propagate, but it did not")
+		}
+		joined, ok := r.(error)
+		if !ok {
+			t.Fatalf("expected panic value to be an error, got %T", r)
+		}
+		if !errors.Is(joined, panicErr) {
+			t.Errorf("joined error should wrap panicErr: %v", joined)
+		}
+		if !errors.Is(joined, rollbackErr) {
+			t.Errorf("joined error should wrap rollbackErr: %v", joined)
+		}
+	}()
+
+	_ = newMockDB(rollbackErr).RunInTx(context.Background(), nil, func(_ context.Context, _ Executor) error {
+		panic(panicErr)
+	})
+
+	t.Fatal("RunInTx should not return normally after a panic")
+}
+
+// TestRunInTxPanicNonErrorPreservesValue verifies that when fn panics with a
+// non-error value, the original panic value is preserved (even if rollback fails).
+func TestRunInTxPanicNonErrorPreservesValue(t *testing.T) {
+	t.Parallel()
+
+	const panicValue = "non-error panic"
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic to propagate, but it did not")
+		}
+		if r != panicValue {
+			t.Fatalf("got panic value %v, want %v", r, panicValue)
+		}
+	}()
+
+	_ = newMockDB(nil).RunInTx(context.Background(), nil, func(_ context.Context, _ Executor) error {
+		panic(panicValue)
+	})
+
+	t.Fatal("RunInTx should not return normally after a panic")
+}


### PR DESCRIPTION
## Problem

`RunInTx` currently does not handle panics inside the provided function.
If `fn` panics, the transaction is never rolled back, leaving row-level
locks held until the connection is GC'd or the server's
`innodb_lock_wait_timeout` fires — which can cause deadlocks under
concurrent load.

```go
db.RunInTx(ctx, nil, func(ctx context.Context, exec bob.Executor) error {
    // INSERT acquires row locks...
    panic("something went wrong") // locks are never released
})
```

## Fix

Add a deferred `recover()` that rolls back the transaction and re-panics,
matching the behaviour of other Go ORMs (GORM, go-pg, gobuffalo/pop).

- If rollback succeeds: re-panic with the original value unchanged
- If rollback fails **and** the panic value is an `error`: join both errors via `errors.Join` (consistent with the existing error-path style) and re-panic
- If rollback fails **and** the panic value is not an `error` (e.g. a string): rollback error is intentionally discarded — changing the panic value type would break callers who `recover()` and type-assert the value

## Tests

Three new tests added to `stdlib_test.go` using a minimal mock `driver.Connector`:

| Test | Verifies |
|---|---|
| `TestRunInTxPanicPropagates` | panic re-raised after successful rollback |
| `TestRunInTxPanicErrorJoinsRollbackErr` | both errors visible via `errors.Is` when rollback also fails |
| `TestRunInTxPanicNonErrorPreservesValue` | original non-error panic value preserved |

## References

- go-pg panic recovery: https://github.com/go-pg/pg/issues/468
- gobuffalo/pop: https://github.com/gobuffalo/pop/pull/775