### PR TITLE
feat(dberrors): add PostgreSQL check constraint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Generated `dberrors` packages now include generic and per-table check-constraint errors for PostgreSQL, matched by constraint name for `pq` and `pgx` drivers. (thanks @keithbro-imx)
+
 ## [v0.46.0] - 2026-06-11
 
 ### Added

--- a/gen/bobgen-psql/templates/dberrors/bob_psql_blocks.bob.go.tpl
+++ b/gen/bobgen-psql/templates/dberrors/bob_psql_blocks.bob.go.tpl
@@ -23,3 +23,29 @@ func (e *UniqueConstraintError) Is(target error) bool {
 	{{end}}
 }
 {{end -}}
+
+{{- define "check_constraint_error_detection_method"}}
+func (e *CheckConstraintError) Is(target error) bool {
+	{{if eq $.Driver "github.com/lib/pq" "github.com/jackc/pgx/v5" "github.com/jackc/pgx/v5/stdlib"}}
+		{{$errType := ""}}
+		{{$constraintNameField := "ConstraintName"}}
+		{{if eq $.Driver "github.com/lib/pq"}}
+      {{$.Importer.Import "github.com/lib/pq"}}
+      {{$errType = "*pq.Error"}}
+      {{$constraintNameField = "Constraint"}}
+		{{else if hasPrefix "github.com/jackc/pgx/v5" $.Driver}}
+      {{$.Importer.Import "github.com/jackc/pgx/v5/pgconn"}}
+			{{$errType = "*pgconn.PgError"}}
+		{{else}}
+			panic("Unsupported driver {{$.Driver}} for CheckConstraintError detection")
+		{{end}}
+    err, ok := target.({{$errType}})
+    if !ok {
+      return false
+    }
+    return err.Code == "23514" && (e.s == "" || err.{{$constraintNameField}} == e.s)
+	{{else}}
+    return false
+	{{end}}
+}
+{{end -}}

--- a/gen/bobgen-psql/templates/dberrors/bob_psql_blocks.bob_test.go.tpl
+++ b/gen/bobgen-psql/templates/dberrors/bob_psql_blocks.bob_test.go.tpl
@@ -1,0 +1,69 @@
+{{- $hasChecks := false -}}
+{{- range $table := .Tables -}}
+{{- if $table.Constraints.Checks -}}{{- $hasChecks = true -}}{{- end -}}
+{{- end -}}
+{{if $hasChecks}}
+{{if or (eq $.Driver "github.com/lib/pq") (hasPrefix "github.com/jackc/pgx/v5" $.Driver)}}
+{{$.Importer.Import "errors"}}
+{{$.Importer.Import "testing"}}
+{{if eq $.Driver "github.com/lib/pq"}}
+{{$.Importer.Import "github.com/lib/pq"}}
+{{else}}
+{{$.Importer.Import "github.com/jackc/pgx/v5/pgconn"}}
+{{end}}
+
+func TestCheckConstraintErrors(t *testing.T) {
+	{{if eq $.Driver "github.com/lib/pq"}}
+	newCheckErr := func(code, constraintName string) error {
+		return &pq.Error{Code: pq.ErrorCode(code), Constraint: constraintName}
+	}
+	{{else}}
+	newCheckErr := func(code, constraintName string) error {
+		return &pgconn.PgError{Code: code, ConstraintName: constraintName}
+	}
+	{{end}}
+
+	checkErr := newCheckErr("23514", "some_constraint")
+	if !errors.Is(ErrCheckConstraint, checkErr) {
+		t.Fatal("expected ErrCheckConstraint to match check violation")
+	}
+	if !ErrCheckConstraint.Is(checkErr) {
+		t.Fatal("expected ErrCheckConstraint.Is to match check violation")
+	}
+
+	uniqueErr := newCheckErr("23505", "some_constraint")
+	if errors.Is(ErrCheckConstraint, uniqueErr) {
+		t.Fatal("expected ErrCheckConstraint not to match unique violation")
+	}
+	if ErrCheckConstraint.Is(uniqueErr) {
+		t.Fatal("expected ErrCheckConstraint.Is not to match unique violation")
+	}
+
+	{{range $table := .Tables}}
+	{{if $table.Constraints.Checks}}
+	{{$tAlias := $.Aliases.Table $table.Key}}
+	{{range $check := $table.Constraints.Checks}}
+	{{- $errName := printf "ErrCheck%s" ($check.Name | camelcase) -}}
+	t.Run("{{$tAlias.UpSingular}}_{{$errName}}", func(t *testing.T) {
+		matchingErr := newCheckErr("23514", {{printf "%q" $check.Name}})
+		if !errors.Is({{$tAlias.UpSingular}}Errors.{{$errName}}, matchingErr) {
+			t.Fatalf("expected {{$errName}} to match constraint %q", {{printf "%q" $check.Name}})
+		}
+		if !{{$tAlias.UpSingular}}Errors.{{$errName}}.Is(matchingErr) {
+			t.Fatalf("expected {{$errName}}.Is to match constraint %q", {{printf "%q" $check.Name}})
+		}
+
+		nonMatchingErr := newCheckErr("23514", "other_constraint")
+		if errors.Is({{$tAlias.UpSingular}}Errors.{{$errName}}, nonMatchingErr) {
+			t.Fatal("expected {{$errName}} not to match different constraint")
+		}
+		if {{$tAlias.UpSingular}}Errors.{{$errName}}.Is(nonMatchingErr) {
+			t.Fatal("expected {{$errName}}.Is not to match different constraint")
+		}
+	})
+	{{end}}
+	{{end}}
+	{{end}}
+}
+{{end}}
+{{end}}

