### PR TITLE
perf(gen): stitch slice relationship loaders in O(N+M) via a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 
+- Generated slice relationship loaders (`<Parent>Slice.Load<Relationship>`) now stitch loaded parents and children in O(N+M) using a map keyed by the join column, instead of the previous O(N×M) nested loop. This greatly speeds up eager-loading and then-loading relationships with many rows on both sides. The map is only used for single-column joins whose key type is comparable with `==`; composite keys and types with a custom `compare_expr` (e.g. `[]byte`) fall back to the original nested loop, so generated behaviour is unchanged. (thanks @sandonemaki)
+
 ### Fixed
 
 - Fixed PostgreSQL `um` / `dm` standalone join mods (`InnerJoin`, `LeftJoin`, etc.) applied before `um.From(...)` / `dm.Using(...)`: the join is now preserved and attached to the next `FROM` / `USING` from_item instead of being dropped. (thanks @atzedus)

--- a/gen/drivers/types.go
+++ b/gen/drivers/types.go
@@ -239,6 +239,34 @@ func (t Types) GetCompareExpr(currentPkg string, i language.Importer, forType st
 	}
 }
 
+// CanCompareWithEquals reports whether the type is compared with == (i.e. usable as a map key).
+func (t Types) CanCompareWithEquals(currentPkg, forType string) bool {
+	_, typDef := t.GetNameAndDef(currentPkg, forType)
+	return typDef.CompareExpr == "" || typDef.CompareExpr == "AAA == BBB"
+}
+
+// UnwrapNullExpr returns an expression for the underlying value of varName, for use as a map key.
+func (t Types) UnwrapNullExpr(currentPkg string, i language.Importer, forType, varName string, nullable bool) string {
+	if !nullable {
+		return varName
+	}
+
+	colTyp, _ := t.GetNameAndDef(currentPkg, forType)
+	nullTyp, _ := t.GetNullTypeWithImports(currentPkg, forType)
+	i.ImportList(nullTyp.UseExprImports)
+
+	useExpr := nullTyp.UseExpr
+	if useExpr == "" {
+		useExpr = "SRC"
+	}
+
+	return strings.NewReplacer(
+		"SRC", varName,
+		"BASETYPE", colTyp,
+		"NULLTYPE", nullTyp.Name,
+	).Replace(useExpr)
+}
+
 func (t Types) GetNullType(currentPkg, forType string) NullType {
 	typ, _ := t.GetNullTypeWithImports(currentPkg, forType)
 	return typ

--- a/gen/templates/loaders/table/110_loaders.go.tpl
+++ b/gen/templates/loaders/table/110_loaders.go.tpl
@@ -251,6 +251,67 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 		o.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
 	}
 
