### PR TITLE
feat(psql/mysql): OrderCombined feature parity with OrderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `With()` on generated queries as a more ergonomic method to add mods on top of generated queries (thanks @daddz)
+- Added `Asc()/Desc()/...` helpers to `sm.OrderCombined` for PostgreSQL/MySQL (thanks @daddz) 
 - Added SQLite `um.SetCols(columns...)` and `im.SetCols(columns...)` for tuple assignment in `UPDATE ... SET` and `ON CONFLICT DO UPDATE SET` (`.ToExprs(...)`, `.ToRow(...)`, `.ToQuery(...)`). SQLite renders `(cols) = (exprs...)`; PostgreSQL `ToRow` still emits `ROW (...)`. MySQL does not support tuple assignment — use multiple `SetCol` calls. (thanks @atzedus)
 
 ### Fixed

--- a/dialect/mysql/dialect/mods.go
+++ b/dialect/mysql/dialect/mods.go
@@ -266,6 +266,33 @@ func (o OrderCombined) Apply(q *SelectQuery) {
 	q.CombinedOrder.AppendOrder(o())
 }
 
+func (o OrderCombined) Asc() OrderCombined {
+	order := o()
+	order.Direction = "ASC"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) Desc() OrderCombined {
+	order := o()
+	order.Direction = "DESC"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) Collate(collationName string) OrderCombined {
+	order := o()
+	order.Collation = collationName
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef
 
 func (s OrderBy[Q]) Apply(q Q) {

--- a/dialect/psql/dialect/mods.go
+++ b/dialect/psql/dialect/mods.go
@@ -297,6 +297,60 @@ func (o OrderCombined) Apply(q *SelectQuery) {
 	q.CombinedOrder.AppendOrder(o())
 }
 
+func (o OrderCombined) Asc() OrderCombined {
+	order := o()
+	order.Direction = "ASC"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) Desc() OrderCombined {
+	order := o()
+	order.Direction = "DESC"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) Using(operator string) OrderCombined {
+	order := o()
+	order.Direction = "USING " + operator
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) NullsFirst() OrderCombined {
+	order := o()
+	order.Nulls = "FIRST"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) NullsLast() OrderCombined {
+	order := o()
+	order.Nulls = "LAST"
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
+func (o OrderCombined) Collate(collationName string) OrderCombined {
+	order := o()
+	order.Collation = collationName
+
+	return OrderCombined(func() clause.OrderDef {
+		return order
+	})
+}
+
 type OrderBy[Q interface{ AppendOrder(bob.Expression) }] func() clause.OrderDef
 
 func (s OrderBy[Q]) Apply(q Q) {

--- a/orm/query_test.go
+++ b/orm/query_test.go
@@ -22,11 +22,10 @@ func (r rawExpr) WriteSQL(_ context.Context, w io.StringWriter, _ bob.Dialect, _
 	return nil, nil
 }
 
-// newModQuery builds a ModQuery whose generated Mod alone reproduces
-// "SELECT id FROM todo", mirroring what the queries plugin emits. Any extra
-// funcs are applied inside the generated Mod after the SELECT/FROM, letting a
-// test reproduce a query that already carries WHERE/ORDER BY/LIMIT/OFFSET
-// clauses the way the generator emits them.
+// newModQuery builds a ModQuery whose generated Mod reproduces
+// "SELECT id FROM todo", mirroring what the queries plugin emits. Extra funcs
+// run inside the Mod after the SELECT/FROM, so a test can add the clauses a
+// generated query already carries.
 func newModQuery(scanner scan.Mapper[int], extra ...func(*dialect.SelectQuery)) orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]] {
 	return orm.ModQuery[*dialect.SelectQuery, rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
 		Query: orm.Query[rawExpr, int, []int, bob.SliceTransformer[int, []int]]{
@@ -73,15 +72,13 @@ func TestModQueryWith(t *testing.T) {
 	testutils.RunTests(t, examples, nil)
 }
 
-// TestModQueryWithExistingClauses exercises augmentation of a generated query
-// that already carries WHERE / ORDER BY / LIMIT / OFFSET clauses, reproducing
-// the way the queries plugin emits them: WHERE goes onto the regular Where
-// field (so user mods AND onto it), while ORDER BY / LIMIT / OFFSET go onto the
-// Combined* fields.
+// TestModQueryWithExistingClauses augments a generated query that already
+// carries clauses: WHERE conditions are ANDed, ORDER BY merges into one clause,
+// and LIMIT / OFFSET are replaced.
 func TestModQueryWithExistingClauses(t *testing.T) {
 	examples := testutils.Testcases{
 		"existing WHERE is ANDed with one extra condition": {
-			Doc:          "A user sm.Where() is appended to the generated WHERE via AND, producing valid SQL",
+			Doc:          "A user sm.Where() ANDs onto the existing WHERE",
 			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2`,
 			ExpectedArgs: []any{true, 1},
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
@@ -91,7 +88,7 @@ func TestModQueryWithExistingClauses(t *testing.T) {
 			),
 		},
 		"existing WHERE is ANDed with multiple extra conditions": {
-			Doc:          "Multiple user sm.Where() mods each AND onto the generated WHERE, preserving arg order",
+			Doc:          "Multiple user sm.Where() mods each AND on, preserving arg order",
 			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2 AND priority > $3`,
 			ExpectedArgs: []any{true, 1, 2},
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
@@ -101,44 +98,41 @@ func TestModQueryWithExistingClauses(t *testing.T) {
 				sm.Where(psql.Quote("priority").GT(psql.Arg(2))),
 			),
 		},
-		// KNOWN LIMITATION: ORDER BY / LIMIT / OFFSET only append. The generated
-		// clauses live on the Combined* fields while user mods set the regular
-		// fields, so both are rendered as separate clauses, yielding invalid SQL.
-		"existing ORDER BY produces a duplicate clause (invalid SQL)": {
-			Doc:         "A user sm.OrderBy() does not merge with the generated ORDER BY; both clauses are emitted",
-			ExpectedSQL: `SELECT id FROM todo ORDER BY id ORDER BY created_at`,
+		"existing ORDER BY merges with the user ORDER BY": {
+			Doc:         "A user sm.OrderBy() appends into the existing ORDER BY clause",
+			ExpectedSQL: `SELECT id FROM todo ORDER BY created_at, id`,
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
-				q.CombinedOrder.AppendOrder(psql.Quote("created_at"))
+				q.AppendOrder(psql.Quote("created_at"))
 			}).With(
 				sm.OrderBy(psql.Quote("id")),
 			),
 		},
-		"existing LIMIT produces a duplicate clause (invalid SQL)": {
-			Doc:         "A user sm.Limit() does not replace the generated LIMIT; both clauses are emitted",
-			ExpectedSQL: `SELECT id FROM todo LIMIT 10 LIMIT 5`,
+		"existing LIMIT is replaced by the user LIMIT": {
+			Doc:         "A user sm.Limit() replaces the existing LIMIT",
+			ExpectedSQL: `SELECT id FROM todo LIMIT 10`,
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
-				q.CombinedLimit.SetLimit(5)
+				q.SetLimit(5)
 			}).With(
 				sm.Limit(10),
 			),
 		},
-		"existing OFFSET produces a duplicate clause (invalid SQL)": {
-			Doc:         "A user sm.Offset() does not replace the generated OFFSET; both clauses are emitted",
-			ExpectedSQL: `SELECT id FROM todo OFFSET 10 OFFSET 5`,
+		"existing OFFSET is replaced by the user OFFSET": {
+			Doc:         "A user sm.Offset() replaces the existing OFFSET",
+			ExpectedSQL: `SELECT id FROM todo OFFSET 10`,
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
-				q.CombinedOffset.SetOffset(5)
+				q.SetOffset(5)
 			}).With(
 				sm.Offset(10),
 			),
 		},
-		"WHERE merges while ORDER BY and LIMIT duplicate": {
-			Doc:          "Combined scenario: the WHERE is correctly ANDed, but ORDER BY and LIMIT each duplicate",
-			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2 ORDER BY id LIMIT 10 ORDER BY created_at LIMIT 5`,
+		"WHERE ANDs, ORDER BY merges, LIMIT is replaced": {
+			Doc:          "Combined scenario across all three behaviors",
+			ExpectedSQL:  `SELECT id FROM todo WHERE done = $1 AND project_id = $2 ORDER BY created_at, id LIMIT 10`,
 			ExpectedArgs: []any{true, 1},
 			Query: newModQuery(nil, func(q *dialect.SelectQuery) {
 				q.AppendWhere(psql.Quote("done").EQ(psql.Arg(true)))
-				q.CombinedOrder.AppendOrder(psql.Quote("created_at"))
-				q.CombinedLimit.SetLimit(5)
+				q.AppendOrder(psql.Quote("created_at"))
+				q.SetLimit(5)
 			}).With(
 				sm.Where(psql.Quote("project_id").EQ(psql.Arg(1))),
 				sm.OrderBy(psql.Quote("id")),

--- a/website/docs/code-generation/queries.md
+++ b/website/docs/code-generation/queries.md
@@ -165,11 +165,42 @@ users, err := AllUsers(1).With(
 ).All(ctx, db)
 ```
 
-:::caution
+:::note
 
-`With()` (like using the query as a mod) only **appends** clauses. For a `WHERE` clause this is fine: the extra condition is joined to the existing one with `AND`. But if the generated query already has an `ORDER BY`, `LIMIT`, or `OFFSET` clause, adding another one does **not** replace it — both are emitted, producing invalid SQL. Only add these clauses when the base query does not already define them.
+How an extra mod combines with a clause the generated query already has depends on which field that clause sits on:
+
+- `sm.Where(...)` is always joined to an existing `WHERE` with `AND`.
+- `sm.OrderBy(...)` is appended to an existing `ORDER BY` (both end up in the same clause).
+- `sm.Limit(...)` / `sm.Offset(...)` **replace** an existing `LIMIT` / `OFFSET`.
+
+For the **psql** generator, a generated plain query places its `ORDER BY` / `LIMIT` / `OFFSET` on these regular fields, so the rules above apply directly. 
+
+For a **combined** query (`UNION` / `INTERSECT` / `EXCEPT`), the outer-most `ORDER BY` / `LIMIT` / `OFFSET` — the ones that apply to the combined result rather than the first branch — live on separate fields. 
+A plain `sm.OrderBy` / `sm.Limit` / `sm.Offset` targets the first branch; to change the outer clauses use `sm.OrderCombined`, `sm.LimitCombined`, `sm.OffsetCombined` (and `sm.FetchCombined`).
+
+The **sqlite** generator behaves the same for plain queries (regular fields) but has no combined-clause mods. 
+
+The **mysql** generator currently emits a plain query's `ORDER BY` / `LIMIT` / `OFFSET` onto the combined fields, so adding another one via `With()` appends rather than replaces and can produce invalid SQL — for mysql, only add these when the base query does not already define them.
 
 :::
+
+For a combined (`UNION` / `INTERSECT` / `EXCEPT`) query, use the `*Combined` mods to change the outer-most clauses that apply to the combined result:
+
+```go
+// Given a generated query such as:
+//   (SELECT id FROM users WHERE id IN ($1) ORDER BY id DESC LIMIT 2 OFFSET 1)
+//   UNION
+//   (SELECT id FROM users WHERE id IN ($2) ORDER BY id ASC LIMIT 3 OFFSET 4)
+//   ORDER BY id DESC LIMIT 5 OFFSET 6
+
+// Replace the outer LIMIT/OFFSET and re-order the combined result.
+// sm.OrderBy/sm.Limit here would target the first branch instead.
+users, err := CombinedUsersOrderLimitOffset(1, 2).With(
+    sm.OrderCombined(psql.Quote("id")).Desc(),
+    sm.LimitCombined(10),
+    sm.OffsetCombined(0),
+).All(ctx, db)
+```
 
 ## Annotating queries
 


### PR DESCRIPTION
Follow-up PR to https://github.com/stephenafamo/bob/pull/704

* Add `Asc()`, `Desc()`, etc. to `OrderCombined` so you can use it like `sm.OrderCombined(psql.Quote("id")).Desc()`
* Updated tests for generated queries with existing `WHERE/ORDER BY/LIMIT/OFFSET`
* Updated docs to reflect current state of generated query mod overrides