### PR TITLE
perf(orm): drop reflection from AfterPreloader collect/load path

### DIFF
--- a/orm/load.go
+++ b/orm/load.go
@@ -120,13 +120,29 @@ func (l Preloader[Q]) ModifyPreloadSettings(s *PreloadSettings[Q]) {
 	s.SubLoaders = append(s.SubLoaders, l)
 }
 
-// NewAfterPreloader returns a new AfterPreloader based on the given types
+// NewAfterPreloader returns a new AfterPreloader based on the given types.
+// The type parameters are captured in closures so that collecting and
+// assembling the loaded objects needs no reflection at load time.
 func NewAfterPreloader[T any, Ts ~[]T]() *AfterPreloader {
-	var one T
-	var slice Ts
+	var collected Ts
 	return &AfterPreloader{
-		oneType:   reflect.TypeOf(one),
-		sliceType: reflect.TypeOf(slice),
+		appendCollected: func(v any) error {
+			t, ok := v.(T)
+			if !ok {
+				return fmt.Errorf("expected to receive %T but got %T", *new(T), v)
+			}
+			collected = append(collected, t)
+			return nil
+		},
+		numCollected: func() int { return len(collected) },
+		toLoad: func() any {
+			// a single object is passed as-is (T); many are passed as the
+			// slice (Ts), matching the reflection-based implementation.
+			if len(collected) == 1 {
+				return collected[0]
+			}
+			return collected
+		},
 	}
 }
 
@@ -136,11 +152,12 @@ func NewAfterPreloader[T any, Ts ~[]T]() *AfterPreloader {
 // later, when this object is called like any other [bob.Loader], it
 // calls the appended loaders with the collected objects
 type AfterPreloader struct {
-	oneType   reflect.Type
-	sliceType reflect.Type
+	funcs []bob.Loader
 
-	funcs     []bob.Loader
-	collected []any
+	// typed helpers set by [NewAfterPreloader]; they close over a Ts buffer
+	appendCollected func(any) error
+	numCollected    func() int
+	toLoad          func() any
 }
 
 func (a *AfterPreloader) AppendLoader(fs ...bob.Loader) {
@@ -152,29 +169,15 @@ func (a *AfterPreloader) Collect(v any) error {
 		return nil
 	}
 
-	if reflect.TypeOf(v) != a.oneType {
-		return fmt.Errorf("expected to receive %s but got %T", a.oneType.String(), v)
-	}
-
-	a.collected = append(a.collected, v)
-	return nil
+	return a.appendCollected(v)
 }
 
 func (a *AfterPreloader) Load(ctx context.Context, exec bob.Executor, _ any) error {
-	if len(a.collected) == 0 || len(a.funcs) == 0 {
+	if len(a.funcs) == 0 || a.numCollected() == 0 {
 		return nil
 	}
 
-	obj := a.collected[0]
-
-	if len(a.collected) > 1 {
-		all := reflect.MakeSlice(a.sliceType, len(a.collected), len(a.collected))
-		for k, v := range a.collected {
-			all.Index(k).Set(reflect.ValueOf(v))
-		}
-
-		obj = all.Interface()
-	}
+	obj := a.toLoad()
 
 	for _, f := range a.funcs {
 		if err := f.Load(ctx, exec, obj); err != nil {

--- a/orm/load_preload_test.go
+++ b/orm/load_preload_test.go
@@ -231,6 +231,39 @@ func TestPreloadMapperParity(t *testing.T) {
 	}
 }
 
+// BenchmarkAfterPreloader isolates the AfterPreloader collect/load path: N
+// per-row Collect calls followed by one Load that assembles the collected
+// objects for the sub-loaders. A no-op sub-loader is appended so Collect and
+// Load do not short-circuit on an empty func list.
+func BenchmarkAfterPreloader(b *testing.B) {
+	children := make([]*testPreloadChild, 10000)
+	for i := range children {
+		children[i] = &testPreloadChild{
+			ID:   int64(i),
+			Name: sql.Null[string]{V: fmt.Sprintf("name-%d", i), Valid: true},
+		}
+	}
+	noop := bob.LoaderFunc(func(context.Context, bob.Executor, any) error { return nil })
+
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				ap := NewAfterPreloader[*testPreloadChild, testPreloadChildSlice]()
+				ap.AppendLoader(noop)
+				for _, c := range children[:n] {
+					if err := ap.Collect(c); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := ap.Load(context.Background(), nil, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkPreloadMapper(b *testing.B) {
 	cols := []string{"id", "c.id", "c.name"}
 


### PR DESCRIPTION
## Summary

Removes reflection from the preload `AfterPreloader` collect/load path.

`AfterPreloader` gathers the objects loaded for a to-one preload and hands
them to the extra loaders. It used to accumulate them in a `[]any`, store the
element/slice `reflect.Type`, and at load time rebuild the typed slice with
`reflect.MakeSlice` + per-element `reflect.ValueOf(...).Set(...)`; every
`Collect` also ran a `reflect.TypeOf(v)` comparison.

`NewAfterPreloader[T, Ts]` now captures its type parameters in closures over a
typed `Ts` buffer, so collecting and assembling the loaded objects needs no
reflection.

## Changes

- `NewAfterPreloader[T, Ts]` builds three closures over a `Ts` buffer:
  - `appendCollected` — type-asserts `v.(T)` and appends (replaces the per-object `reflect.TypeOf` compare in `Collect`)
  - `numCollected` — buffer length
  - `toLoad` — returns the single `T` when one object was collected, else the `Ts` slice (same shape the reflection path produced)
- Drop the `oneType` / `sliceType` `reflect.Type` fields and the `collected []any` buffer
- Add `BenchmarkAfterPreloader` isolating the collect/load path

Behaviour is unchanged: a type mismatch in `Collect` still errors, and one
collected object is passed as `T` while many are passed as `Ts`.

## Performance

`BenchmarkAfterPreloader`, base (`preload-typed-maper`) → this branch:

```
n=100     1481 ns → 591 ns   (2.5x)    5480 B → 2304 B   (-58%)
n=1000   11450 ns → 3692 ns  (3.1x)   43496 B → 17664 B  (-59%)
n=10000 143900 ns → 53550 ns (2.7x)  748010 B → 310529 B (-58%)
```

~2.5–3.1× faster and ~58% less memory. Alloc count rises by a fixed +2 per
preloader (the closures), independent of row count.

## Notes

- Base branch: `preload-typed-maper` (will retarget to `main` after the base is merged)
- Only `orm/load.go` (+ the new benchmark) changes; no templates are touched, so there is nothing to regenerate for this PR

## Checklist

- [x] Existing tests pass (`go test ./orm/...`)
- [x] Benchmarks confirm the improvement