### PR TITLE
fix(orm): preserve Scanner in Query.Clone()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed generated join alias suffixes using `randInt()`, which could produce negative values when `maphash.Hash.Sum64()` overflowed `int64` ([#719](https://github.com/stephenafamo/bob/issues/719)). Generated join mods now use `bob.NextUniqueInt()` instead. (thanks @atzedus)
+- Fixed `orm.Query.Clone()` dropping the `Scanner`, which made `All`/`One`/`Cursor`/`Each` on a cloned query panic with a nil pointer dereference. (thanks @sandonemaki)
 
 ## [v0.48.0] - 2026-06-26
 

--- a/orm/query.go
+++ b/orm/query.go
@@ -56,6 +56,7 @@ type Query[Q bob.Expression, T, Ts any, Tr bob.Transformer[T, Ts]] struct {
 func (q Query[Q, T, Ts, Tr]) Clone() Query[Q, T, Ts, Tr] {
 	return Query[Q, T, Ts, Tr]{
 		ExecQuery: q.ExecQuery.Clone(),
+		Scanner:   q.Scanner,
 	}
 }
 

--- a/orm/query_test.go
+++ b/orm/query_test.go
@@ -161,3 +161,21 @@ func TestModQueryWithPreservesScanner(t *testing.T) {
 		t.Fatal("With() did not preserve the original scanner")
 	}
 }
+
+func TestQueryClonePreservesScanner(t *testing.T) {
+	scannerCalled := false
+	scanner := func(context.Context, []string) (func(*scan.Row) (any, error), func(any) (int, error)) {
+		scannerCalled = true
+		return nil, nil
+	}
+
+	cloned := newModQuery(scanner).Query.Clone()
+	if cloned.Scanner == nil {
+		t.Fatal("Clone() dropped the scanner")
+	}
+
+	cloned.Scanner(context.Background(), nil)
+	if !scannerCalled {
+		t.Fatal("Clone() did not preserve the original scanner")
+	}
+}


### PR DESCRIPTION
## Summary

`orm.Query.Clone()` only clones the embedded `ExecQuery` and never copies `Scanner`,
so any cloned query has a nil scanner and `All`/`One`/`Cursor`/`Each` panic:

    q := models.Users.Query()
    cloned := q.Query.Clone()
    _, err := cloned.All(ctx, exec) // panic: invalid memory address or nil pointer dereference

## Fix

Copy the `Scanner` in `Clone()` (one line), and add a regression test
(`TestQueryClonePreservesScanner`) mirroring the existing
`TestModQueryWithPreservesScanner`. The test fails on `main` and passes with the fix.

Noticed while working on #715: with the mapper flowing through `q.Scanner`,
a clone silently dropping it is easier to hit than before.