### PR TITLE
perf(gen): scan through-mapper key columns by index, not by name

### DIFF
--- a/gen/templates/loaders/table/110_loaders.go.tpl
+++ b/gen/templates/loaders/table/110_loaders.go.tpl
@@ -410,13 +410,33 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 
 	{{$.Importer.Import "github.com/stephenafamo/scan" -}}
   mapper := scan.Mod(scan.StructMapper[*{{$fAlias.UpSingular}}](), func(ctx context.Context, cols []string) (scan.BeforeFunc, func(any, any) error) {
+    // Resolve each joined key column name to its index once per query. The
+    // previous code scanned by name on every row, which meant a linear column
+    // search per row; the columns are added by this loader so they are always
+    // present, but an unselected column simply stays unresolved and is skipped.
+    {{range $index, $local := $firstSide.FromColumns -}}
+      {{- $fromColAlias := index $firstFrom.Columns $local -}}
+    {{$fromColAlias}}Idx := -1
+    {{end -}}
+    for i, col := range cols {
+      switch col {
+      {{range $index, $local := $firstSide.FromColumns -}}
+        {{- $fromColAlias := index $firstFrom.Columns $local -}}
+      case "related_{{$firstSide.From}}.{{$fromColAlias}}":
+        {{$fromColAlias}}Idx = i
+      {{end -}}
+      }
+    }
+
     return func(row *scan.Row) (any, error) {
       {{range $index, $local := $firstSide.FromColumns -}}
         {{- $fromColAlias := index $firstFrom.Columns $local -}}
         {{- $fromCol := $.Tables.GetColumn $firstSide.From $local -}}
         {{- $fromTyp := $.Types.Get $.CurrentPackage $.Importer $fromCol.Type -}}
         {{$fromColAlias}}Slice = append({{$fromColAlias}}Slice, *new({{$fromTyp}}))
-        row.ScheduleScanByName("related_{{$firstSide.From}}.{{$fromColAlias}}", &{{$fromColAlias}}Slice[len({{$fromColAlias}}Slice)-1])
+        if {{$fromColAlias}}Idx >= 0 {
+          row.ScheduleScanByIndex({{$fromColAlias}}Idx, &{{$fromColAlias}}Slice[len({{$fromColAlias}}Slice)-1])
+        }
       {{end}}
 
       return nil, nil


### PR DESCRIPTION
## Summary

Switches the bob-generated slice-relationship loaders (the 110 template) from
name-based to index-based column scanning.

The generated loaders schedule the joined key columns
(`related_<table>.<col>`) with `row.ScheduleScanByName` inside the per-row
callback. `ScheduleScanByName` does a linear scan of the result column list on
every call (`scan`'s `row.go`), so a load of N rows with C selected columns pays
O(N×C) just resolving column names — the same lookup repeated every row.

This resolves each key column's index **once per query** and scans by index on
each row, matching the index-based approach already used by the generated
struct/preload mappers (003 / 105 templates).

## Changes

- `gen/templates/loaders/table/110_loaders.go.tpl`: in the slice loader's
  mapper, resolve each `related_<table>.<col>` name to its column index once
  (single pass over `cols`), then use `row.ScheduleScanByIndex` per row instead
  of `row.ScheduleScanByName`.

Generated code goes from:

```go
return func(row *scan.Row) (any, error) {
    IDSlice = append(IDSlice, *new(int64))
    row.ScheduleScanByName("related_tags.ID", &IDSlice[len(IDSlice)-1])
    return nil, nil
}
```

to:

```go
IDIdx := -1
for i, col := range cols {
    switch col {
    case "related_tags.ID":
        IDIdx = i
    }
}
return func(row *scan.Row) (any, error) {
    IDSlice = append(IDSlice, *new(int64))
    if IDIdx >= 0 {
        row.ScheduleScanByIndex(IDIdx, &IDSlice[len(IDSlice)-1])
    }
    return nil, nil
}
```

## Performance

Column resolution drops from O(rows × columns) to O(columns) per query — the
per-row linear column-name search is eliminated. The key columns are added by
the loader itself, so they are always present; an unresolved column is simply
skipped (same semantics as the index-based 003/105 mappers).

## Verification

- `go build ./gen/...`
- `go test ./gen/bobgen-sqlite/driver/ -run TestSQLite` (full generate + `go build`
  of the generated models) passes
- Inspected the generated output: the through-mapper resolves the index once
  and scans via `ScheduleScanByIndex`; no `ScheduleScanByName` remains

## Notes

- Branch cut from `main`; independent of the `preload-typed-maper` stack (the
  edited region — the per-row key-column scan — is identical on both). Expect a
  trivial conflict at the mapper's opening line if both land, where that branch
  changes `scan.StructMapper[...]` to `q.Scanner`.
- Related: `stephenafamo/scan` column-index caching (scan#8)

## Checklist

- [x] Regenerated code compiles (`TestSQLite` generate + build)
- [x] Existing tests pass