+  {{- /* Map-based stitching only for a single `==`-comparable join column;
+	       composite keys and custom compare_expr types fall back to the nested loop. */ -}}
+	{{- $useMap := eq (len $side.FromColumns) 1 -}}
+	{{- $local := index $side.FromColumns 0 -}}
+	{{- $foreign := index $side.ToColumns 0 -}}
+	{{- $fromCol := $.Tables.GetColumn $side.From $local -}}
+	{{- $toCol := $.Tables.GetColumn $side.To $foreign -}}
+	{{- $fromColAlias := index $fromAlias.Columns $local -}}
+	{{- $toColAlias := index $toAlias.Columns $foreign -}}
+	{{- if and $useMap (not ($.Types.CanCompareWithEquals $.CurrentPackage $fromCol.Type)) -}}{{- $useMap = false -}}{{- end -}}
+	{{if $useMap}}
+	// O(N+M) stitch via a map keyed by the join column (key -> []parent; was O(N*M)).
+	{{$tAlias.DownSingular}}ByKey := make(map[{{$.Types.Get $.CurrentPackage $.Importer $fromCol.Type}}][]*{{$tAlias.UpSingular}}, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		{{if $fromCol.Nullable}}
+		// NULL never matches any row in SQL, so don't add it to the map
+		if !{{$.Types.GetNullTypeValid $.CurrentPackage $fromCol.Type (cat "o." $fromColAlias)}} {
+			continue
+		}
+		{{end}}
+		{{$tAlias.DownSingular}}ByKey[{{$.Types.UnwrapNullExpr $.CurrentPackage $.Importer $fromCol.Type (cat "o." $fromColAlias) $fromCol.Nullable}}] = append({{$tAlias.DownSingular}}ByKey[{{$.Types.UnwrapNullExpr $.CurrentPackage $.Importer $fromCol.Type (cat "o." $fromColAlias) $fromCol.Nullable}}], o)
+	}
+
+	for _, rel := range {{$fAlias.DownPlural}} {
+		{{if $toCol.Nullable}}
+		if !{{$.Types.GetNullTypeValid $.CurrentPackage $toCol.Type (cat "rel." $toColAlias)}} {
+			continue
+		}
+		{{end}}
+		owners, ok := {{$tAlias.DownSingular}}ByKey[{{$.Types.UnwrapNullExpr $.CurrentPackage $.Importer $toCol.Type (cat "rel." $toColAlias) $toCol.Nullable}}]
+		if !ok {
+			continue
+		}
+
+		for _, o := range owners {
+			{{if not $rel.IsToMany}}
+			// to-one: keep only the first matching child (matches the previous break)
+			if o.R.{{$relAlias}} != nil {
+				continue
+			}
+			{{end}}
+			{{if and (not $.NoBackReferencing) $invRel.Name}}
+			{{$invAlias := $fAlias.Relationship $invRel.Name}}
+				{{if $invRel.IsToMany}}
+				rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
+				{{else}}
+				rel.R.{{$invAlias}} =  o
+				rel.R.{{$.RelationLoadedName}}.{{$invAlias}} = true
+				{{end}}
+			{{end}}
+			{{if $rel.IsToMany}}
+			o.R.{{$relAlias}} = append(o.R.{{$relAlias}}, rel)
+			{{else}}
+			o.R.{{$relAlias}} =  rel
+			{{end}}
+		}
+	}
+	{{else}}
 	for _, o := range os {
 		if o == nil {
 			continue
@@ -307,6 +368,7 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 			{{end -}}
 		}
 	}
+  {{end}}
 
 	return nil
 }
@@ -374,6 +436,59 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 		o.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
 	}
 
+  {{- /* Same as the direct-join case, but the child key is the carried slice
+	       {{`{{$fromCol}}Slice[i]`}} instead of a field on rel. */ -}}
+	{{- $useMap := eq (len $firstSide.FromColumns) 1 -}}
+	{{- $local := index $firstSide.FromColumns 0 -}}
+	{{- $fromCol := index $firstFrom.Columns $local -}}
+	{{- $fromColDef := $.Tables.GetColumn $firstSide.From $local -}}
+	{{- if and $useMap (not ($.Types.CanCompareWithEquals $.CurrentPackage $fromColDef.Type)) -}}{{- $useMap = false -}}{{- end -}}
+	{{if $useMap}}
+	// O(N+M) stitch via a map; child key is the carried slice {{$fromCol}}Slice[i] (was O(N*M)).
+	{{$tAlias.DownSingular}}ByKey := make(map[{{$.Types.Get $.CurrentPackage $.Importer $fromColDef.Type}}][]*{{$tAlias.UpSingular}}, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		{{if $fromColDef.Nullable}}
+		// NULL never matches any row in SQL, so don't add it to the map
+		if !{{$.Types.GetNullTypeValid $.CurrentPackage $fromColDef.Type (printf "o.%s" $fromCol)}} {
+			continue
+		}
+		{{end}}
+		{{$tAlias.DownSingular}}ByKey[{{$.Types.UnwrapNullExpr $.CurrentPackage $.Importer $fromColDef.Type (printf "o.%s" $fromCol) $fromColDef.Nullable}}] = append({{$tAlias.DownSingular}}ByKey[{{$.Types.UnwrapNullExpr $.CurrentPackage $.Importer $fromColDef.Type (printf "o.%s" $fromCol) $fromColDef.Nullable}}], o)
+	}
+
+	for i, rel := range {{$fAlias.DownPlural}} {
+		owners, ok := {{$tAlias.DownSingular}}ByKey[{{$fromCol}}Slice[i]]
+		if !ok {
+			continue
+		}
+
+		for _, o := range owners {
+			{{if not $rel.IsToMany}}
+			// to-one: keep only the first matching child (matches the previous break)
+			if o.R.{{$relAlias}} != nil {
+				continue
+			}
+			{{end}}
+			{{if and (not $.NoBackReferencing) $invRel.Name}}
+			{{$invAlias := $fAlias.Relationship $invRel.Name}}
+				{{if $invRel.IsToMany}}
+				rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
+				{{else}}
+				rel.R.{{$invAlias}} =  o
+				rel.R.{{$.RelationLoadedName}}.{{$invAlias}} = true
+				{{end}}
+			{{end}}
+			{{if $rel.IsToMany}}
+			o.R.{{$relAlias}} = append(o.R.{{$relAlias}}, rel)
+			{{else}}
+			o.R.{{$relAlias}} =  rel
+			{{end}}
+		}
+	}
+	{{else}}
 	for _, o := range os {
 		for i, rel := range {{$fAlias.DownPlural}} {
 			{{range $index, $local := $firstSide.FromColumns -}}
@@ -412,6 +527,7 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 			{{end -}}
 		}
 	}
