### PR TITLE
fix(psql): fix generated query mods for combined queries (UNION/INTERSECT/EXCEPT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
+- Fixed generated query mods for combined `UNION/INTERSECT/EXCEPT` queries dropping or misrouting the first operand's `ORDER BY/LIMIT/OFFSET` into the combined-result clauses. (thanks @daddz)
 
 ### Changed
 
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
-
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 
 ## [v0.45.0] - 2026-05-28

--- a/gen/bobgen-psql/driver/parser/mods_select.go
+++ b/gen/bobgen-psql/driver/parser/mods_select.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	pg "github.com/pganalyze/pg_query_go/v6"
+
 	"github.com/stephenafamo/bob/clause"
 	"github.com/stephenafamo/bob/internal"
 )
@@ -175,18 +176,21 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 		)
 	}
 
-	if limitInfo, ok := info.children["LimitCount"]; ok {
+	// ORDER BY / LIMIT / OFFSET that belong to the main (first) select branch.
+	// For a plain query this is the whole query; for a combined query (UNION /
+	// INTERSECT / EXCEPT) this is the first operand, which keeps its own clauses.
+	if limitInfo, ok := mainInfo.children["LimitCount"]; ok {
 		w.editRules = append(w.editRules,
 			internal.RecordPoints(
 				int(limitInfo.start),
 				int(limitInfo.end)-1,
 				func(start, end int) error {
-					switch stmt.SelectStmt.LimitOption {
+					switch main.LimitOption {
 					case pg.LimitOption_LIMIT_OPTION_COUNT:
-						fmt.Fprintf(w.mods, "q.CombinedLimit.SetLimit(EXPR.subExpr(%d, %d))\n", start, end)
+						fmt.Fprintf(w.mods, "q.SetLimit(EXPR.subExpr(%d, %d))\n", start, end)
 					case pg.LimitOption_LIMIT_OPTION_WITH_TIES:
 						w.imports = append(w.imports, []string{"github.com/stephenafamo/bob/clause"})
-						fmt.Fprintf(w.mods, `q.CombinedFetch.SetFetch(clause.Fetch{
+						fmt.Fprintf(w.mods, `q.Fetch.SetFetch(clause.Fetch{
 								Count: EXPR.subExpr(%d, %d),
 								WithTies: true,
 							})
@@ -204,24 +208,79 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 				int(offsetInfo.start),
 				int(offsetInfo.end)-1,
 				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.CombinedOffset.SetOffset(EXPR.subExpr(%d, %d))\n", start, end)
+					fmt.Fprintf(w.mods, "q.SetOffset(EXPR.subExpr(%d, %d))\n", start, end)
 					return nil
 				},
 			)...,
 		)
 	}
 
-	if orderInfo, ok := info.children["SortClause"]; ok {
+	if orderInfo, ok := mainInfo.children["SortClause"]; ok {
 		w.editRules = append(w.editRules,
 			internal.RecordPoints(
 				int(orderInfo.start),
 				int(orderInfo.end)-1,
 				func(start, end int) error {
-					fmt.Fprintf(w.mods, "q.CombinedOrder.AppendOrder(EXPR.subExpr(%d, %d))\n", start, end)
+					fmt.Fprintf(w.mods, "q.AppendOrder(EXPR.subExpr(%d, %d))\n", start, end)
 					return nil
 				},
 			)...,
 		)
+	}
+
+	// For a combined query the top-level ORDER BY / LIMIT / OFFSET apply to the
+	// outer-most query (the combined result), so they are recorded separately.
+	// When there are no combines, mainInfo == info and these clauses are already
+	// handled above as part of the main branch.
+	if len(combines) > 0 {
+		if limitInfo, ok := info.children["LimitCount"]; ok {
+			w.editRules = append(w.editRules,
+				internal.RecordPoints(
+					int(limitInfo.start),
+					int(limitInfo.end)-1,
+					func(start, end int) error {
+						switch stmt.SelectStmt.LimitOption {
+						case pg.LimitOption_LIMIT_OPTION_COUNT:
+							fmt.Fprintf(w.mods, "q.CombinedLimit.SetLimit(EXPR.subExpr(%d, %d))\n", start, end)
+						case pg.LimitOption_LIMIT_OPTION_WITH_TIES:
+							w.imports = append(w.imports, []string{"github.com/stephenafamo/bob/clause"})
+							fmt.Fprintf(w.mods, `q.CombinedFetch.SetFetch(clause.Fetch{
+									Count: EXPR.subExpr(%d, %d),
+									WithTies: true,
+								})
+							`, start, end)
+						}
+						return nil
+					},
+				)...,
+			)
+		}
+
+		if offsetInfo, ok := info.children["LimitOffset"]; ok {
+			w.editRules = append(w.editRules,
+				internal.RecordPoints(
+					int(offsetInfo.start),
+					int(offsetInfo.end)-1,
+					func(start, end int) error {
+						fmt.Fprintf(w.mods, "q.CombinedOffset.SetOffset(EXPR.subExpr(%d, %d))\n", start, end)
+						return nil
+					},
+				)...,
+			)
+		}
+
+		if orderInfo, ok := info.children["SortClause"]; ok {
+			w.editRules = append(w.editRules,
+				internal.RecordPoints(
+					int(orderInfo.start),
+					int(orderInfo.end)-1,
+					func(start, end int) error {
+						fmt.Fprintf(w.mods, "q.CombinedOrder.AppendOrder(EXPR.subExpr(%d, %d))\n", start, end)
+						return nil
+					},
+				)...,
+			)
+		}
 	}
 
 	for i, lockClause := range stmt.SelectStmt.LockingClause {

--- a/gen/bobgen-psql/driver/psql.golden.json
+++ b/gen/bobgen-psql/driver/psql.golden.json
@@ -8688,6 +8688,162 @@
 			"path": "./queries",
 			"files": [
 				{
+					"path": "queries/combined.sql",
+					"queries": [
+						{
+							"type": 1,
+							"name": "PlainUsersOrderLimitOffset",
+							"raw": "SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC LIMIT 2 OFFSET 1",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "id",
+									"db_name": "id",
+									"nullable": false,
+									"type": "int32",
+									"type_limits": null
+								}
+							],
+							"args": [
+								{
+									"col": {
+										"name": "id",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": null
+									},
+									"children": null,
+									"positions": [
+										[
+											34,
+											36
+										]
+									],
+									"can_be_multiple": true
+								}
+							],
+							"mods": "q.AppendSelect(EXPR.subExpr(7, 9))\nq.SetTable(EXPR.subExpr(15, 20))\nq.AppendWhere(EXPR.subExpr(27, 37))\nq.AppendOrder(EXPR.subExpr(47, 54))\nq.SetLimit(EXPR.subExpr(61, 62))\nq.SetOffset(EXPR.subExpr(70, 71))\n"
+						},
+						{
+							"type": 1,
+							"name": "CombinedUsersOrderLimitOffset",
+							"raw": "(SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC LIMIT 2 OFFSET 1)\nUNION\n(SELECT id FROM users WHERE id IN ($2) ORDER BY id ASC LIMIT 3 OFFSET 4)\nORDER BY id DESC LIMIT 5 OFFSET 6",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "id",
+									"db_name": "id",
+									"nullable": false,
+									"type": "int32",
+									"type_limits": null
+								}
+							],
+							"args": [
+								{
+									"col": {
+										"name": "id",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": null
+									},
+									"children": null,
+									"positions": [
+										[
+											35,
+											37
+										]
+									],
+									"can_be_multiple": true
+								},
+								{
+									"col": {
+										"name": "id_2",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": null
+									},
+									"children": null,
+									"positions": [
+										[
+											115,
+											117
+										]
+									],
+									"can_be_multiple": true
+								}
+							],
+							"mods": "q.AppendSelect(EXPR.subExpr(8, 10))\nq.SetTable(EXPR.subExpr(16, 21))\nq.AppendWhere(EXPR.subExpr(28, 38))\nq.AppendOrder(EXPR.subExpr(48, 55))\nq.SetLimit(EXPR.subExpr(62, 63))\nq.SetOffset(EXPR.subExpr(71, 72))\n\n                        q.AppendCombine(clause.Combine{\n                            Strategy: \"UNION\",\n                            All: false,\n                            Query: bob.BaseQuery[bob.Expression]{\n                                Expression: EXPR.subExpr(81, 151),\n                                QueryType: bob.QueryTypeSelect,\n                                Dialect: dialect.Dialect,\n                            },\n                        })\n                    q.CombinedOrder.AppendOrder(EXPR.subExpr(162, 169))\nq.CombinedLimit.SetLimit(EXPR.subExpr(176, 177))\nq.CombinedOffset.SetOffset(EXPR.subExpr(185, 186))\n"
+						},
+						{
+							"type": 1,
+							"name": "CombinedUsersFetchWithTies",
+							"raw": "(SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC FETCH FIRST 2 ROWS WITH TIES)\nUNION ALL\n(SELECT id FROM users WHERE id IN ($2))\nORDER BY id DESC FETCH FIRST 5 ROWS WITH TIES",
+							"config": {
+								"result_type_one": "",
+								"result_type_all": "",
+								"result_type_transformer": ""
+							},
+							"columns": [
+								{
+									"name": "id",
+									"db_name": "id",
+									"nullable": false,
+									"type": "int32",
+									"type_limits": null
+								}
+							],
+							"args": [
+								{
+									"col": {
+										"name": "id",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": null
+									},
+									"children": null,
+									"positions": [
+										[
+											35,
+											37
+										]
+									],
+									"can_be_multiple": true
+								},
+								{
+									"col": {
+										"name": "id_2",
+										"db_name": "",
+										"nullable": false,
+										"type": "int32",
+										"type_limits": null
+									},
+									"children": null,
+									"positions": [
+										[
+											131,
+											133
+										]
+									],
+									"can_be_multiple": true
+								}
+							],
+							"mods": "q.AppendSelect(EXPR.subExpr(8, 10))\nq.SetTable(EXPR.subExpr(16, 21))\nq.AppendWhere(EXPR.subExpr(28, 38))\nq.AppendOrder(EXPR.subExpr(48, 55))\nq.Fetch.SetFetch(clause.Fetch{\n\t\t\t\t\t\t\t\tCount: EXPR.subExpr(68, 69),\n\t\t\t\t\t\t\t\tWithTies: true,\n\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\n                        q.AppendCombine(clause.Combine{\n                            Strategy: \"UNION\",\n                            All: true,\n                            Query: bob.BaseQuery[bob.Expression]{\n                                Expression: EXPR.subExpr(97, 134),\n                                QueryType: bob.QueryTypeSelect,\n                                Dialect: dialect.Dialect,\n                            },\n                        })\n                    q.CombinedOrder.AppendOrder(EXPR.subExpr(145, 152))\nq.CombinedFetch.SetFetch(clause.Fetch{\n\t\t\t\t\t\t\t\t\tCount: EXPR.subExpr(165, 166),\n\t\t\t\t\t\t\t\t\tWithTies: true,\n\t\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t"
+						}
+					]
+				},
+				{
 					"path": "queries/users.sql",
 					"queries": [
 						{

--- a/gen/bobgen-psql/driver/queries/combined.sql
+++ b/gen/bobgen-psql/driver/queries/combined.sql
@@ -1,0 +1,19 @@
+-- PlainUsersOrderLimitOffset
+SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC LIMIT 2 OFFSET 1
+;
+
+
+-- CombinedUsersOrderLimitOffset
+(SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC LIMIT 2 OFFSET 1)
+UNION
+(SELECT id FROM users WHERE id IN ($2) ORDER BY id ASC LIMIT 3 OFFSET 4)
+ORDER BY id DESC LIMIT 5 OFFSET 6
+;
+
+
+-- CombinedUsersFetchWithTies
+(SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC FETCH FIRST 2 ROWS WITH TIES)
+UNION ALL
+(SELECT id FROM users WHERE id IN ($2))
+ORDER BY id DESC FETCH FIRST 5 ROWS WITH TIES
+;


### PR DESCRIPTION
The psql query parser was generating incorrect mods for combined queries. It always routed the top-level `ORDER BY/LIMIT/OFFSET/FETCH` into the `Combined...` clauses, and never handled the first queries' own clauses. 

A query like:
```sql
-- MyQuery
(SELECT ... ORDER BY id DESC LIMIT 2 OFFSET 1)
UNION
(SELECT ...)
ORDER BY id DESC LIMIT 5 OFFSET 6
```
```go
query := psql.Select(queries.MyQuery(), sm.LimitCombined(10), sm.OffsetCombined(10), sm.OrderCombined("id"))
```
would lose the first queries' `ORDER BY/LIMIT`, misroute its `OFFSET` onto the combined result, and drop the outer OFFSET, so the generated query no longer matched the SQL it was parsed from.

This change splits the handling to mirror how `dialect.SelectQuery` actually renders. 
The first queries' `ORDER BY/LIMIT/OFFSET/FETCH` map to the regular query clauses, while the outer-most clauses map to `CombinedOrder/CombinedLimit/CombinedOffset/CombinedFetch` (only when combines are present).