### PR TITLE
feat(clause): extract SetCols and add SQLite tuple SET support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added SQLite `um.SetCols(columns...)` and `im.SetCols(columns...)` for tuple assignment in `UPDATE ... SET` and `ON CONFLICT DO UPDATE SET` (`.ToExprs(...)`, `.ToRow(...)`, `.ToQuery(...)`). SQLite renders `(cols) = (exprs...)`; PostgreSQL `ToRow` still emits `ROW (...)`. MySQL does not support tuple assignment — use multiple `SetCol` calls. (thanks @atzedus)
+
 ### Fixed
 
 - Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
 
 ### Changed
+
+- Moved PostgreSQL `SetCols` tuple-assignment builder from `dialect/psql/dialect/setcols.go` to shared `clause/setcols.go` (`clause.NewSetCols`, `clause.SetColsOptions`). Dialect wrappers configure `ToRow` via `SetColsOptions.RowPrefix` (e.g. `"ROW"` on PostgreSQL). (thanks @atzedus)
 
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
 

--- a/clause/setcols.go
+++ b/clause/setcols.go
@@ -1,4 +1,4 @@
-package dialect
+package clause
 
 import (
 	"context"
@@ -11,10 +11,10 @@ import (
 // columnsAssignment represents (columns...) = [ROW] (values...) or (columns...) = (subquery).
 // Exactly one of query or values is set, depending on ToQuery vs ToExprs/ToRow.
 type columnsAssignment struct {
-	cols   []bob.Expression
-	query  bob.Query // ToQuery: subquery on the right-hand side
-	values []any     // ToExprs / ToRow: expressions on the right-hand side
-	isRow  bool
+	cols      []bob.Expression
+	query     bob.Query // ToQuery: subquery on the right-hand side
+	values    []any     // ToExprs / ToRow: expressions on the right-hand side
+	rowPrefix string    // ToRow only: token before "(", e.g. "ROW" on PostgreSQL
 }
 
 func (a columnsAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
@@ -33,12 +33,12 @@ func (a columnsAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bo
 		return append(colArgs, valArgs...), nil
 	}
 
-	valPrefix := "("
-	if a.isRow {
-		valPrefix = "ROW ("
+	if a.rowPrefix != "" {
+		w.WriteString(a.rowPrefix)
+		w.WriteString(" ")
 	}
 
-	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), a.values, valPrefix, ", ", ")")
+	valArgs, err := bob.ExpressSlice(ctx, w, d, start+len(colArgs), a.values, "(", ", ", ")")
 	if err != nil {
 		return nil, err
 	}
@@ -46,30 +46,50 @@ func (a columnsAssignment) WriteSQL(ctx context.Context, w io.StringWriter, d bo
 	return append(colArgs, valArgs...), nil
 }
 
-// SetCols is a reusable helper for PostgreSQL tuple assignments:
+// SetColsOptions configures tuple-assignment rendering for a [SetCols] builder.
+type SetColsOptions struct {
+	// RowPrefix is emitted before the value list in ToRow, e.g. "ROW" on PostgreSQL.
+	RowPrefix string
+}
+
+// SetCols is a reusable helper for tuple assignments in SET clauses:
 // (columns...) = ROW(...) | (values...) | (subquery)
 type SetCols[Q interface{ AppendSet(clauses ...any) }] struct {
 	columns []string
+	opts    SetColsOptions
 }
 
-// NewSetCols creates a reusable tuple-assignment builder for SET clauses.
-// It can be used by UPDATE queries, INSERT ... ON CONFLICT DO UPDATE,
-// and MERGE UPDATE actions.
+// NewSetCols creates a tuple-assignment builder for SET clauses.
+// It can be used by UPDATE queries, INSERT ... ON CONFLICT DO UPDATE, and MERGE UPDATE actions.
+// Dialect-specific rendering is configured via [SetCols.Options].
 func NewSetCols[Q interface{ AppendSet(clauses ...any) }](columns ...string) SetCols[Q] {
 	return SetCols[Q]{columns: columns}
 }
 
-// ToRow sets columns to ROW of expressions: (columns...) = ROW (expressions...)
+// Options returns a copy of the builder with the given options applied.
+func (s SetCols[Q]) Options(opts SetColsOptions) SetCols[Q] {
+	s.opts = opts
+	return s
+}
+
+// ToRow sets columns to a row of expressions: (columns...) = [prefix] (expressions...)
 func (s SetCols[Q]) ToRow(values ...bob.Expression) bob.Mod[Q] {
 	return bob.ModFunc[Q](func(q Q) {
-		q.AppendSet(columnsAssignment{cols: internal.QuoteIdentifiers(s.columns), values: internal.ToAnySlice(values), isRow: true})
+		q.AppendSet(columnsAssignment{
+			cols:      internal.QuoteIdentifiers(s.columns),
+			values:    internal.ToAnySlice(values),
+			rowPrefix: s.opts.RowPrefix,
+		})
 	})
 }
 
 // ToExprs sets columns to expressions: (columns...) = (expressions...)
 func (s SetCols[Q]) ToExprs(values ...bob.Expression) bob.Mod[Q] {
 	return bob.ModFunc[Q](func(q Q) {
-		q.AppendSet(columnsAssignment{cols: internal.QuoteIdentifiers(s.columns), values: internal.ToAnySlice(values)})
+		q.AppendSet(columnsAssignment{
+			cols:   internal.QuoteIdentifiers(s.columns),
+			values: internal.ToAnySlice(values),
+		})
 	})
 }
 

--- a/dialect/psql/im/qm.go
+++ b/dialect/psql/im/qm.go
@@ -102,8 +102,8 @@ func SetExpr(col bob.Expression) mods.Set[*clause.ConflictClause] {
 }
 
 // SetCols creates a multi-column setter: (columns...) = ROW(...) | (values...) | (subquery)
-func SetCols(columns ...string) dialect.SetCols[*clause.ConflictClause] {
-	return dialect.NewSetCols[*clause.ConflictClause](columns...)
+func SetCols(columns ...string) clause.SetCols[*clause.ConflictClause] {
+	return clause.NewSetCols[*clause.ConflictClause](columns...).Options(clause.SetColsOptions{RowPrefix: "ROW"})
 }
 
 // Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.

--- a/dialect/psql/mm/qm.go
+++ b/dialect/psql/mm/qm.go
@@ -254,8 +254,8 @@ func SetExpr(col bob.Expression) mods.Set[*UpdateAction] {
 }
 
 // SetCols creates a multi-column setter: (columns...) = ROW(...) | (values...) | (subquery)
-func SetCols(columns ...string) dialect.SetCols[*UpdateAction] {
-	return dialect.NewSetCols[*UpdateAction](columns...)
+func SetCols(columns ...string) clause.SetCols[*UpdateAction] {
+	return clause.NewSetCols[*UpdateAction](columns...).Options(clause.SetColsOptions{RowPrefix: "ROW"})
 }
 
 // InsertAction collects options for WHEN ... THEN INSERT actions.

--- a/dialect/psql/um/qm.go
+++ b/dialect/psql/um/qm.go
@@ -59,8 +59,8 @@ func SetExpr(col bob.Expression) mods.Set[*dialect.UpdateQuery] {
 }
 
 // SetCols creates a multi-column setter: (columns...) = ROW(...) | (values...) | (subquery)
-func SetCols(columns ...string) dialect.SetCols[*dialect.UpdateQuery] {
-	return dialect.NewSetCols[*dialect.UpdateQuery](columns...)
+func SetCols(columns ...string) clause.SetCols[*dialect.UpdateQuery] {
+	return clause.NewSetCols[*dialect.UpdateQuery](columns...).Options(clause.SetColsOptions{RowPrefix: "ROW"})
 }
 
 func From(table any, joins ...dialect.JoinChain[*dialect.UpdateQuery]) dialect.FromChain[*dialect.UpdateQuery] {

--- a/dialect/sqlite/im/qm.go
+++ b/dialect/sqlite/im/qm.go
@@ -100,6 +100,11 @@ func SetExpr(col bob.Expression) mods.Set[*clause.ConflictClause] {
 	return mods.Set[*clause.ConflictClause]{Col: col}
 }
 
+// SetCols creates a multi-column setter: (columns...) = (values...) | (subquery)
+func SetCols(columns ...string) clause.SetCols[*clause.ConflictClause] {
+	return clause.NewSetCols[*clause.ConflictClause](columns...)
+}
+
 // Excluded references a column from the EXCLUDED pseudo-table in ON CONFLICT DO UPDATE.
 func Excluded(column string) dialect.Expression {
 	return dialect.Expression{}.New(

--- a/dialect/sqlite/insert_test.go
+++ b/dialect/sqlite/insert_test.go
@@ -113,6 +113,49 @@ func TestInsert(t *testing.T) {
 				VALUES (?1, ?2), (?3, ?4)`,
 			ExpectedArgs: []any{8, "Anvil Distribution", 9, "Sentry Distribution"},
 		},
+		"on conflict do update set tuple to exprs": {
+			Query: sqlite.Insert(
+				im.Into("users", "id", "first_name", "last_name"),
+				im.Values(sqlite.Arg(1, "Thomas", "Anderson")),
+				im.OnConflict("id").DoUpdate(
+					im.SetCols("first_name", "last_name").ToExprs(
+						sqlite.Raw("EXCLUDED.first_name"),
+						sqlite.Raw("EXCLUDED.last_name"),
+					),
+				),
+			),
+			ExpectedSQL:  `INSERT INTO users ("id", "first_name", "last_name") VALUES (?1, ?2, ?3) ON CONFLICT (id) DO UPDATE SET ("first_name", "last_name") = (EXCLUDED.first_name, EXCLUDED.last_name)`,
+			ExpectedArgs: []any{1, "Thomas", "Anderson"},
+		},
+		"on conflict do update set tuple to row": {
+			Query: sqlite.Insert(
+				im.Into("users", "id", "first_name", "last_name"),
+				im.Values(sqlite.Arg(1, "Thomas", "Anderson")),
+				im.OnConflict("id").DoUpdate(
+					im.SetCols("first_name", "last_name").ToRow(
+						sqlite.Arg("Neo"),
+						sqlite.Arg("Anderson"),
+					),
+				),
+			),
+			ExpectedSQL:  `INSERT INTO users ("id", "first_name", "last_name") VALUES (?1, ?2, ?3) ON CONFLICT (id) DO UPDATE SET ("first_name", "last_name") = (?4, ?5)`,
+			ExpectedArgs: []any{1, "Thomas", "Anderson", "Neo", "Anderson"},
+		},
+		"on conflict do update set tuple to query": {
+			Query: sqlite.Insert(
+				im.Into("users", "id", "first_name", "last_name"),
+				im.Values(sqlite.Arg(1, "Thomas", "Anderson")),
+				im.OnConflict("id").DoUpdate(
+					im.SetCols("first_name", "last_name").ToQuery(sqlite.Select(
+						sm.Columns("first_name", "last_name"),
+						sm.From("archived_users"),
+						sm.Where(sqlite.Raw("archived_users.id = EXCLUDED.id")),
+					)),
+				),
+			),
+			ExpectedSQL:  `INSERT INTO users ("id", "first_name", "last_name") VALUES (?1, ?2, ?3) ON CONFLICT (id) DO UPDATE SET ("first_name", "last_name") = (SELECT first_name, last_name FROM archived_users WHERE archived_users.id = EXCLUDED.id)`,
+			ExpectedArgs: []any{1, "Thomas", "Anderson"},
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/sqlite/um/qm.go
+++ b/dialect/sqlite/um/qm.go
@@ -2,6 +2,7 @@ package um
 
 import (
 	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/clause"
 	"github.com/stephenafamo/bob/dialect/sqlite/dialect"
 	"github.com/stephenafamo/bob/expr"
 	"github.com/stephenafamo/bob/internal"
@@ -77,6 +78,11 @@ func SetCol(from string) mods.Set[*dialect.UpdateQuery] {
 // SetExpr is like SetCol but the column LHS is any expression (e.g. sqlite.Quote("t", "col")).
 func SetExpr(col bob.Expression) mods.Set[*dialect.UpdateQuery] {
 	return mods.Set[*dialect.UpdateQuery]{Col: col}
+}
+
+// SetCols creates a multi-column setter: (columns...) = (values...) | (subquery)
+func SetCols(columns ...string) clause.SetCols[*dialect.UpdateQuery] {
+	return clause.NewSetCols[*dialect.UpdateQuery](columns...)
 }
 
 func From(table any) dialect.FromChain[*dialect.UpdateQuery] {

--- a/dialect/sqlite/update_test.go
+++ b/dialect/sqlite/update_test.go
@@ -100,6 +100,41 @@ func TestUpdate(t *testing.T) {
 			  WHERE ("employees"."id" = ?1)`,
 			ExpectedArgs: []any{1},
 		},
+		"set tuple columns from row": {
+			Query: sqlite.Update(
+				um.Table("weather"),
+				um.SetCols("temp_lo", "temp_hi", "prcp").ToRow(
+					sqlite.Raw("temp_lo + 1"),
+					sqlite.Raw("temp_lo + 15"),
+					sqlite.Raw("DEFAULT"),
+				),
+				um.Where(sqlite.Quote("city").EQ(sqlite.Arg("San Francisco"))),
+			),
+			ExpectedSQL:  `UPDATE weather SET ("temp_lo", "temp_hi", "prcp") = (temp_lo + 1, temp_lo + 15, DEFAULT) WHERE ("city" = ?1)`,
+			ExpectedArgs: []any{"San Francisco"},
+		},
+		"set tuple columns from exprs": {
+			Query: sqlite.Update(
+				um.Table("products"),
+				um.SetCols("name", "price").ToExprs(
+					sqlite.Raw("'updated'"),
+					sqlite.Raw("price * 1.1"),
+				),
+			),
+			ExpectedSQL: `UPDATE products SET ("name", "price") = ('updated', price * 1.1)`,
+		},
+		"set tuple columns from sub-select": {
+			Query: sqlite.Update(
+				um.Table("accounts"),
+				um.SetCols("contact_first_name", "contact_last_name").ToQuery(sqlite.Select(
+					sm.Columns("first_name", "last_name"),
+					sm.From("employees"),
+					sm.Where(sqlite.Quote("employees", "id").EQ(sqlite.Quote("accounts", "sales_person"))),
+				)),
+			),
+			ExpectedSQL: `UPDATE accounts SET ("contact_first_name", "contact_last_name") =
+			  (SELECT first_name, last_name FROM employees WHERE ("employees"."id" = "accounts"."sales_person"))`,
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/website/docs/query-builder/quotes.md
+++ b/website/docs/query-builder/quotes.md
@@ -24,7 +24,8 @@ For qualified column names in `SET` / `ON CONFLICT DO UPDATE`, use `SetExpr` (or
 | `im.OnConflictOnConstraint(name)` | psql, sqlite | Constraint name |
 | `um/dm.WhereCurrentOf(cursor)` | psql | Cursor name |
 | `um/im/mm.SetCol("col")` | psql; um/im on sqlite; um + `im.UpdateCol` on mysql | LHS of single-column `SET` |
-| `um/im/mm.SetCols("a", "b")` | psql only | Tuple assignment `(a, b) = ...` |
+| `um/im.SetCols("a", "b")` | psql, sqlite | Tuple assignment `(a, b) = ...`; PostgreSQL `ToRow` emits `ROW (...)` |
+| `mm.SetCols("a", "b")` | psql only | Tuple assignment in `MERGE ... UPDATE SET` |
 | `mm.Columns("a", "b")` | psql only | `MERGE ... INSERT (a, b)` column list |
 | `im.SetExcluded("a", "b")` | psql, sqlite | `"a" = EXCLUDED."a"`, ... |
 | `im.Excluded("col")` | psql, sqlite | `EXCLUDED."col"` |
@@ -70,6 +71,9 @@ um.Set(
 
 // MERGE update
 mm.SetCol("price").To(psql.Quote("u", "price"))
+
+// Tuple SET (PostgreSQL ToRow uses ROW (...); SQLite uses (...))
+um.SetCols("temp_lo", "temp_hi").ToExprs(psql.Raw("temp_lo + 1"), psql.Raw("temp_lo + 15"))
 
 // Table in FROM (pass Quote when you want quoting)
 sm.From(psql.Quote("films"))


### PR DESCRIPTION
- Move tuple-assignment helper from `dialect/psql/dialect/setcols.go` to shared `clause/setcols.go`
- Configure dialect-specific `ToRow` rendering via `SetColsOptions.RowPrefix` (PostgreSQL: `ROW`, SQLite: none)
- Add `um.SetCols` / `im.SetCols` for SQLite (`UPDATE` and `ON CONFLICT DO UPDATE SET`)
- Update docs