+  {{end}}
 
 	return nil
 }

--- a/gen/templates/loaders/table/110_loaders.go.tpl
+++ b/gen/templates/loaders/table/110_loaders.go.tpl
@@ -432,6 +432,9 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 	}
 
 	for _, o := range os {
+    if o == nil {
+			continue
+		}
 		o.R.{{$relAlias}} = nil
 		o.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
 	}
@@ -490,6 +493,9 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 	}
 	{{else}}
 	for _, o := range os {
+    if o == nil {
+			continue
+		}
 		for i, rel := range {{$fAlias.DownPlural}} {
 			{{range $index, $local := $firstSide.FromColumns -}}
 			{{- $fromCol := index $firstFrom.Columns $local -}}


### PR DESCRIPTION
## Summary

Generated slice relationship loaders (`<Parent>Slice.Load<Relationship>`) stitch the
loaded parents and children with an **O(N×M) nested loop**. For relationships with many
rows on both sides this dominates load time. This PR stitches them in **O(N+M)** using a
map keyed by the join column, while keeping the existing behaviour.

## Motivation

In a real eager/then-load of a relationship with many parents and children, the
non-query Go time was:

| | non-query Go time |
|---|---|
| before | ~178 s |
| after | ~0.8 s |

The query itself was already fast; the cost was the `O(N×M)` stitching loop.

## What changed

`gen/templates/loaders/table/110_loaders.go.tpl` — both slice loaders
(direct join, and through a join table) now build a map `joinKey -> []*Parent`
and stitch by looking each child up once:

```go
// Example: UserSlice.LoadPosts (a User has many Posts: post.user_id = user.id)

// before: O(N×M)
for _, o := range os {
    for _, rel := range posts {
        if !(o.ID == rel.UserID) { continue }
        rel.R.User = o
        o.R.Posts = append(o.R.Posts, rel)
    }
}

// after: O(N+M)
userByKey := make(map[int64][]*User, len(os))
for _, o := range os {
    if o == nil { continue }
    userByKey[o.ID] = append(userByKey[o.ID], o)
}
for _, rel := range posts {
    owners, ok := userByKey[rel.UserID]
    if !ok { continue }
    for _, o := range owners {
        rel.R.User = o
        o.R.Posts = append(o.R.Posts, rel)
    }
}
```

Two small helpers were added to `gen/drivers/types.go`:

- `CanCompareWithEquals` — whether a type is compared with `==` (no custom `compare_expr`),
  i.e. usable as a Go map key.
- `UnwrapNullExpr` — extracts the underlying value of a nullable column for use as a map key.

## Safety / behaviour preservation

The map path is taken **only when it is provably equivalent**, otherwise it falls back to
the original nested loop, so generated behaviour is unchanged:

- **Single-column, `==`-comparable joins only.** Composite keys and types with a custom
  `compare_expr` (e.g. `[]byte`, which cannot be a Go map key) fall back to the nested loop.
- **NULL handling.** Nullable join columns are keyed by their underlying value and NULL rows
  are skipped (NULL never matches in SQL), matching the previous `continue` guards.
- **to-one.** The map version keeps only the first matching child
  (`if o.R.<rel> != nil { continue }`), matching the previous `break`.
- The same parent key may map to several parents, so the value is `[]*Parent`.

## Testing

- `golangci-lint run` → `0 issues.`
- `gofumpt -l` → no diff
- `go test ./gen/bobgen-sqlite/driver/` → generation + build + generated tests pass on the
  pure-Go `modernc` and `ncruces` drivers (covering direct joins, many-to-many through a
  join table, nullable FKs, and to-one / to-many).

## Checklist

- [x] `golangci-lint run` reports 0 issues
- [x] `gofumpt -l` reports no changes
- [x] generated code compiles and the generated tests pass (sqlite, modernc/ncruces)
