### PR TITLE
fix(gen): don't import a type's package when only optional expressions use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an unused type import (e.g. `github.com/google/uuid`) in generated models when the type is only referenced through optional wrapper expressions, such as m2m relationship helpers for a join table with a `uuid` column ([#730](https://github.com/stephenafamo/bob/issues/730)).
 - Fixed the counts plugin's generated `C` field reusing the `relation_tag` struct tag, which collided with the relations `R` field and caused `encoding/json` to drop both fields when a real tag name was configured. The `C` field now uses a dedicated `relation_tag_count` config option (default `"-"`). (thanks @jacobmolby)
 - Fixed generated join alias suffixes using `randInt()`, which could produce negative values when `maphash.Hash.Sum64()` overflowed `int64` ([#719](https://github.com/stephenafamo/bob/issues/719)). Generated join mods now use `bob.NextUniqueInt()` instead. (thanks @atzedus)
 - Fixed `orm.Query.Clone()` dropping the `Scanner`, which made `All`/`One`/`Cursor`/`Each` on a cloned query panic with a nil pointer dereference. (thanks @sandonemaki)

--- a/gen/bobgen-psql/driver/gen_unused_import_test.go
+++ b/gen/bobgen-psql/driver/gen_unused_import_test.go
@@ -1,0 +1,146 @@
+package driver_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephenafamo/bob/gen"
+	helpers "github.com/stephenafamo/bob/gen/bobgen-helpers"
+	driver "github.com/stephenafamo/bob/gen/bobgen-psql/driver"
+	"github.com/stephenafamo/bob/gen/drivers"
+	"github.com/stephenafamo/bob/gen/plugins"
+)
+
+type stubDriver struct {
+	types drivers.Types
+	info  *drivers.DBInfo[any, any, driver.IndexExtra]
+}
+
+func (s stubDriver) Dialect() string      { return "psql" }
+func (s stubDriver) Types() drivers.Types { return s.types }
+func (s stubDriver) Assemble(context.Context) (*drivers.DBInfo[any, any, driver.IndexExtra], error) {
+	return s.info, nil
+}
+
+func col(name, dbType, goType string) drivers.Column {
+	return drivers.Column{Name: name, DBType: dbType, Type: goType}
+}
+
+// Mirrors issue #730: a table with no UUID columns must not import the uuid
+// package in its generated model file, even when uuid_pkg is configured and
+// other tables use UUIDs.
+func TestScalarTableModelHasNoUUIDImport(t *testing.T) {
+	types := helpers.Types()
+	types.Register("uuid.UUID", drivers.Type{
+		Imports:    []string{`"github.com/google/uuid"`},
+		RandomExpr: `return uuid.New()`,
+	})
+
+	info := &drivers.DBInfo[any, any, driver.IndexExtra]{
+		Driver: "github.com/jackc/pgx/v5/stdlib",
+		Tables: drivers.Tables[any, driver.IndexExtra]{
+			{
+				Key:  "sample_table",
+				Name: "sample_table",
+				Columns: []drivers.Column{
+					col("id", "integer", "int32"),
+					col("parent_id", "integer", "int32"),
+					col("label_id", "integer", "int32"),
+					col("enabled", "boolean", "bool"),
+				},
+				Constraints: drivers.Constraints[any]{
+					Primary: &drivers.Constraint[any]{Name: "sample_table_pkey", Columns: []string{"id"}},
+				},
+			},
+			{
+				Key:  "tags",
+				Name: "tags",
+				Columns: []drivers.Column{
+					col("id", "uuid", "uuid.UUID"),
+					col("name", "text", "string"),
+				},
+				Constraints: drivers.Constraints[any]{
+					Primary: &drivers.Constraint[any]{Name: "tags_pkey", Columns: []string{"id"}},
+				},
+			},
+			{
+				Key:  "sample_tags",
+				Name: "sample_tags",
+				Columns: []drivers.Column{
+					col("sample_id", "integer", "int32"),
+					col("tag_id", "uuid", "uuid.UUID"),
+				},
+				Constraints: drivers.Constraints[any]{
+					Primary: &drivers.Constraint[any]{Name: "sample_tags_pkey", Columns: []string{"sample_id", "tag_id"}},
+					Foreign: []drivers.ForeignKey[any]{
+						{
+							Constraint:     drivers.Constraint[any]{Name: "sample_tags_sample_id_fkey", Columns: []string{"sample_id"}},
+							ForeignTable:   "sample_table",
+							ForeignColumns: []string{"id"},
+						},
+						{
+							Constraint:     drivers.Constraint[any]{Name: "sample_tags_tag_id_fkey", Columns: []string{"tag_id"}},
+							ForeignTable:   "tags",
+							ForeignColumns: []string{"id"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp := t.TempDir()
+	gomod := "module scratch.local/repro\n\ngo 1.24\n"
+	if err := os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(gomod), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	outputPlugins := plugins.Setup[any, any, driver.IndexExtra](
+		plugins.PresetAll, gen.PSQLTemplates,
+	)
+
+	state := &gen.State[any]{Config: gen.Config[any]{}}
+	if err := gen.Run[any, any, driver.IndexExtra](
+		context.Background(), state, stubDriver{types: types, info: info}, outputPlugins...,
+	); err != nil {
+		t.Fatalf("gen.Run: %v", err)
+	}
+
+	var checked int
+	err = filepath.WalkDir(tmp, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(tmp, path)
+		if strings.Contains(rel, "sample_table") {
+			checked++
+			if strings.Contains(string(b), "github.com/google/uuid") &&
+				!strings.Contains(string(b), "uuid.") {
+				t.Errorf("%s imports github.com/google/uuid but never uses it", rel)
+			}
+			t.Logf("checked %s (%d bytes)", rel, len(b))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checked == 0 {
+		t.Fatal("no sample_table files were generated/checked")
+	}
+}

--- a/gen/drivers/types.go
+++ b/gen/drivers/types.go
@@ -351,7 +351,9 @@ func (t Types) FromOptional(currentPkg string, i language.Importer, forType, var
 	colTyp, _ := t.GetNameAndDef(currentPkg, forType)
 	optTyp, imports := t.getOptional(currentPkg, forType, isNull, fromOrToNull)
 	nullTyp := t.GetNullType(currentPkg, forType)
-	i.ImportList(imports)
+	if exprNamesType(optTyp.UseExpr) {
+		i.ImportList(imports)
+	}
 	i.ImportList(optTyp.UseExprImports)
 	return strings.NewReplacer(
 		"SRC", varName,
@@ -365,7 +367,9 @@ func (t Types) ToOptional(currentPkg string, i language.Importer, forType, varNa
 	colTyp, _ := t.GetNameAndDef(currentPkg, forType)
 	optTyp, imports := t.getOptional(currentPkg, forType, isNull, fromOrToNull)
 	nullTyp := t.GetNullType(currentPkg, forType)
-	i.ImportList(imports)
+	if exprNamesType(optTyp.CreateExpr) {
+		i.ImportList(imports)
+	}
 	i.ImportList(optTyp.CreateExprImports)
 	return strings.NewReplacer(
 		"SRC", varName,
@@ -373,6 +377,17 @@ func (t Types) ToOptional(currentPkg string, i language.Importer, forType, varNa
 		"BASETYPE", colTyp,
 		"OPTIONALTYPE", optTyp.Name,
 	).Replace(optTyp.CreateExpr)
+}
+
+// exprNamesType reports whether an optional/null expression template writes a
+// type name into the generated code. Expressions like `omit.From(SRC)` only
+// reference the wrapped value, so the base type's imports are not needed for
+// them; expressions like `func () *BASETYPE {...}` or `NULLTYPE{V: SRC}` spell
+// out a type name and do need them.
+func exprNamesType(expr string) bool {
+	return strings.Contains(expr, "BASETYPE") ||
+		strings.Contains(expr, "NULLTYPE") ||
+		strings.Contains(expr, "OPTIONALTYPE")
 }
 
 var _ TypeModifier = AarondlNull{}


### PR DESCRIPTION
Fixes #730.

**Symptom.** Generating models for a table with no UUID columns emits `import "github.com/google/uuid"` in that table's `*.bob.go` model file with zero uses, so `go build` fails with `imported and not used`.

**Trigger.** The minimal `sample_table` from the issue reproduces this once it participates in an m2m relationship whose join table carries a `uuid` column (e.g. `sample_tags(sample_id int, tag_id uuid)` → `tags(id uuid)`), which matches the reporter's real schema (their generated file also imports `fmt`/`strconv`, which only relationship templates add).

**Root cause.** `Types.ToOptional` / `Types.FromOptional` unconditionally import the base type's `Imports` alongside the wrapper package. But these helpers render *expressions*, not type names: the m2m relationship ops in `011_rel_ops.go.tpl` emit `TagID: omit.From(tags[i].ID)` for the through table's columns — the expression never names `uuid.UUID`, yet the uuid package got imported into the local table's file. Tables whose own columns use the type never notice (the import is genuinely used there); tables that only *relate through* such a type get the unused import.

**Fix.** Import the base type's packages in `ToOptional`/`FromOptional` only when the expression template actually writes a type name into the generated code (contains a `BASETYPE`/`NULLTYPE`/`OPTIONALTYPE` placeholder). Pointer mode (`func () *BASETYPE {...}`) and `database/sql` null mode (`NULLTYPE{V: SRC, ...}`) keep their imports; `omit`/`omitnull`/`null` expressions carry their own `CreateExprImports`/`UseExprImports` already. Same conditional-import approach as #666 used for the factory random template.

**Known boundary.** A config-registered custom type whose `NullType` expressions hardcode a package-qualified name (instead of using the `NULLTYPE` placeholder) while declaring that package only in the base `imports` would now skip that import in optional expressions; nothing in-tree or in the documented config style does this (expression imports belong in `*_expr_imports`), but flagging it in case you'd like a stricter heuristic.

**Regression test.** `gen/bobgen-psql/driver/gen_unused_import_test.go` runs full generation offline through a stub driver (no database, no containers): scalar-only `sample_table` m2m-related to uuid-keyed `tags` through `sample_tags`, with `uuid_pkg: google` registration mirroring the psql driver. It fails on `main` (uuid imported, unused) and passes with this change.

**Verification** (macOS arm64, go1.26.5):

- new regression test fails before / passes after;
- the full generated output of the fixture (models, factory, dbinfo, dberrors for all three tables) compiles: `go build ./...` + `go vet ./...` on the generated module — the uuid-keyed table still imports and uses uuid; only the unused import is gone;
- `go test -race ./...` passes across all packages, including the container-backed mysql/psql/sqlite driver golden suites;
- `golangci-lint run`: 0 issues;
- the same regression test also fails on the `v0.48.0` tag (the reporter's version), confirming a long-standing bug rather than a recent regression.

Prepared with AI assistance (Claude Code); happy to adjust anything in review.
