### PR TITLE
feat(codegen): add column_order config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `column_order` config option (shared across all drivers). Set to `"name"` to sort generated model columns alphabetically, producing deterministic output regardless of the order migrations were applied to the database. Defaults to `"ordinal"` (previous behaviour: database physical column order).
+
 ### Fixed
 
 - Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)

--- a/gen/bobgen-helpers/helpers.go
+++ b/gen/bobgen-helpers/helpers.go
@@ -41,6 +41,9 @@ type Config struct {
 	Queries []string `yaml:"queries"`
 	// List of tables that will be should be ignored. Others are included
 	Except map[string][]string
+	// Order of columns in generated models.
+	// "name" sorts alphabetically; "ordinal" (default) preserves database column order.
+	ColumnOrder string `yaml:"column_order"`
 }
 
 func GetConfigFromFile[ConstraintExtra, DriverConfig any](configPath, driverConfigKey string) (gen.Config[ConstraintExtra], DriverConfig, plugins.Config, error) {

--- a/gen/bobgen-mysql/driver/mysql.go
+++ b/gen/bobgen-mysql/driver/mysql.go
@@ -84,7 +84,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 
 	dbinfo = &DBInfo{Driver: "github.com/go-sql-driver/mysql"}
 
-	dbinfo.Tables, err = drivers.BuildDBInfo[any](ctx, d, d.config.Concurrency, d.config.Config.Only, d.config.Config.Except)
+	dbinfo.Tables, err = drivers.BuildDBInfo[any](ctx, d, d.config.Concurrency, d.config.Config.Only, d.config.Config.Except, d.config.Config.ColumnOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/gen/bobgen-psql/driver/psql.go
+++ b/gen/bobgen-psql/driver/psql.go
@@ -145,7 +145,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 		return nil, fmt.Errorf("unable to load enums: %w", err)
 	}
 
-	dbinfo.Tables, err = drivers.BuildDBInfo[any](ctx, d, d.config.Concurrency, d.config.Only, d.config.Except)
+	dbinfo.Tables, err = drivers.BuildDBInfo[any](ctx, d, d.config.Concurrency, d.config.Only, d.config.Except, d.config.ColumnOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/gen/bobgen-sqlite/driver/sqlite.go
+++ b/gen/bobgen-sqlite/driver/sqlite.go
@@ -299,6 +299,12 @@ func (d driver) getTable(ctx context.Context, schema, name string, colFilter dri
 		return table, err
 	}
 
+	if d.config.ColumnOrder == "name" {
+		sort.Slice(table.Columns, func(i, j int) bool {
+			return table.Columns[i].Name < table.Columns[j].Name
+		})
+	}
+
 	table.Constraints.Primary = d.primaryKey(schema, name, tinfo)
 	table.Constraints.Foreign, err = d.foreignKeys(ctx, schema, name)
 	if err != nil {

--- a/gen/drivers/interface.go
+++ b/gen/drivers/interface.go
@@ -73,7 +73,7 @@ type Constructor[ConstraintExtra, IndexExtra any] interface {
 // minus the tables specified in the excludes.
 func BuildDBInfo[DBExtra, ConstraintExtra, IndexExtra any](
 	ctx context.Context, c Constructor[ConstraintExtra, IndexExtra],
-	concurrency int, only, except map[string][]string,
+	concurrency int, only, except map[string][]string, columnOrder string,
 ) ([]Table[ConstraintExtra, IndexExtra], error) {
 	var err error
 	var ret []Table[ConstraintExtra, IndexExtra]
@@ -91,7 +91,7 @@ func BuildDBInfo[DBExtra, ConstraintExtra, IndexExtra any](
 
 	colFilter := ParseColumnFilter(tablesInfo.Keys(), only, except)
 
-	ret, err = tables(ctx, c, concurrency, tablesInfo, colFilter)
+	ret, err = tables(ctx, c, concurrency, tablesInfo, colFilter, columnOrder)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load tables: %w", err)
 	}
@@ -126,7 +126,7 @@ func BuildDBInfo[DBExtra, ConstraintExtra, IndexExtra any](
 	return ret, nil
 }
 
-func tables[C, I any](ctx context.Context, c Constructor[C, I], concurrency int, infos TablesInfo, filter ColumnFilter) ([]Table[C, I], error) {
+func tables[C, I any](ctx context.Context, c Constructor[C, I], concurrency int, infos TablesInfo, filter ColumnFilter, columnOrder string) ([]Table[C, I], error) {
 	sort.Slice(infos, func(i, j int) bool {
 		return infos[i].Key < infos[j].Key
 	})
@@ -142,7 +142,7 @@ func tables[C, I any](ctx context.Context, c Constructor[C, I], concurrency int,
 		go func(i int, info TableInfo) {
 			defer wg.Done()
 			defer limiter.put()
-			t, err := table(ctx, c, info, filter)
+			t, err := table(ctx, c, info, filter, columnOrder)
 			if err != nil {
 				errs <- err
 				return
@@ -162,7 +162,7 @@ func tables[C, I any](ctx context.Context, c Constructor[C, I], concurrency int,
 }
 
 // table returns columns info for a given table
-func table[C, I any](ctx context.Context, c Constructor[C, I], info TableInfo, filter ColumnFilter) (Table[C, I], error) {
+func table[C, I any](ctx context.Context, c Constructor[C, I], info TableInfo, filter ColumnFilter, columnOrder string) (Table[C, I], error) {
 	var err error
 	t := Table[C, I]{
 		Key: info.Key,
@@ -170,6 +170,12 @@ func table[C, I any](ctx context.Context, c Constructor[C, I], info TableInfo, f
 
 	if t.Schema, t.Name, t.Columns, err = c.TableDetails(ctx, info, filter); err != nil {
 		return Table[C, I]{}, fmt.Errorf("unable to fetch table column info (%s): %w", info.Key, err)
+	}
+
+	if columnOrder == "name" {
+		sort.Slice(t.Columns, func(i, j int) bool {
+			return t.Columns[i].Name < t.Columns[j].Name
+		})
 	}
 
 	return t, nil

--- a/gen/drivers/table_test.go
+++ b/gen/drivers/table_test.go
@@ -1,8 +1,96 @@
 package drivers
 
 import (
+	"context"
 	"testing"
 )
+
+// mockConstructor satisfies Constructor[any, any] for testing BuildDBInfo.
+type mockConstructor struct {
+	columns []Column
+}
+
+func (m mockConstructor) TablesInfo(_ context.Context, _ Filter) (TablesInfo, error) {
+	return TablesInfo{{Key: "t", Schema: "public", Name: "t"}}, nil
+}
+
+func (m mockConstructor) TableDetails(_ context.Context, info TableInfo, _ ColumnFilter) (string, string, []Column, error) {
+	cp := make([]Column, len(m.columns))
+	copy(cp, m.columns)
+	return info.Schema, info.Name, cp, nil
+}
+
+func (m mockConstructor) Comments(_ context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (m mockConstructor) Constraints(_ context.Context, _ ColumnFilter) (DBConstraints[any], error) {
+	return DBConstraints[any]{
+		PKs:     map[string]*Constraint[any]{},
+		FKs:     map[string][]ForeignKey[any]{},
+		Uniques: map[string][]Constraint[any]{},
+		Checks:  map[string][]Check[any]{},
+	}, nil
+}
+
+func (m mockConstructor) Indexes(_ context.Context) (DBIndexes[any], error) {
+	return DBIndexes[any]{}, nil
+}
+
+func TestBuildDBInfoColumnOrder(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "zebra"},
+		{Name: "apple"},
+		{Name: "mango"},
+	}
+
+	t.Run("ordinal preserves input order", func(t *testing.T) {
+		t.Parallel()
+		tables, err := BuildDBInfo[any](context.Background(), mockConstructor{cols}, 1, nil, nil, "ordinal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := ColumnNames(tables[0].Columns)
+		want := []string{"zebra", "apple", "mango"}
+		for i, name := range want {
+			if got[i] != name {
+				t.Errorf("position %d: got %q, want %q", i, got[i], name)
+			}
+		}
+	})
+
+	t.Run("default (empty) preserves input order", func(t *testing.T) {
+		t.Parallel()
+		tables, err := BuildDBInfo[any](context.Background(), mockConstructor{cols}, 1, nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := ColumnNames(tables[0].Columns)
+		want := []string{"zebra", "apple", "mango"}
+		for i, name := range want {
+			if got[i] != name {
+				t.Errorf("position %d: got %q, want %q", i, got[i], name)
+			}
+		}
+	})
+
+	t.Run("name sorts alphabetically", func(t *testing.T) {
+		t.Parallel()
+		tables, err := BuildDBInfo[any](context.Background(), mockConstructor{cols}, 1, nil, nil, "name")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := ColumnNames(tables[0].Columns)
+		want := []string{"apple", "mango", "zebra"}
+		for i, name := range want {
+			if got[i] != name {
+				t.Errorf("position %d: got %q, want %q", i, got[i], name)
+			}
+		}
+	})
+}
 
 func TestGetTable(t *testing.T) {
 	t.Parallel()

--- a/website/docs/code-generation/mysql.md
+++ b/website/docs/code-generation/mysql.md
@@ -45,7 +45,8 @@ The values that exist for the drivers:
 | only        | Only generate these                  |         |
 | except      | Skip generation for these            |         |
 | queries     | Folders containing sql query files   |         |
-| concurrency | How many tables to fetch in parallel | 10      |
+| concurrency  | How many tables to fetch in parallel | 10      |
+| column_order | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
 
 ## Only/Except:
 

--- a/website/docs/code-generation/psql.md
+++ b/website/docs/code-generation/psql.md
@@ -56,6 +56,7 @@ The values that exist for the drivers:
 | only          | Only generate these                               |                          |
 | except        | Skip generation for these                         |                          |
 | concurrency   | How many tables to fetch in parallel              | 10                       |
+| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
 
 ## Driver-specific code
 

--- a/website/docs/code-generation/sqlite.md
+++ b/website/docs/code-generation/sqlite.md
@@ -48,6 +48,7 @@ The values that exist for the drivers:
 | queries       | List of folders containing query files            | []string{}           |
 | only          | Only generate these                               |                      |
 | except        | Skip generation for these                         |                      |
+| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
 
 ## Driver-specific code
 


### PR DESCRIPTION
## Problem

When multiple developers apply migrations independently, the `ordinal_position` of columns diverges between their local databases. Since bob generates models ordered by `ordinal_position`, two developers generating from the same logical schema produce different files — causing spurious diffs in source control.

## Solution

Add a `column_order` config option (shared across all three drivers via `helpers.Config`) with two values:

- `"ordinal"` (default) — preserves previous behaviour, no breaking change
- `"name"` — sorts columns alphabetically after retrieval, producing deterministic output regardless of migration order

The sort is applied post-retrieval in `drivers.BuildDBInfo` (psql, mysql) and `driver.getTable` (sqlite), keeping the change minimal and consistent.

## Usage

```yaml
# bobgen.yaml
column_order: name
```