### PR TITLE
perf(gen): reuse the preload child scan buffer across rows

### DIFF
--- a/gen/templates/loaders/table/105_preload_mapper.go.tpl
+++ b/gen/templates/loaders/table/105_preload_mapper.go.tpl
@@ -50,8 +50,14 @@ func {{$tAlias.DownSingular}}ScanMapperNullable(prefix string) scan.Mapper[*{{$t
 			}
 		}
 
+		// One scratch buffer reused for every row: before -> scan -> after runs
+		// synchronously per row, the scheduled columns are fully overwritten each
+		// row, and unselected columns stay zero, so a single buffer preserves the
+		// per-row NULL semantics without allocating a buffer per parent row. The
+		// returned child (o below) is always freshly allocated, so buf never
+		// escapes past the after func.
+		buf := new({{$tAlias.DownSingular}}PreloadBuf)
 		return func(row *scan.Row) (any, error) {
-			buf := new({{$tAlias.DownSingular}}PreloadBuf)
 			for _, t := range targets {
 				row.ScheduleScanByIndex(t.idx, t.dst(buf))
 			}

--- a/orm/load_preload_test.go
+++ b/orm/load_preload_test.go
@@ -85,8 +85,8 @@ func testPreloadChildMapper(prefix string) scan.Mapper[*testPreloadChild] {
 			}
 		}
 
+		buf := new(childBuf)
 		return func(row *scan.Row) (any, error) {
-				buf := new(childBuf)
 				for _, t := range targets {
 					row.ScheduleScanByIndex(t.idx, t.dst(buf))
 				}


### PR DESCRIPTION
## Summary

The generated `<table>ScanMapperNullable` (added in #725) allocates its
`PreloadBuf` scratch struct with `new(...)` **inside the per-row `before`
func** — one heap allocation per parent row, LEFT JOIN misses included.

The buffer is pure scratch. Per row the sequence `before -> scan -> after` runs
synchronously; the scheduled columns are fully overwritten by `Scan` every row,
and unselected columns are never scheduled so they stay zero for the whole
query. A single query-scoped buffer therefore preserves the exact per-row NULL
semantics. This hoists `buf` out of `before` and reuses it. The returned child
`o` is still freshly `new(T)`, so `buf` never escapes past `after`.

## Changes

- `gen/templates/loaders/table/105_preload_mapper.go.tpl`: allocate `buf` once
  in the mapper setup (query scope) instead of per row in `before`.
- `orm/load_preload_test.go`: mirror the same hoist in the hand-written
  `testPreloadChildMapper` so `TestPreloadMapperParity` runs the reused-buffer
  shape.

## Performance

`BenchmarkPreloadMapper/typed`, `main` → this branch:

```
n=100     622 -> 523 allocs   28056 -> 23320 B (-17%)   18.3µs -> 16.4µs
n=1000   6025 -> 5026 allocs  266617 -> 218680 B (-18%) 177µs -> 160µs
n=10000 60032 -> 50033 allocs 2.79MB -> 2.31MB (-17%)   2.02ms -> 1.78ms
```

Exactly one fewer allocation per parent row; ~17% less memory, ~10–12% faster.

## Verification

- `go test ./orm/...` — `TestPreloadMapperParity` (matched / all-NULL miss /
  partial NULL / column subset) passes, confirming buffer reuse preserves the
  LEFT JOIN NULL/no-child semantics.
- `go test ./gen/bobgen-sqlite/driver/ -run TestSQLite` — full generate +
  `go build` + generated tests pass.
- Inspected generated output: `buf` is allocated once per query, outside the
  per-row `before`.

## Notes

- Branch cut from `main` (after #725 merged); independent of the open #726/#727.

## Checklist

- [x] Regenerated code, diff reviewed
- [x] Existing tests pass
- [x] Benchmarks confirm the improvement