### PR TITLE
feat: augment generated queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `With()` on generated queries as a more ergonomic method to add mods on top of generated queries (thanks @daddz)
+
 ### Changed
 
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
-
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 
 ## [v0.45.0] - 2026-05-28

--- a/gen/templates/queries/query/01_query.go.tpl
+++ b/gen/templates/queries/query/01_query.go.tpl
@@ -6,6 +6,7 @@
 {{$.Importer.Import "context"}}
 {{$.Importer.Import "github.com/stephenafamo/bob"}}
 {{$.Importer.Import "github.com/stephenafamo/bob/orm"}}
+{{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s" $.Dialect)}}
 {{$.Importer.Import (printf "github.com/stephenafamo/bob/dialect/%s/dialect" $.Dialect)}}
 
 //go:embed {{.QueryFile.BaseName}}.bob.sql
@@ -114,6 +115,7 @@ func {{$upperName}} ({{join ", " $args}}) *{{$upperName}}Query {
       Mod: bob.ModFunc[{{$dialectType}}](func(q {{$dialectType}}) {
           {{replace "EXPR" "expressionTypArgs" ($query.Mods.IncludeInTemplate $.Importer)}}
       }),
+      Build: {{$.Dialect}}.{{$queryType}},
     }
   {{- else -}}
     return &{{$upperName}}Query{
@@ -127,6 +129,7 @@ func {{$upperName}} ({{join ", " $args}}) *{{$upperName}}Query {
       Mod: bob.ModFunc[{{$dialectType}}](func(q {{$dialectType}}) {
           {{replace "EXPR" "expressionTypArgs" ($query.Mods.IncludeInTemplate $.Importer)}}
       }),
+      Build: {{$.Dialect}}.{{$queryType}},
     }
   {{- end}} 
 }

--- a/orm/query.go
+++ b/orm/query.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"iter"
 
-	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/scan"
+
+	"github.com/stephenafamo/bob"
 )
 
 type ExecQuery[Q bob.Expression] struct {
@@ -78,22 +79,39 @@ func (q Query[Q, T, Ts, Tr]) Each(ctx context.Context, exec bob.Executor) (func(
 	return bob.Each(ctx, exec, q, q.Scanner)
 }
 
-type ModExecQuery[Q any, E bob.Expression] struct {
+type ModExecQuery[Q bob.Expression, E bob.Expression] struct {
 	ExecQuery[E]
-	Mod bob.Mod[Q]
+	Mod   bob.Mod[Q]
+	Build func(...bob.Mod[Q]) bob.BaseQuery[Q]
 }
 
 func (q ModExecQuery[Q, E]) Apply(e Q) {
 	q.Mod.Apply(e)
 }
 
-type ModQuery[Q any, E bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
+func (q ModExecQuery[Q, E]) With(mods ...bob.Mod[Q]) ExecQuery[Q] {
+	return ExecQuery[Q]{
+		BaseQuery: q.Build(append([]bob.Mod[Q]{q.Mod}, mods...)...),
+	}
+}
+
+type ModQuery[Q bob.Expression, E bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
 	Query[E, T, Ts, Tr]
-	Mod bob.Mod[Q]
+	Mod   bob.Mod[Q]
+	Build func(...bob.Mod[Q]) bob.BaseQuery[Q]
 }
 
 func (q ModQuery[Q, E, T, Ts, Tr]) Apply(e Q) {
 	q.Mod.Apply(e)
+}
+
+func (q ModQuery[Q, E, T, Ts, Tr]) With(mods ...bob.Mod[Q]) Query[Q, T, Ts, Tr] {
+	return Query[Q, T, Ts, Tr]{
+		ExecQuery: ExecQuery[Q]{
+			BaseQuery: q.Build(append([]bob.Mod[Q]{q.Mod}, mods...)...),
+		},
+		Scanner: q.Scanner,
+	}
 }
 
 func ArgsToExpression(querySQL string, from, to int, argIter iter.Seq[ArgWithPosition]) bob.Expression {

--- a/orm/query_test.go
+++ b/orm/query_test.go
@@ -1,0 +1,86 @@
+package orm_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stephenafamo/scan"
+
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+	"github.com/stephenafamo/bob/orm"
+	testutils "github.com/stephenafamo/bob/test/utils"
+)
+
+type rawExpr struct{ sql string }
+
+func (r rawExpr) WriteSQL(_ context.Context, w io.StringWriter, _ bob.Dialect, _ int) ([]any, error) {
+	w.WriteString(r.sql)
+	return nil, nil
+}
+
+// newModQuery builds a ModQuery whose generated Mod alone reproduces
+// "SELECT id FROM todo", mirroring what the queries plugin emits.
+func newModQuery(scanner scan.Mapper[int]) orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]] {
+	return orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
+		Query: orm.Query[rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
+			ExecQuery: orm.ExecQuery[rawExpr]{
+				BaseQuery: bob.BaseQuery[rawExpr]{
+					Expression: rawExpr{sql: "SELECT id FROM todo"},
+					Dialect:    dialect.Dialect,
+					QueryType:  bob.QueryTypeSelect,
+				},
+			},
+			Scanner: scanner,
+		},
+		Mod: bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
+			q.AppendSelect(psql.Quote("id"))
+			q.SetTable(psql.Quote("todo"))
+		}),
+		Build: psql.Select,
+	}
+}
+
+func TestModQueryWith(t *testing.T) {
+	mq := newModQuery(nil)
+
+	examples := testutils.Testcases{
+		"base query from generated mod": {
+			Doc:         "With() and no extra mods reproduces the base query from the generated Mod alone",
+			ExpectedSQL: `SELECT id FROM todo`,
+			Query:       mq.With(),
+		},
+		"augmented with extra mods": {
+			Doc:          "Extra mods are appended on top of the generated Mod",
+			ExpectedSQL:  `SELECT id FROM todo WHERE (project_id = $1) LIMIT 10`,
+			ExpectedArgs: []any{1},
+			Query: mq.With(
+				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
+				sm.Limit(10),
+			),
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}
+
+func TestModQueryWithPreservesScanner(t *testing.T) {
+	scannerCalled := false
+	scanner := func(context.Context, []string) (func(*scan.Row) (any, error), func(any) (int, error)) {
+		scannerCalled = true
+		return nil, nil
+	}
+
+	augmented := newModQuery(scanner).With()
+	if augmented.Scanner == nil {
+		t.Fatal("With() dropped the scanner")
+	}
+
+	augmented.Scanner(context.Background(), nil)
+	if !scannerCalled {
+		t.Fatal("With() did not preserve the original scanner")
+	}
+}

--- a/orm/query_test.go
+++ b/orm/query_test.go
@@ -23,8 +23,11 @@ func (r rawExpr) WriteSQL(_ context.Context, w io.StringWriter, _ bob.Dialect, _
 }
 
 // newModQuery builds a ModQuery whose generated Mod alone reproduces
-// "SELECT id FROM todo", mirroring what the queries plugin emits.
-func newModQuery(scanner scan.Mapper[int]) orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]] {
+// "SELECT id FROM todo", mirroring what the queries plugin emits. Any extra
+// funcs are applied inside the generated Mod after the SELECT/FROM, letting a
+// test reproduce a query that already carries WHERE/ORDER BY/LIMIT/OFFSET
+// clauses the way the generator emits them.
+func newModQuery(scanner scan.Mapper[int], extra ...func(*dialect.SelectQuery)) orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]] {
 	return orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
 		Query: orm.Query[rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
 			ExecQuery: orm.ExecQuery[rawExpr]{
@@ -39,6 +42,9 @@ func newModQuery(scanner scan.Mapper[int]) orm.ModQuery[*dialect.SelectQuery, ra
 		Mod: bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
 			q.AppendSelect(psql.Quote("id"))
 			q.SetTable(psql.Quote("todo"))
+			for _, fn := range extra {
+				fn(q)
+			}
 		}),
 		Build: psql.Select,
 	}
@@ -59,6 +65,83 @@ func TestModQueryWith(t *testing.T) {
 			ExpectedArgs: []any{1},
 			Query: mq.With(
 				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
+				sm.Limit(10),
+			),
+		},
+	}
+
+	testutils.RunTests(t, examples, nil)
+}
+
+// TestModQueryWithExistingClauses exercises augmentation of a generated query
+// that already carries WHERE / ORDER BY / LIMIT / OFFSET clauses, reproducing
+// the way the queries plugin emits them: WHERE goes onto the regular Where
+// field (so user mods AND onto it), while ORDER BY / LIMIT / OFFSET go onto the
+// Combined* fields.
+func TestModQueryWithExistingClauses(t *testing.T) {
+	examples := testutils.Testcases{
+		"existing WHERE is ANDed with one extra condition": {
+			Doc:          "A user sm.Where() is appended to the generated WHERE via AND, producing valid SQL",
+			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2`,
+			ExpectedArgs: []any{true, 1},
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.AppendWhere(psql.Quote("done").EQ(psql.Arg(true)))
+			}).With(
+				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
+			),
+		},
+		"existing WHERE is ANDed with multiple extra conditions": {
+			Doc:          "Multiple user sm.Where() mods each AND onto the generated WHERE, preserving arg order",
+			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2 AND priority > $3`,
+			ExpectedArgs: []any{true, 1, 2},
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.AppendWhere(psql.Quote("done").EQ(psql.Arg(true)))
+			}).With(
+				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
+				sm.Where(psql.Quote("priority").GT(psql.Arg(2))),
+			),
+		},
+		// KNOWN LIMITATION: ORDER BY / LIMIT / OFFSET only append. The generated
+		// clauses live on the Combined* fields while user mods set the regular
+		// fields, so both are rendered as separate clauses, yielding invalid SQL.
+		"existing ORDER BY produces a duplicate clause (invalid SQL)": {
+			Doc:         "A user sm.OrderBy() does not merge with the generated ORDER BY; both clauses are emitted",
+			ExpectedSQL: `SELECT id FROM todo ORDER BY id ORDER BY created_at`,
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.CombinedOrder.AppendOrder(psql.Quote("created_at"))
+			}).With(
+				sm.OrderBy(psql.Quote("id")),
+			),
+		},
+		"existing LIMIT produces a duplicate clause (invalid SQL)": {
+			Doc:         "A user sm.Limit() does not replace the generated LIMIT; both clauses are emitted",
+			ExpectedSQL: `SELECT id FROM todo LIMIT 10 LIMIT 5`,
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.CombinedLimit.SetLimit(5)
+			}).With(
+				sm.Limit(10),
+			),
+		},
+		"existing OFFSET produces a duplicate clause (invalid SQL)": {
+			Doc:         "A user sm.Offset() does not replace the generated OFFSET; both clauses are emitted",
+			ExpectedSQL: `SELECT id FROM todo OFFSET 10 OFFSET 5`,
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.CombinedOffset.SetOffset(5)
+			}).With(
+				sm.Offset(10),
+			),
+		},
+		"WHERE merges while ORDER BY and LIMIT duplicate": {
+			Doc:          "Combined scenario: the WHERE is correctly ANDed, but ORDER BY and LIMIT each duplicate",
+			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2 ORDER BY id LIMIT 10 ORDER BY created_at LIMIT 5`,
+			ExpectedArgs: []any{true, 1},
+			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
+				q.AppendWhere(psql.Quote("done").EQ(psql.Arg(true)))
+				q.CombinedOrder.AppendOrder(psql.Quote("created_at"))
+				q.CombinedLimit.SetLimit(5)
+			}).With(
+				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
+				sm.OrderBy(psql.Quote("id")),
 				sm.Limit(10),
 			),
 		},

--- a/website/docs/code-generation/queries.md
+++ b/website/docs/code-generation/queries.md
@@ -153,6 +153,24 @@ query := sqlite.Select(
 )
 ```
 
+#### Augmenting with `With()`
+
+As a shortcut, the generated query also has a `With()` method that applies extra mods on top of the generated query and returns a runnable query, so you can keep the finishers without re-wrapping it in `Select`:
+
+```go
+// Also filter where name = "Bob", and only return 10 rows
+users, err := AllUsers(1).With(
+    sm.Where(psql.Quote("name").EQ(psql.Arg("Bob"))),
+    sm.Limit(10),
+).All(ctx, db)
+```
+
+:::caution
+
+`With()` (like using the query as a mod) only **appends** clauses. For a `WHERE` clause this is fine: the extra condition is joined to the existing one with `AND`. But if the generated query already has an `ORDER BY`, `LIMIT`, or `OFFSET` clause, adding another one does **not** replace it — both are emitted, producing invalid SQL. Only add these clauses when the base query does not already define them.
+
+:::
+
 ## Annotating queries
 
 Each query has the following attributes that can be modified with annotations:


### PR DESCRIPTION
Adds a new `With()` function to `ModQuery` and `ExecModQuery` to conveniently add additional mods to generated queries.