--- a/gen/templates/dberrors/bob_errors.bob.go.tpl
+++ b/gen/templates/dberrors/bob_errors.bob.go.tpl
@@ -21,3 +21,27 @@ func (e *UniqueConstraintError) Is(target error) bool {
   return false
 }
 {{end}}
+
+// ErrCheckConstraint captures all check constraint errors by explicitly leaving `s` empty.
+var ErrCheckConstraint = &CheckConstraintError{s: ""}
+
+type CheckConstraintError struct {
+  // schema is the schema where the check constraint is defined.
+  schema string
+  // table is the name of the table where the check constraint is defined.
+  table string
+  // columns are the columns referenced by the check constraint.
+  columns []string
+	// s is a string uniquely identifying the constraint in the raw error message returned from the database.
+	s string
+}
+
+func (e *CheckConstraintError) Error() string {
+  return e.s
+}
+
+{{block "check_constraint_error_detection_method" . -}}
+func (e *CheckConstraintError) Is(target error) bool {
+  return false
+}
+{{end}}

--- a/gen/templates/dberrors/table/001_dberrors.bob.go.tpl
+++ b/gen/templates/dberrors/table/001_dberrors.bob.go.tpl
@@ -1,4 +1,4 @@
-{{if or .Table.Constraints.Uniques .Table.Constraints.Primary }}
+{{if or .Table.Constraints.Uniques .Table.Constraints.Primary .Table.Constraints.Checks }}
 {{- $table := .Table -}}
 {{- $tAlias := .Aliases.Table $table.Key -}}
 
@@ -20,6 +20,14 @@ var {{$tAlias.UpSingular}}Errors = &{{$tAlias.DownSingular}}Errors{
     s: "{{$index.Name}}",
   },
 	{{end}}
