### PR TITLE
fix(gen): emit per-column expressions in setter Apply inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
+
 ### Changed
 
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)

--- a/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
+++ b/gen/bobgen-mysql/templates/models/table/100_blocks.go.tpl
@@ -32,7 +32,7 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
         {{$colAlias := $tAlias.Column $column.Name -}}
         {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
+        if {{$.Types.IsOptionalInvalid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
           return {{$.Dialect}}.Raw("DEFAULT").WriteSQL(ctx, w, d, start)
         }
         return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)

--- a/gen/bobgen-sqlite/templates/models/table/100_blocks.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/table/100_blocks.go.tpl
@@ -27,7 +27,7 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
       vals = append(vals, bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
         {{$colAlias := $tAlias.Column $column.Name -}}
         {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
+        if {{$.Types.IsOptionalInvalid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
           return {{$.Dialect}}.Arg(nil).WriteSQL(ctx, w, d, start)
         }
         return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)

--- a/gen/bobgen-sqlite/templates/models/table/100_blocks.go.tpl
+++ b/gen/bobgen-sqlite/templates/models/table/100_blocks.go.tpl
@@ -19,24 +19,23 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     {{end}}
   }
 
-	q.AppendValues(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
-    vals := make([]bob.Expression, 0, {{len $table.NonGeneratedColumns}})
-    {{range $index, $column := $table.NonGeneratedColumns -}}
-      {{$colAlias := $tAlias.Column $column.Name -}}
-      {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-      if {{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
-        vals = append(vals, {{$.Dialect}}.Arg({{$colGetter}}))
-      }
-
+  vals := make([]bob.Expression, 0, len(q.TableRef.Columns))
+  for _, col := range q.TableRef.Columns {
+    switch col {
+    {{range $column := $table.NonGeneratedColumns -}}
+    case {{printf "%q" $column.Name}}:
+      vals = append(vals, bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+        {{$colAlias := $tAlias.Column $column.Name -}}
+        {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
+        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
+          return {{$.Dialect}}.Arg(nil).WriteSQL(ctx, w, d, start)
+        }
+        return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
+      }))
     {{end -}}
-
-    {{if $table.Constraints.Primary -}}
-    if len(vals) == 0 {
-      vals = append(vals{{range $table.Constraints.Primary.Columns}}, {{$.Dialect}}.Arg(nil){{end}})
     }
-    {{end}}
+  }
 
-    return bob.ExpressSlice(ctx, w, d, start, vals, "", ", ", "")
-  }))
+  q.AppendValues(vals...)
 }
 {{- end}}

