### PR TITLE
fix: replace randInt with bob.NextUniqueInt for join aliases (closes #719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `bob.NextUniqueInt()` for generating unique SQL alias suffixes ([#719](https://github.com/stephenafamo/bob/issues/719)). (thanks @atzedus)
+
+### Fixed
+
+- Fixed generated join alias suffixes using `randInt()`, which could produce negative values when `maphash.Hash.Sum64()` overflowed `int64` ([#719](https://github.com/stephenafamo/bob/issues/719)). Generated join mods now use `bob.NextUniqueInt()` instead. (thanks @atzedus)
+
 ## [v0.48.0] - 2026-06-26
 
 ### Changed

--- a/gen/templates/joins/bob_joins.bob.go.tpl
+++ b/gen/templates/joins/bob_joins.bob.go.tpl
@@ -62,13 +62,3 @@ func (m modAs[Q, C]) AliasedAs(alias string) bob.Mod[Q] {
   return m
 }
 
-{{$.Importer.Import "hash/maphash"}}
-func randInt() int64 {
-	out := int64(new(maphash.Hash).Sum64())
-
-	if out < 0 {
-		return -out % 10000
-	}
-
-	return out % 10000
-}

--- a/gen/templates/joins/table/120_joins.go.tpl
+++ b/gen/templates/joins/table/120_joins.go.tpl
@@ -28,7 +28,7 @@
           c: {{$fAlias.UpPlural}}.Columns,
           f: func(to {{$fAlias.DownSingular}}Columns) bob.Mod[Q] {
             {{if gt (len $rel.Sides) 1 -}}{{$.Importer.Import "strconv" -}}
-              random := strconv.FormatInt(randInt(), 10)
+              uniqueSuffix := strconv.FormatUint(bob.NextUniqueInt(), 10)
             {{- end}}
             mods := make(mods.QueryMods[Q], 0, {{len $rel.Sides}})
 
@@ -40,10 +40,10 @@
             {{- $toTable := $.Tables.Get $side.To -}}
             {
               {{if ne $index 0 -}}
-              cols := {{$fromCols}}.AliasedAs({{$fromCols}}.Alias() + random)
+              cols := {{$fromCols}}.AliasedAs({{$fromCols}}.Alias() + uniqueSuffix)
               {{end -}}
               {{if ne $index (sub (len $rel.Sides) 1) -}}
-              to := {{$toCols}}.AliasedAs({{$toCols}}.Alias() + random)
+              to := {{$toCols}}.AliasedAs({{$toCols}}.Alias() + uniqueSuffix)
               {{end -}}
               mods = append(mods, dialect.Join[Q](typ, {{$to.UpPlural}}.NameExpr().As(to.Alias())).On(
                   {{range $i, $local := $side.FromColumns -}}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"strings"
-	"sync/atomic"
 )
 
 func Pointer[T any](val T) *T {
@@ -50,13 +49,6 @@ func FilterNonZero[T comparable](s []T) []T {
 	}
 
 	return filtered
-}
-
-//nolint:gochecknoglobals
-var uniqueCounter int64
-
-func NextUniqueInt() int64 {
-	return atomic.AddInt64(&uniqueCounter, 1) + 10000
 }
 
 func SliceMatch[T comparable, Ts ~[]T](a, b Ts) bool {

--- a/orm/load.go
+++ b/orm/load.go
@@ -235,7 +235,7 @@ func Preload[T Preloadable, Ts ~[]T, E bob.Expression, Q PreloadableQuery](rel P
 		for i, side := range rel.Sides {
 			alias = settings.Alias
 			if settings.Alias == "" {
-				alias = fmt.Sprintf("%s_%d", side.To.Alias(), internal.NextUniqueInt())
+				alias = fmt.Sprintf("%s_%d", side.To.Alias(), bob.NextUniqueInt())
 			}
 			on := make([]bob.Expression, 0, len(side.FromColumns)+len(side.FromWhere)+len(side.ToWhere))
 			for i, fromCol := range side.FromColumns {

--- a/unique.go
+++ b/unique.go
@@ -1,0 +1,17 @@
+package bob
+
+import "sync/atomic"
+
+//nolint:gochecknoglobals
+var uniqueCounter atomic.Uint64
+
+// NextUniqueInt returns a unique positive integer suitable for SQL alias suffixes.
+// Values start at 10001 and increment. On uint64 overflow the counter restarts at 1.
+func NextUniqueInt() uint64 {
+	n := uniqueCounter.Add(1)
+	if n == 0 {
+		n = 1
+	}
+
+	return n + 10000
+}


### PR DESCRIPTION
Move NextUniqueInt from internal to bob as uint64 so generated join mods and preloaders share one counter without int64 overflow or collisions.