### PR TITLE
perf(gen): use col = ANY(\$1) for single-column relationship loaders on psql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
+- Fixed generated query mods for combined `UNION/INTERSECT/EXCEPT` queries dropping or misrouting the first operand's `ORDER BY/LIMIT/OFFSET` into the combined-result clauses. (thanks @daddz)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PostgreSQL `um` / `dm` standalone join mods (`InnerJoin`, `LeftJoin`, etc.) applied before `um.From(...)` / `dm.Using(...)`: the join is now preserved and attached to the next `FROM` / `USING` from_item instead of being dropped. (thanks @atzedus)
 - Fixed/extended PostgreSQL `sm.From(...)`: it now accepts variadic join chains (`sm.From(table, joins...)`), and inline joins are merged with already attached standalone joins when replacing the primary `FROM` source. (thanks @atzedus)
 
+### Fixed
+
+- Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
+
 ### Changed
 
 - Moved PostgreSQL `SetCols` tuple-assignment builder from `dialect/psql/dialect/setcols.go` to shared `clause/setcols.go` (`clause.NewSetCols`, `clause.SetColsOptions`). Dialect wrappers configure `ToRow` via `SetColsOptions.RowPrefix` (e.g. `"ROW"` on PostgreSQL). (thanks @atzedus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- PostgreSQL single-column relationship loaders — both the slice relationship query (`<Parent>Slice.<Rel>`) and the batch count method (`<Parent>Slice.LoadCount<Rel>`) — now filter related rows with `col = ANY($1)` instead of `col IN (SELECT unnest($1))`, so the query planner can use an index scan on the foreign key instead of a `Seq Scan + Hash Semi Join`. Composite-key relationships keep the existing `IN (SELECT unnest(...))` form. (thanks @sandonemaki)
+
 ## [v0.46.0] - 2026-06-11
 
 
@@ -27,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 - Generated slice relationship loaders (`<Parent>Slice.Load<Relationship>`) now stitch loaded parents and children in O(N+M) using a map keyed by the join column, instead of the previous O(N×M) nested loop. This greatly speeds up eager-loading and then-loading relationships with many rows on both sides. The map is only used for single-column joins whose key type is comparable with `==`; composite keys and types with a custom `compare_expr` (e.g. `[]byte`) fall back to the original nested loop, so generated behaviour is unchanged. (thanks @sandonemaki)
-- PostgreSQL single-column relationship loaders — both the slice relationship query (`<Parent>Slice.<Rel>`) and the batch count method (`<Parent>Slice.LoadCount<Rel>`) — now filter related rows with `col = ANY($1)` instead of `col IN (SELECT unnest($1))`, so the query planner can use an index scan on the foreign key instead of a `Seq Scan + Hash Semi Join`. Composite-key relationships keep the existing `IN (SELECT unnest(...))` form. (thanks @sandonemaki)
 
 
 ## [v0.45.0] - 2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.46.0] - 2026-06-11
 
+
 ### Added
 
 - `With()` on generated queries as a more ergonomic method to add mods on top of generated queries (thanks @daddz)
@@ -20,17 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PostgreSQL `um` / `dm` standalone join mods (`InnerJoin`, `LeftJoin`, etc.) applied before `um.From(...)` / `dm.Using(...)`: the join is now preserved and attached to the next `FROM` / `USING` from_item instead of being dropped. (thanks @atzedus)
 - Fixed/extended PostgreSQL `sm.From(...)`: it now accepts variadic join chains (`sm.From(table, joins...)`), and inline joins are merged with already attached standalone joins when replacing the primary `FROM` source. (thanks @atzedus)
 
-### Fixed
-
-- Fixed generated `Setter.Apply` wrapping all insert values in a single `ExpressionFunc`, which prevented `BeforeInsertHooks` and query mods from modifying individual column values via `q.Values.Vals[row][columnIndex]`. Base and SQLite codegen templates now emit one expression per column (MySQL already did). Generated SQL is unchanged. (thanks @atzedus)
-- Fixed generated query mods for combined `UNION/INTERSECT/EXCEPT` queries dropping or misrouting the first operand's `ORDER BY/LIMIT/OFFSET` into the combined-result clauses. (thanks @daddz)
-
 ### Changed
 
 - Moved PostgreSQL `SetCols` tuple-assignment builder from `dialect/psql/dialect/setcols.go` to shared `clause/setcols.go` (`clause.NewSetCols`, `clause.SetColsOptions`). Dialect wrappers configure `ToRow` via `SetColsOptions.RowPrefix` (e.g. `"ROW"` on PostgreSQL). (thanks @atzedus)
 - `EQ` comparisons passed to `SET` / `ON CONFLICT DO UPDATE SET` / `MERGE ... UPDATE SET` / MySQL `ON DUPLICATE KEY UPDATE` render without the extra parentheses used in `WHERE` / `ON` (e.g. `SET "users"."name" = $1` vs `WHERE ("users"."name" = $1)`). (thanks @atzedus)
 - `NameAsExpr()` on dialect `View` / `Table` types (PostgreSQL, SQLite, MySQL) omits a redundant `AS` when the alias matches the table name (for example `FROM "users"` instead of `FROM "users" AS "users"`). An explicit alias is still emitted when a schema is set at construction (`AS "schema.table"`). (thanks @atzedus)
 - Generated slice relationship loaders (`<Parent>Slice.Load<Relationship>`) now stitch loaded parents and children in O(N+M) using a map keyed by the join column, instead of the previous O(N×M) nested loop. This greatly speeds up eager-loading and then-loading relationships with many rows on both sides. The map is only used for single-column joins whose key type is comparable with `==`; composite keys and types with a custom `compare_expr` (e.g. `[]byte`) fall back to the original nested loop, so generated behaviour is unchanged. (thanks @sandonemaki)
+- PostgreSQL single-column relationship loaders — both the slice relationship query (`<Parent>Slice.<Rel>`) and the batch count method (`<Parent>Slice.LoadCount<Rel>`) — now filter related rows with `col = ANY($1)` instead of `col IN (SELECT unnest($1))`, so the query planner can use an index scan on the foreign key instead of a `Seq Scan + Hash Semi Join`. Composite-key relationships keep the existing `IN (SELECT unnest(...))` form. (thanks @sandonemaki)
 
 ## [v0.45.0] - 2026-05-28
 
@@ -49,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** MySQL `sm.ForUpdate` and `sm.ForShare` now take `tables ...any` with the same semantics as PostgreSQL (`mysql.Quote(...)` when needed). (thanks @atzedus)
 - **BREAKING:** `clause.Lock.Tables` is now `[]any` instead of `[]string` (used by `FOR UPDATE` / `FOR SHARE` rendering). (thanks @atzedus)
 - **BREAKING:** `View` / `Table` `Name()` now returns the bare table (or view) name as `string`. In v0.44.0, `Name()` returned a dialect `Expression` (qualified table reference for SQL). That role moved to new methods:
-  - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` when schema was generated empty)
+  - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` whens schema was generated empty)
   - `NameAsExpr()` — what `NameAs()` did in v0.44.0 (name plus table alias)
     Update manual call sites, codegen templates, and generated models: `Users.Name()` in SQL builders → `Users.NameExpr()`, `Users.NameAs()` → `Users.NameAsExpr()`; use `Users.Name()` when you need the unqualified name string. On PostgreSQL and SQLite, `Schema()` still returns the schema when set.
 - Codegen templates and `orm.Preload` now use `NameExpr()` / `NameAsExpr()` instead of `Name()` / `NameAs()`. (thanks @atzedus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated slice relationship loaders (`<Parent>Slice.Load<Relationship>`) now stitch loaded parents and children in O(N+M) using a map keyed by the join column, instead of the previous O(N×M) nested loop. This greatly speeds up eager-loading and then-loading relationships with many rows on both sides. The map is only used for single-column joins whose key type is comparable with `==`; composite keys and types with a custom `compare_expr` (e.g. `[]byte`) fall back to the original nested loop, so generated behaviour is unchanged. (thanks @sandonemaki)
 - PostgreSQL single-column relationship loaders — both the slice relationship query (`<Parent>Slice.<Rel>`) and the batch count method (`<Parent>Slice.LoadCount<Rel>`) — now filter related rows with `col = ANY($1)` instead of `col IN (SELECT unnest($1))`, so the query planner can use an index scan on the foreign key instead of a `Seq Scan + Hash Semi Join`. Composite-key relationships keep the existing `IN (SELECT unnest(...))` form. (thanks @sandonemaki)
 
+
 ## [v0.45.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** MySQL `sm.ForUpdate` and `sm.ForShare` now take `tables ...any` with the same semantics as PostgreSQL (`mysql.Quote(...)` when needed). (thanks @atzedus)
 - **BREAKING:** `clause.Lock.Tables` is now `[]any` instead of `[]string` (used by `FOR UPDATE` / `FOR SHARE` rendering). (thanks @atzedus)
 - **BREAKING:** `View` / `Table` `Name()` now returns the bare table (or view) name as `string`. In v0.44.0, `Name()` returned a dialect `Expression` (qualified table reference for SQL). That role moved to new methods:
-  - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` whens schema was generated empty)
+  - `NameExpr()` — what `Name()` did in v0.44.0 (on PostgreSQL and SQLite, respects `UseSchema` when schema was generated empty)
   - `NameAsExpr()` — what `NameAs()` did in v0.44.0 (name plus table alias)
     Update manual call sites, codegen templates, and generated models: `Users.Name()` in SQL builders → `Users.NameExpr()`, `Users.NameAs()` → `Users.NameAsExpr()`; use `Users.Name()` when you need the unqualified name string. On PostgreSQL and SQLite, `Schema()` still returns the schema when set.
 - Codegen templates and `orm.Preload` now use `NameExpr()` / `NameAsExpr()` instead of `Name()` / `NameAs()`. (thanks @atzedus)

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -202,6 +202,12 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
 		{{- end}}
 	}
+	{{- if eq (len $firstSide.FromColumns) 1}}
+	{{- $local := index $firstSide.FromColumns 0 -}}
+	{{- $column := $.Table.GetColumn $local -}}
+	{{- $fromCol := index $firstFrom.Columns $local}}
+	PKArgExpr := {{$.Dialect}}.Any({{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
+	{{- else}}
 	PKArgExpr := {{$.Dialect}}.Select(sm.Columns(
 		{{- range $index, $local := $firstSide.FromColumns -}}
 		{{- $column := $.Table.GetColumn $local -}}
@@ -209,6 +215,7 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		{{$.Dialect}}.F("unnest", {{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]")),
 		{{- end}}
 	))
+	{{- end}}
 	{{- end}}
 
 	// countResult holds one scanned row from the batch count query.
@@ -269,12 +276,16 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		),
 		{{end -}}
 		{{- end}}
-		// WHERE fk IN (parent PKs)
+		// WHERE fk IN (parent PKs) — psql single-column FK uses `= ANY(array)` (see PKArgExpr above)
 		{{if eq (len $firstSide.FromColumns) 1 -}}
 		{{$local := index $firstSide.FromColumns 0 -}}
 		{{$toLocal := index $firstSide.ToColumns 0 -}}
 		{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+		{{if eq $.Dialect "psql" -}}
+		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.EQ(PKArgExpr)),
+		{{- else -}}
 		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.OP("IN", PKArgExpr)),
+		{{- end}}
 		{{- else -}}
 		sm.Where({{$.Dialect}}.Group(
 			{{range $index, $local := $firstSide.FromColumns -}}

--- a/gen/templates/models/table/009_rel_query.go.tpl
+++ b/gen/templates/models/table/009_rel_query.go.tpl
@@ -87,6 +87,12 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
         pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
       {{- end}}
     }
+    {{if eq (len $firstSide.FromColumns) 1}}
+    {{- $local := index $firstSide.FromColumns 0}}
+    {{- $column := $.Table.GetColumn $local}}
+    {{- $fromCol := index $firstFrom.Columns $local}}
+    PKArgExpr := psql.Any(psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
+    {{else}}
     PKArgExpr := psql.Select(sm.Columns(
       {{- range $index, $local := $firstSide.FromColumns -}}
         {{$column := $.Table.GetColumn $local}}
@@ -94,6 +100,7 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
         psql.F("unnest", psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]")),
       {{- end}}
     ))
+    {{end}}
   {{end}}
 	{{- end}}
 
@@ -125,12 +132,17 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
 		),
 		{{- else -}}
 			{{if gt (len $side.FromColumns) 0 -}}
-				sm.Where({{$.Dialect}}.Group(
-				{{- range $index, $local := $side.FromColumns -}}
-					{{- $fromCol := index $from.Columns $local -}}
-					{{- $toCol := index $to.Columns (index $side.ToColumns $index) -}}
-					{{$to.UpPlural}}.Columns.{{$toCol}},
-				{{- end}}).OP("IN", PKArgExpr)),
+				{{if and (eq $.Dialect "psql") (eq (len $side.FromColumns) 1) -}}
+					{{- $toCol := index $to.Columns (index $side.ToColumns 0) -}}
+					sm.Where({{$to.UpPlural}}.Columns.{{$toCol}}.EQ(PKArgExpr)),
+				{{- else -}}
+					sm.Where({{$.Dialect}}.Group(
+					{{- range $index, $local := $side.FromColumns -}}
+						{{- $fromCol := index $from.Columns $local -}}
+						{{- $toCol := index $to.Columns (index $side.ToColumns $index) -}}
+						{{$to.UpPlural}}.Columns.{{$toCol}},
+					{{- end}}).OP("IN", PKArgExpr)),
+				{{- end}}
 			{{- end}}
 			{{- range $where := $side.FromWhere}}
 				{{- $fromCol := index $from.Columns $where.Column}}


### PR DESCRIPTION
## Summary

For the PostgreSQL dialect, two generated `<Parent>Slice` helpers filter children by the
parent-PK set with `fk IN (SELECT unnest(CAST($1 AS T[])))`:

- the relationship query `func (os <Parent>Slice) <Relationship>(...)` (used by the slice
  eager / then loaders), and
- the batch count method `func (os <Parent>Slice) LoadCount<Rel>(...)` (counts a to-many
  relationship for many parents in one `GROUP BY` query).

This PR changes the **single-column** case of both to `fk = ANY(CAST($1 AS T[]))`, so the
PostgreSQL planner can use an index scan on the foreign key instead of a
`Seq Scan + Hash Semi Join`. Composite keys and other dialects are unchanged.

## Generated code & SQL — before / after

Example: `users` (parent) → `posts` (child, `posts.user_id -> users.id`, `bigint`),
i.e. `UserSlice.Posts(...)`.

**Before**

```go
PKArgExpr := psql.Select(sm.Columns(
    psql.F("unnest", psql.Cast(psql.Arg(pkID), "bigint[]")),
))
sm.Where(psql.Group(Posts.Columns.UserID).OP("IN", PKArgExpr)),
```

```sql
WHERE posts.user_id IN (SELECT unnest(CAST($1 AS bigint[])))
```

**After**

```go
PKArgExpr := psql.Any(psql.Cast(psql.Arg(pkID), "bigint[]"))
sm.Where(Posts.Columns.UserID.EQ(PKArgExpr)),
```

```sql
WHERE posts.user_id = ANY(CAST($1 AS bigint[]))
```

## Query plan

**Before — `fk IN (SELECT unnest($1))`**

```text
Hash Semi Join
  Hash Cond: (posts.user_id = (unnest($1)))
  ->  Seq Scan on posts                 -- full table scan (the slowdown)
  ->  Hash
        ->  Function Scan on unnest      -- fixed row estimate; $1 length unknown at plan time
```

**After — `fk = ANY($1)`**

```text
Bitmap Heap Scan on posts
  Recheck Cond: (user_id = ANY ($1))
  ->  Bitmap Index Scan on posts_user_id_idx
        Index Cond: (user_id = ANY ($1))  -- the FK index is used
```

## Why

| | Before (`Seq Scan` + `Hash Semi Join`) | After (`Bitmap Index Scan`) |
| --- | --- | --- |
| Generated SQL | `user_id IN (SELECT unnest(CAST($1 AS bigint[])))` | `user_id = ANY(CAST($1 AS bigint[]))` |
| FK index | not used (absent from the plan) | used (`posts_user_id_idx`) |
| Rows read | all of `posts` (every heap page) | only matching rows |
| Cost | scales with table size (O(rows)) | scales with the result size |
| Ops | needs `pg_hint_plan` hints | no hints, stable |
| Reason | `IN (subquery)` is planned as a semi-join; `unnest()` has a fixed row estimate and the `$1` array length is unknown at plan time, so the planner falls back to scanning the whole table and the index cannot be applied | `= ANY(array)` is a `ScalarArrayOpExpr`, not a join, so the planner takes the FK index path directly |

## Scope

- Two templates, same change: `gen/templates/models/table/009_rel_query.go.tpl` (slice
  relationship query) and `gen/templates/counts/table/115_counts.go.tpl` (batch count
  method). The count method's example is identical — the same 2-line edit
  (`= ANY` + `.EQ(...)`) on the SELECT it builds.
- psql + single join column only. Composite keys keep `(c1, c2) IN (SELECT unnest..., unnest...)`
  (a row tuple cannot use `= ANY`); other dialects are unchanged.

## EXPLAIN ANALYZE benchmark (PostgreSQL 18.4, index on FK column)

Tested with PREPARE/EXECUTE (parametrized `$1`, matching actual generated code) against
a child table where each parent has ~1,000 child rows — a typical one-to-many workload.
The **Returned rows** column confirms both forms return identical results.

| Rows | Batch | Before time | Before plan | After time | After plan | Speedup | Returned rows |
|---|---|---|---|---|---|---|---|
| 100K | 5 | 6.1 ms | Seq Scan + Hash Semi Join | 0.77 ms | Bitmap Index Scan | **7.9×** | 4,559 |
| 100K | 50 | 9.7 ms | Seq Scan + Hash Semi Join | 4.0 ms | Bitmap Index Scan | **2.4×** | 50,035 |
| 1M | 5 | 3.1 ms | Nested Loop (5× Bitmap Index) | 1.4 ms | Bitmap Index Scan | **2.2×** | 4,513 |
| 1M | 50 | 35.5 ms | Seq Scan + Hash Semi Join | 10.2 ms | Bitmap Index Scan | **3.5×** | 49,459 |
| 10M | 5 | 19.1 ms | Nested Loop (5× Bitmap Index) | 2.4 ms | Bitmap Index Scan | **8.0×** | 4,552 |
| 10M | 50 | 115.6 ms | Nested Loop (50× Bitmap Index) | 41.4 ms | Bitmap Index Scan | **2.8×** | 49,592 |
| 10M | 200 | 278 ms | Seq Scan + Hash Join | 79.8 ms | Bitmap Index Scan | **3.5×** | 199,316 |
| 50M | 5 | 134 ms | Nested Loop (5× Bitmap Index) | 7.8 ms | Bitmap Index Scan | **17×** | 4,539 |
| 50M | 50 | 1,087 ms | Nested Loop (50× Bitmap Index) | 171 ms | Bitmap Index Scan | **6.4×** | 49,530 |
| 50M | 200 | 2,508 ms | Nested Loop (200× Bitmap Index) | 504 ms | Bitmap Index Scan | **5.0×** | 200,508 |

### Production database validation (PostgreSQL 18, warm cache)

The same SQL forms were run against a production application database to confirm
the synthetic results hold on real data. The FK column has a B-tree index in both cases.

**Case 1 — simple FK lookup (batch = 20)**

| | Before (`IN unnest`) | After (`= ANY`) |
|---|---|---|
| Execution time | 192 ms | 12 ms |
| Scan on child table | Index Scan × 20 (one per FK value) | Bitmap Index Scan × 1 |
| Speedup | | **16×** |

The planner consolidated 20 individual index seeks into a single Bitmap Index Scan,
matching the pattern shown in the synthetic benchmark.

**Case 2 — FK lookup with JOIN to a large related table (batch = 1)**

| | Before (`IN unnest`) | After (`= ANY`) |
|---|---|---|
| Execution time | 901 ms | 11 ms |
| Join strategy | Merge Join — Index Only Scan on related table (1.4 M rows) | Nested Loop — 73 × Index Scan (~10 rows each) |
| Speedup | | **82×** |

`= ANY` gave the planner enough information to switch from Merge Join (which required
a full ordered scan of 1.4 M rows in a related table) to Nested Loop with targeted
index lookups, reducing rows read from ~1.4 M to ~730. This shows the improvement
reaches beyond the child table itself: accurate FK estimation affects join strategy
for the entire query.


## Checklist

- [x] `golangci-lint run` reports 0 issues
- [x] `gofumpt -l` reports no changes (changed files are `.tpl` only; flagged `.go` files are pre-existing and unrelated to this PR)
- [x] Generated code compiles and codegen tests pass — PostgreSQL (`pgx-v5-std`: assemble / generate / generate_with_aliases)
- [x] Generated code compiles and codegen tests pass — SQLite (`modernc` / `ncruces`: assemble / generate / generate_with_aliases)
- [x] PostgreSQL `EXPLAIN ANALYZE` confirms composite index is used and results are identical before/after (see benchmark above)
- [x] `./gen/...` unit tests pass