--- a/gen/drivers/types.go
+++ b/gen/drivers/types.go
@@ -57,6 +57,9 @@ type NullType struct {
 	// ValidExpr is used to check if a value of this type is valid
 	// e.g. `SRC.Valid` for sql.Null[T] or `SRC.IsSet()` for null.Val[T]
 	ValidExpr string `yaml:"valid_expr"`
+	// InvalidExpr is used to check if an optional value is unset
+	// e.g. `SRC.IsUnset()` for omitnull.Val[T]
+	InvalidExpr string `yaml:"invalid_expr"`
 	// UseExpr is used to convert a null value of this type
 	// to a non-null value, if not provided it is assigned directly
 	UseExpr string `yaml:"use_expr"`
@@ -290,6 +293,21 @@ func (t Types) getOptional(curr, namedType string, isNull, fromOrToNull bool) (N
 }
 
 func (t Types) IsOptionalValid(currentPkg, forType string, null bool, varName string) string {
+	optTyp, _ := t.getOptional(currentPkg, forType, null, null)
+	return t.replaceOptionalExprs(currentPkg, forType, null, varName, optTyp.ValidExpr)
+}
+
+func (t Types) IsOptionalInvalid(currentPkg, forType string, null bool, varName string) string {
+	optTyp, _ := t.getOptional(currentPkg, forType, null, null)
+	expr := optTyp.InvalidExpr
+	if expr == "" {
+		return "!(" + t.IsOptionalValid(currentPkg, forType, null, varName) + ")"
+	}
+
+	return t.replaceOptionalExprs(currentPkg, forType, null, varName, expr)
+}
+
+func (t Types) replaceOptionalExprs(currentPkg, forType string, null bool, varName, expr string) string {
 	colTyp, _ := t.GetNameAndDef(currentPkg, forType)
 	optTyp, _ := t.getOptional(currentPkg, forType, null, null)
 	nullTyp := t.GetNullType(currentPkg, forType)
@@ -298,7 +316,7 @@ func (t Types) IsOptionalValid(currentPkg, forType string, null bool, varName st
 		"NULLTYPE", nullTyp.Name,
 		"BASETYPE", colTyp,
 		"OPTIONALTYPE", optTyp.Name,
-	).Replace(optTyp.ValidExpr)
+	).Replace(expr)
 }
 
 func (t Types) FromOptional(currentPkg string, i language.Importer, forType, varName string, isNull, fromOrToNull bool) string {
@@ -351,6 +369,7 @@ func (a AarondlNull) OptionalType(name string, def Type, isNull, fromOrToNull bo
 		ot := NullType{
 			Name:              fmt.Sprintf("omit.Val[%s]", name),
 			ValidExpr:         "SRC.IsValue()",
+			InvalidExpr:       "SRC.IsUnset()",
 			UseExpr:           "SRC.MustGet()",
 			UseExprImports:    []string{},
 			CreateExpr:        "omit.From(SRC)",
@@ -414,6 +433,7 @@ func (a AarondlNull) OptionalType(name string, def Type, isNull, fromOrToNull bo
 		ot := NullType{
 			Name:              fmt.Sprintf("omit.Val[%s]", name),
 			ValidExpr:         "SRC.IsValue()",
+			InvalidExpr:       "SRC.IsUnset()",
 			UseExpr:           "SRC.MustGet()",
 			UseExprImports:    []string{},
 			CreateExpr:        "omit.From(SRC)",
@@ -432,7 +452,8 @@ func (a AarondlNull) OptionalType(name string, def Type, isNull, fromOrToNull bo
 
 	nt := NullType{
 		Name:              fmt.Sprintf("omitnull.Val[%s]", name),
-		ValidExpr:         "!SRC.IsUnset()",
+		ValidExpr:         "SRC.IsValue() || SRC.IsNull()",
+		InvalidExpr:       "SRC.IsUnset()",
 		UseExpr:           "SRC.MustGet()",
 		UseExprImports:    []string{},
 		CreateExpr:        "omitnull.From(SRC)",
@@ -499,6 +520,7 @@ func optionalTypePointers(tm TypeModifier, name string, def Type, isNull, fromOr
 	ot := NullType{
 		Name:              fmt.Sprintf("*%s", name),
 		ValidExpr:         "SRC != nil",
+		InvalidExpr:       "SRC == nil",
 		UseExpr:           "func () BASETYPE { if SRC == nil { return *new(BASETYPE) }; return *SRC }()",
 		UseExprImports:    nil,
 		CreateExpr:        "func () *BASETYPE { return &SRC }()",
@@ -514,6 +536,7 @@ func optionalTypePointers(tm TypeModifier, name string, def Type, isNull, fromOr
 		ot = NullType{
 			Name:              fmt.Sprintf("*%s", nullType.Name),
 			ValidExpr:         "SRC != nil",
+			InvalidExpr:       "SRC == nil",
 			UseExpr:           "func () NULLTYPE { if SRC == nil { return *new(NULLTYPE) }; v := SRC; return *v }()",
 			UseExprImports:    nil,
 			CreateExpr:        "func () *NULLTYPE { v := SRC; return &v }()",

--- a/gen/templates/factory/table/003_create.go.tpl
+++ b/gen/templates/factory/table/003_create.go.tpl
@@ -14,7 +14,7 @@ func ensureCreatable{{$tAlias.UpSingular}}(m *models.{{$tAlias.UpSingular}}Sette
     {{- $colGetter := $.Types.ToOptional $.CurrentPackage $.Importer $column.Type "val" $column.Nullable $column.Nullable -}}
     {{- $typDef :=  $.Types.Index $column.Type -}}
     {{- $colTyp := or $typDef.AliasOf $column.Type -}}
-    if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "m." $colAlias)}}) {
+    if {{$.Types.IsOptionalInvalid $.CurrentPackage $column.Type $column.Nullable (cat "m." $colAlias)}} {
       val := random_{{normalizeType $column.Type}}(nil, {{$column.LimitsString}})
       m.{{$colAlias}} = {{$colGetter}}
     }

--- a/gen/templates/models/table/002_setter.go.tpl
+++ b/gen/templates/models/table/002_setter.go.tpl
@@ -55,21 +55,17 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     })
   {{end}}
 
-	q.AppendValues(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
-    vals := make([]bob.Expression, {{len $table.NonGeneratedColumns}})
-    {{range $index, $column := $table.NonGeneratedColumns -}}
-      {{$colAlias := $tAlias.Column $column.Name -}}
-      {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-      if {{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
-        vals[{{$index}}] = {{$.Dialect}}.Arg({{$colGetter}})
-      } else {
-        vals[{{$index}}] = {{$.Dialect}}.Raw("DEFAULT")
-      }
-
-    {{end -}}
-
-    return bob.ExpressSlice(ctx, w, d, start, vals, "", ", ", "")
-  }))
+	q.AppendValues(
+  {{range $index, $column := $table.NonGeneratedColumns -}}
+    bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
+        {{$colAlias := $tAlias.Column $column.Name -}}
+        {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
+        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
+          return {{$.Dialect}}.Raw("DEFAULT").WriteSQL(ctx, w, d, start)
+        }
+        return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)
+    }),
+  {{- end}})
 }
 {{- end}}
 

--- a/gen/templates/models/table/002_setter.go.tpl
+++ b/gen/templates/models/table/002_setter.go.tpl
@@ -60,7 +60,7 @@ func (s *{{$tAlias.UpSingular}}Setter) Apply(q *dialect.InsertQuery) {
     bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error){
         {{$colAlias := $tAlias.Column $column.Name -}}
         {{$colGetter := $.Types.FromOptional $.CurrentPackage $.Importer $column.Type (cat "s." $colAlias) $column.Nullable $column.Nullable -}}
-        if !({{$.Types.IsOptionalValid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}}) {
+        if {{$.Types.IsOptionalInvalid $.CurrentPackage $column.Type $column.Nullable (cat "s." $colAlias)}} {
           return {{$.Dialect}}.Raw("DEFAULT").WriteSQL(ctx, w, d, start)
         }
         return {{$.Dialect}}.Arg({{$colGetter}}).WriteSQL(ctx, w, d, start)


### PR DESCRIPTION
- Change the base setter `Apply` template to append one `ExpressionFunc` per insert column instead of a single `ExpressionFunc` for the entire row
- Update the SQLite override to build per-column expressions dynamically from `q.TableRef.Columns`, preserving its partial-column insert semantics
- Align PostgreSQL/SQLite behavior with the existing MySQL template, which already used per-column expressions

**Problem**

Generated `Setter.Apply` methods wrapped all insert values in one `ExpressionFunc`. As a result, `q.Values.Vals[row]` contained a single expression for the whole row rather than one expression per column.

That made it impossible to modify individual column values from `BeforeInsertHooks`, contextual mods, or other query hooks that operate on `q.Values.Vals[row][columnIndex]`.

Generated SQL output is unchanged; only the internal expression structure differs.