+	{{range $check := $table.Constraints.Checks}}
+	ErrCheck{{$check.Name | camelcase}}: &CheckConstraintError{
+    schema: {{printf "%q" $table.Schema}},
+    table: {{printf "%q" $table.Name}},
+    columns: {{printf "%#v" $check.Columns}},
+    s: {{printf "%q" $check.Name}},
+  },
+	{{end}}
 }
 
 type {{$tAlias.DownSingular}}Errors struct {
@@ -29,6 +37,9 @@ type {{$tAlias.DownSingular}}Errors struct {
   {{end}}
 	{{range $index := $table.Constraints.Uniques}}
 	ErrUnique{{$index.Name | camelcase}} *UniqueConstraintError
+	{{end}}
+	{{range $check := $table.Constraints.Checks}}
+	ErrCheck{{$check.Name | camelcase}} *CheckConstraintError
 	{{end}}
 }
 {{ end -}}

--- a/website/docs/code-generation/configuration.md
+++ b/website/docs/code-generation/configuration.md
@@ -21,7 +21,7 @@ When using the CLI, Bob loads several built-in plugins.
 - `enums`: Generates code for enums in a separate package, if there are any present.
 - `models`: Generates code for models. Depends on `enums`.
 - `factory`: Generates code for factories. Depends on `models`.
-- `dberrors`: Generates code for unique constraint errors. Depends on `models`.
+- `dberrors`: Generates code for unique and check constraint errors. Depends on `models`.
 - `where`: Adds templates to the `models` package to generate code for where clauses e.g `models.SelectWhere.Table.Where.Rel()`.
 - `loaders`: Adds templates to the `models` package to generate code for loaders e.g `models.SelectThenLoad.Table.Rel()`.
 - `joins`: Adds templates to the `models` package to generate code for joins e.g `models.SelectJoin.Table.LeftJoin.Rel`.

--- a/website/docs/code-generation/usage.md
+++ b/website/docs/code-generation/usage.md
@@ -245,6 +245,46 @@ if models.ErrUniqueConstraint.Is(err) {
 
 When using the `errors.Is()` variant, be mindful that the order of arguments matters due to Go's internal implementation. The first argument should be the error constant, while the second argument should be the actual error returned from the database. If you flip the arguments, the function won't work as intended and won't catch the unique constraint error.
 
+### Check Constraint Errors
+
+For tables with check constraints, Bob generates `CheckConstraintError` constants in the same `dberrors` package. On PostgreSQL, these match SQLSTATE `23514` by constraint name.
+
+Take the following database table, for example:
+
+```sql
+CREATE TABLE pilots (
+    id serial PRIMARY KEY NOT NULL,
+    age int NOT NULL,
+    CONSTRAINT pilots_age_positive CHECK (age > 0)
+);
+```
+
+Bob will define the following field inside the generated `pilotErrors` struct:
+
+```go
+type pilotErrors struct {
+    ErrCheckPilotsAgePositive *CheckConstraintError
+}
+```
+
+The error can be matched in the same ways as unique constraint errors:
+
+```go
+pilot, err := models.Pilots.Insert(setter).One(ctx, db)
+if errors.Is(dberrors.PilotErrors.ErrCheckPilotsAgePositive, err) {
+    // handle the error
+}
+```
+
+Bob also defines a generic `ErrCheckConstraint` constant for matching any check constraint violation:
+
+```go
+pilot, err := models.Pilots.Insert(setter).One(ctx, db)
+if errors.Is(dberrors.ErrCheckConstraint, err) {
+    // handle the error
+}
+```
+
 ## Query Building
 
 Several constants[^1] are also generated to help with query building. As with all queries built with [Bob's query builder](../query-builder/intro), the building blocks are expressions and mods.


### PR DESCRIPTION
## Summary

- Generate `CheckConstraintError` and per-table `ErrCheck...` constants from check constraints in the `dberrors` package
- Match PostgreSQL check violations (SQLSTATE `23514`) by constraint name for `pq` and `pgx` drivers
- Add synthetic generated tests and update code generation docs

## Why

Bob already generates typed errors for unique constraint violations, but check constraint violations were not covered. On PostgreSQL these surface as SQLSTATE `23514`, so callers had to match raw driver errors instead of using the same `errors.Is` pattern as unique constraints.

## Before / After

Before, the `dberrors` plugin only generated `UniqueConstraintError` constants. Check constraint violations from PostgreSQL had to be handled by inspecting raw `pq.Error` / `pgconn.PgError` values.

After this change, tables with check constraints get generated `ErrCheck{Name}` constants plus a generic `ErrCheckConstraint`, and PostgreSQL drivers match `23514` by constraint name. Unique constraint error generation and matching are unchanged.

## Test plan

- [x] `go test ./gen/bobgen-psql/driver`