### PR TITLE
Fix column order on sql query star type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed column_order on `*` selectors in sql queries in postgres
+
 ### Added
 
 - Added `bob.NextUniqueInt()` for generating unique SQL alias suffixes ([#719](https://github.com/stephenafamo/bob/issues/719)). (thanks @atzedus)

--- a/gen/bobgen-psql/driver/parser/parser.go
+++ b/gen/bobgen-psql/driver/parser/parser.go
@@ -20,12 +20,13 @@ import (
 
 var returningWithClauseRegex = regexp.MustCompile(`(?is)\breturning\s+with\s*\(`)
 
-func New(db *sql.DB, t tables, sharedSchema string, translator *Translator) *Parser {
+func New(db *sql.DB, t tables, sharedSchema string, translator *Translator, columnOrder string) *Parser {
 	return &Parser{
 		conn:         db,
 		db:           t,
 		sharedSchema: sharedSchema,
 		translator:   translator,
+		columnOrder:  columnOrder,
 	}
 }
 
@@ -34,6 +35,7 @@ type Parser struct {
 	db           tables
 	sharedSchema string
 	translator   *Translator
+	columnOrder  string
 }
 
 func (p *Parser) ParseFolders(ctx context.Context, paths ...string) ([]drivers.QueryFolder, error) {
@@ -73,11 +75,6 @@ func (p *Parser) ParseQueries(ctx context.Context, s string) ([]drivers.Query, e
 }
 
 func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, error) {
-	argTypes, resTypes, err := p.getArgsAndCols(ctx, input)
-	if err != nil {
-		return drivers.Query{}, fmt.Errorf("get args and cols: %w", err)
-	}
-
 	scanResult, err := pgparse.Scan(input)
 	if err != nil {
 		return drivers.Query{}, fmt.Errorf("scan: %w", err)
@@ -95,6 +92,7 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 	w := walker{
 		db:           p.db,
 		sharedSchema: p.sharedSchema,
+		columnOrder:  p.columnOrder,
 		input:        input,
 		tokens:       scanResult.GetTokens(),
 		mods:         &strings.Builder{},
@@ -139,17 +137,22 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 		return drivers.Query{}, errors.Join(w.errors...)
 	}
 
+	formatted, err := w.formattedQuery()
+	if err != nil {
+		return drivers.Query{}, fmt.Errorf("format: %w", err)
+	}
+
+	argTypes, resTypes, err := p.getArgsAndCols(ctx, formatted)
+	if err != nil {
+		return drivers.Query{}, fmt.Errorf("get args and cols: %w", err)
+	}
+
 	if len(source.columns) != len(resTypes) {
 		return drivers.Query{}, fmt.Errorf("expected %d columns, got %d", len(resTypes), len(source.columns))
 	}
 
 	if len(w.args) != len(argTypes) {
 		return drivers.Query{}, fmt.Errorf("expected %d args, got %d", len(resTypes), len(source.columns))
-	}
-
-	formatted, err := w.formattedQuery()
-	if err != nil {
-		return drivers.Query{}, fmt.Errorf("format: %w", err)
 	}
 
 	comment, err := w.getQueryComment(info.start)

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -538,12 +538,19 @@ func (w *walker) getStarColumns(target *pg.Node, info nodeInfo, prefix string, s
 			continue
 		}
 
-		columns = append(columns, source.columns...)
+		cols := source.columns
+		if w.columnOrder == "name" {
+			cols = slices.SortedFunc(slices.Values(cols), func(a, b col) int {
+				return strings.Compare(a.name, b.name)
+			})
+		}
+
+		columns = append(columns, cols...)
 
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		expandQuotedSource(buf, source, prefix)
+		expandQuotedSource(buf, queryResult{schema: source.schema, name: source.name, columns: cols}, prefix)
 		i++
 	}
 	w.editRules = append(

--- a/gen/bobgen-psql/driver/parser/walker.go
+++ b/gen/bobgen-psql/driver/parser/walker.go
@@ -78,6 +78,7 @@ type queryResult struct {
 type walker struct {
 	db           tables
 	sharedSchema string
+	columnOrder  string
 	names        map[position]string
 	nullability  map[position]nullable
 	groups       map[argPos]struct{}

--- a/gen/bobgen-psql/driver/psql.go
+++ b/gen/bobgen-psql/driver/psql.go
@@ -162,7 +162,7 @@ func (d *driver) Assemble(ctx context.Context) (*DBInfo, error) {
 		return dbinfo.Enums[i].Type < dbinfo.Enums[j].Type
 	})
 
-	dbinfo.QueryFolders, err = parser.New(d.conn, dbinfo.Tables, d.config.SharedSchema, d.translator).ParseFolders(ctx, d.config.Queries...)
+	dbinfo.QueryFolders, err = parser.New(d.conn, dbinfo.Tables, d.config.SharedSchema, d.translator, d.config.ColumnOrder).ParseFolders(ctx, d.config.Queries...)
 	if err != nil {
 		return nil, fmt.Errorf("parse query folders: %w", err)
 	}

--- a/gen/bobgen-psql/driver/psql_test.go
+++ b/gen/bobgen-psql/driver/psql_test.go
@@ -24,6 +24,13 @@ import (
 
 var flagOverwriteGolden = flag.Bool("overwrite-golden", false, "Overwrite the golden file with the current execution results")
 
+const columnOrderNameStarQuery = `-- GetUsersWithVideos
+SELECT
+  u.*,
+  v.id AS video_id
+FROM users AS u
+INNER JOIN videos AS v ON v.user_id = u.id;`
+
 func TestDriver(t *testing.T) {
 	postgresContainer, err := postgres.Run(
 		t.Context(), "pgvector/pgvector:0.8.0-pg16",
@@ -61,6 +68,7 @@ func TestDriver(t *testing.T) {
 
 	t.Run("driver", func(t *testing.T) { testPostgresDriver(t, dsn) })
 	t.Run("assemble", func(t *testing.T) { testPostgresAssemble(t, dsn) })
+	t.Run("column_order_name_star_types", func(t *testing.T) { testPostgresColumnOrderStarTypes(t, dsn) })
 }
 
 func testPostgresDriver(t *testing.T, dsn string) {
@@ -132,6 +140,65 @@ func testPostgresDriver(t *testing.T, dsn string) {
 				Dialect:         "psql",
 			})
 		})
+	}
+}
+
+func testPostgresColumnOrderStarTypes(t *testing.T, dsn string) {
+	t.Helper()
+
+	queryDir := t.TempDir()
+	if err := os.WriteFile(queryDir+"/joined.sql", []byte(columnOrderNameStarQuery), 0o600); err != nil {
+		t.Fatalf("write query file: %v", err)
+	}
+
+	drv := New(Config{
+		Config: helpers.Config{
+			Dsn:         dsn,
+			Queries:     []string{queryDir},
+			ColumnOrder: "name",
+		},
+		Schemas: []string{"public"},
+	})
+
+	info, err := drv.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+
+	var query drivers.Query
+	found := false
+	for _, folder := range info.QueryFolders {
+		for _, file := range folder.Files {
+			for _, q := range file.Queries {
+				if q.Name == "GetUsersWithVideos" {
+					query = q
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("query GetUsersWithVideos not found in assembled output")
+	}
+
+	colTypes := make(map[string]string, len(query.Columns))
+	for _, col := range query.Columns {
+		colTypes[col.Name] = col.TypeName
+	}
+
+	wantTypes := map[string]string{
+		"id":              "int32",
+		"email_validated": "bool",
+		"primary_email":   "string",
+		"parent_id":       "int32",
+		"party_id":        "int32",
+		"referrer":        "int32",
+		"video_id":        "int32",
+	}
+	for name, want := range wantTypes {
+		if got := colTypes[name]; got != want {
+			t.Errorf("column %s: type = %q, want %q", name, got, want)
+		}
 	}
 }
 

--- a/website/docs/code-generation/mysql.md
+++ b/website/docs/code-generation/mysql.md
@@ -39,13 +39,13 @@ MYSQL_DSN="user:pass@tcp(host:port)/dbname"
 
 The values that exist for the drivers:
 
-| Name        | Description                          | Default |
-| ----------- | ------------------------------------ | ------- |
-| dsn         | URL to connect to                    |         |
-| only        | Only generate these                  |         |
-| except      | Skip generation for these            |         |
-| queries     | Folders containing sql query files   |         |
-| concurrency  | How many tables to fetch in parallel | 10      |
+| Name         | Description                                                                                                      | Default   |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- | --------- |
+| dsn          | URL to connect to                                                                                                |           |
+| only         | Only generate these                                                                                              |           |
+| except       | Skip generation for these                                                                                        |           |
+| queries      | Folders containing sql query files                                                                               |           |
+| concurrency  | How many tables to fetch in parallel                                                                             | 10        |
 | column_order | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
 
 ## Only/Except:

--- a/website/docs/code-generation/psql.md
+++ b/website/docs/code-generation/psql.md
@@ -45,18 +45,18 @@ PSQL_DSN="postgres://user:pass@host:port/dbname?sslmode=disable"
 
 The values that exist for the drivers:
 
-| Name          | Description                                       | Default                  |
-| ------------- | ------------------------------------------------- | ------------------------ |
-| driver        | Driver to use for generating driver-specific code | `github.com/lib/pq`      |
-| dsn           | URL to connect to                                 |                          |
-| schemas       | Schemas find tables in                            | ["public"]               |
-| shared_schema | Schema to not include prefix in model             | first value in "schemas" |
-| uuid_pkg      | UUID package to use (gofrs or google)             | "gofrs"                  |
-| queries       | Folders containing sql query files                |                          |
-| only          | Only generate these                               |                          |
-| except        | Skip generation for these                         |                          |
-| concurrency   | How many tables to fetch in parallel              | 10                       |
-| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
+| Name          | Description                                                                                                      | Default                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| driver        | Driver to use for generating driver-specific code                                                                | `github.com/lib/pq`      |
+| dsn           | URL to connect to                                                                                                |                          |
+| schemas       | Schemas find tables in                                                                                           | ["public"]               |
+| shared_schema | Schema to not include prefix in model                                                                            | first value in "schemas" |
+| uuid_pkg      | UUID package to use (gofrs or google)                                                                            | "gofrs"                  |
+| queries       | Folders containing sql query files                                                                               |                          |
+| only          | Only generate these                                                                                              |                          |
+| except        | Skip generation for these                                                                                        |                          |
+| concurrency   | How many tables to fetch in parallel                                                                             | 10                       |
+| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal"                |
 
 ## Driver-specific code
 

--- a/website/docs/code-generation/sqlite.md
+++ b/website/docs/code-generation/sqlite.md
@@ -39,16 +39,16 @@ SQLITE_DSN="file.db"
 
 The values that exist for the drivers:
 
-| Name          | Description                                       | Default              |
-| ------------- | ------------------------------------------------- | -------------------- |
-| driver        | Driver to use for generating driver-specific code | `modernc.org/sqlite` |
-| dsn           | Path to database                                  |                      |
-| attach        | Schemas to attach and the path to the db          | map[string]string{}  |
-| shared_schema | Schema to not include prefix in model             | "main"               |
-| queries       | List of folders containing query files            | []string{}           |
-| only          | Only generate these                               |                      |
-| except        | Skip generation for these                         |                      |
-| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal" |
+| Name          | Description                                                                                                      | Default              |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------- |
+| driver        | Driver to use for generating driver-specific code                                                                | `modernc.org/sqlite` |
+| dsn           | Path to database                                                                                                 |                      |
+| attach        | Schemas to attach and the path to the db                                                                         | map[string]string{}  |
+| shared_schema | Schema to not include prefix in model                                                                            | "main"               |
+| queries       | List of folders containing query files                                                                           | []string{}           |
+| only          | Only generate these                                                                                              |                      |
+| except        | Skip generation for these                                                                                        |                      |
+| column_order  | Order of columns in generated models. `"name"` sorts alphabetically; `"ordinal"` preserves database column order | "ordinal"            |
 
 ## Driver-specific code
 


### PR DESCRIPTION
## Problem

When `column_order: "name"` is set, the psql driver sorts table columns
alphabetically in `w.db` before query parsing. Custom SQL queries using
`.*` (e.g. `SELECT u.* FROM users AS u`) expand the wildcard using that
sorted column list, producing `source.columns` in alphabetical order.

However, `getArgsAndCols` was called on the original SQL — before the
rewrite — so PostgreSQL's `PREPARE` expanded `.*` in ordinal (creation)
order and returned `result_types` in that order. The parser then zipped
`source.columns` (alphabetical) with `resTypes` (ordinal) by position,
assigning the wrong Go type and nullable status to each column.

## Fix

Thread `columnOrder` into the parser and walker. In `getStarColumns`,
sort the columns alphabetically before writing the SQL expansion when
`columnOrder` is `"name"` — so the rewritten SQL reflects the sorted
order. Move `getArgsAndCols` to run on the formatted (already-rewritten)
SQL rather than the original input. PostgreSQL then prepares the sorted
expansion and returns `result_types` in the same order as
`source.columns`, keeping the zip correct.

Also aligns `column_order` pipe widths in the psql, mysql, and sqlite
driver docs tables.

---
*🤖 Created by agent*