### PR TITLE
perf(gen): stitch copyMatchingRows via a map keyed by the primary key (O(N×M) → O(N+M))

### DIFF
--- a/gen/templates/models/table/007_slice_methods.go.tpl
+++ b/gen/templates/models/table/007_slice_methods.go.tpl
@@ -49,10 +49,33 @@ func (o {{$tAlias.UpSingular}}Slice) pkIN() dialect.Expression {
     }))
 }
 
+{{/* A single ==-comparable primary key column is matched in O(N+M) via a map;
+     composite keys and custom compare_expr types fall back to the nested loop. */ -}}
+{{- $pkCol := index $pkCols 0 -}}
+{{- $useMap := and (not $multiPK) ($.Types.CanCompareWithEquals $.CurrentPackage ($table.GetColumn $pkCol).Type)}}
 // copyMatchingRows finds models in the given slice that have the same primary key
 // then it first copies the existing relationships from the old model to the new model
 // and then replaces the old model in the slice with the new model
 func (o {{$tAlias.UpSingular}}Slice) copyMatchingRows(from ...*{{$tAlias.UpSingular}}) {
+  {{if $useMap -}}
+  {{$colAlias := $tAlias.Column $pkCol -}}
+  fromByPK := make(map[{{$.Types.Get $.CurrentPackage $.Importer ($table.GetColumn $pkCol).Type}}]*{{$tAlias.UpSingular}}, len(from))
+  for _, new := range from {
+    // keep the first row for each key, like the nested loop did
+    if _, ok := fromByPK[new.{{$colAlias}}]; !ok {
+      fromByPK[new.{{$colAlias}}] = new
+    }
+  }
+
+  for i, old := range o {
+    new, ok := fromByPK[old.{{$colAlias}}]
+    if !ok {
+      continue
+    }
+    {{if $.Relationships.Get $table.Key}}new.R = old.R{{end}}
+    o[i] = new
+  }
+  {{- else -}}
   for i, old := range o {
     for _, new := range from {
 			{{range $column := $table.Constraints.Primary.Columns -}}
@@ -73,6 +96,7 @@ func (o {{$tAlias.UpSingular}}Slice) copyMatchingRows(from ...*{{$tAlias.UpSingu
       break
     }
   }
+  {{- end}}
 }
 
 


### PR DESCRIPTION
## Summary

The generated `copyMatchingRows` — used by `UpdateAll`, `DeleteAll`, `ReloadAll`
and `MergeMod` to stitch the `RETURNING` rows back into the original slice while
preserving each model's `R` relationships — matches every slice element against
every returned row in a nested loop:

```go
for i, old := range o {
    for _, new := range from {
        if new.ID != old.ID { continue }
        new.R = old.R
        o[i] = new
        break
    }
}
```

That is O(N×M) primary-key comparisons. A 5,000-row `UpdateAll` performs
~25 million comparisons (~26ms of pure CPU) just to match rows it already has.

This applies the same map-stitch approach as the relationship loaders (#706):
when the table has a single primary key column whose type is comparable with
`==`, build a `map[PK]*Model` from the returned rows once and match each slice
element with a single lookup — O(N+M).

## Changes

- `gen/templates/models/table/007_slice_methods.go.tpl`: when the primary key
  is a single column and `CanCompareWithEquals` reports it is usable as a map
  key, generate the map-based match. Composite primary keys and custom
  `compare_expr` types keep the previous nested loop (the same gating as the
  loader map-stitch in #706).
- The map keeps the **first** returned row per key, matching the nested loop's
  `break` semantics exactly; `new.R = old.R` and `o[i] = new` are unchanged.
- `CHANGELOG.md` entry under Unreleased → Changed.

Generated code goes from the nested loop above to:

```go
fromByPK := make(map[int64]*Sponsor, len(from))
for _, new := range from {
    // keep the first row for each key, like the nested loop did
    if _, ok := fromByPK[new.ID]; !ok {
        fromByPK[new.ID] = new
    }
}

for i, old := range o {
    new, ok := fromByPK[old.ID]
    if !ok {
        continue
    }
    new.R = old.R
    o[i] = new
}
```

Tables with composite primary keys (e.g. `video_tags`) still generate the
previous nested loop.

## Performance

Standalone benchmark of the two generated shapes (N slice rows matched against
M=N returned rows, returned in reverse order):

| N=M | nested loop (before) | map (after) | speedup |
|---|---|---|---|
| 100 | 4.5µs | 20µs | 0.22× |
| 1,000 | 411µs | 215µs | 1.9× |
| 5,000 | 26.1ms | 1.1ms | **23×** |

At small N the map allocation makes it slightly slower in absolute terms
(+16µs at N=100), which is negligible next to the round-trip of the
`UPDATE ... RETURNING` that always precedes it; the nested loop's cost grows
quadratically while the map stays linear. This is the same trade-off already
accepted for the loader map-stitch in #706.

## Testing

- `go test ./gen/bobgen-psql/driver` — passes (generates, compiles and runs
  the generated tests against a real PostgreSQL container)
- `go test ./gen/bobgen-sqlite/driver` — modernc passes; verified both output
  shapes are emitted (map for single-column PKs, nested-loop fallback for the
  composite-key `video_tags`)