### PR TITLE
fix: close rows in QueryStmt.One to stop leaking a connection per call

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -155,6 +155,9 @@ func (s QueryStmt[Arg, T, Ts]) One(ctx context.Context, arg Arg) (T, error) {
 	}
 
 	t, err = scan.OneFromRows(ctx, s.mapper, rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		return t, err
 	}
@@ -182,6 +185,9 @@ func (s QueryStmt[Arg, T, Ts]) All(ctx context.Context, arg Arg) (Ts, error) {
 	}
 
 	rawSlice, err := scan.AllFromRows(ctx, s.mapper, rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -243,5 +249,11 @@ func (s QueryStmt[Arg, T, Ts]) Cursor(ctx context.Context, arg Arg) (scan.ICurso
 		}
 	})
 
-	return scan.CursorFromRows(ctx, m2, rows)
+	c, err := scan.CursorFromRows(ctx, m2, rows)
+	if err != nil {
+		rows.Close()
+		return nil, err
+	}
+
+	return c, nil
 }

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -1,0 +1,162 @@
+package bob
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stephenafamo/scan"
+)
+
+// fakeRows is a scan.Rows that records whether Close was called.
+type fakeRows struct {
+	vals    []int
+	idx     int
+	closed  bool
+	scanErr error
+}
+
+func (r *fakeRows) Columns() ([]string, error) { return []string{"id"}, nil }
+func (r *fakeRows) Next() bool                 { return r.idx < len(r.vals) }
+func (r *fakeRows) Err() error                 { return nil }
+func (r *fakeRows) Close() error               { r.closed = true; return nil }
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+	for _, d := range dest {
+		if p, ok := d.(*int); ok {
+			*p = r.vals[r.idx]
+		}
+	}
+	r.idx++
+	return nil
+}
+
+// fakeStmt is a PreparedExecutor returning a single fakeRows.
+type fakeStmt struct {
+	rows *fakeRows
+}
+
+func (s fakeStmt) ExecContext(ctx context.Context, args ...any) (sql.Result, error) {
+	return nil, nil
+}
+
+func (s fakeStmt) QueryContext(ctx context.Context, args ...any) (scan.Rows, error) {
+	return s.rows, nil
+}
+
+func (s fakeStmt) Close() error { return nil }
+
+// fakePreparer implements Preparer[fakeStmt].
+type fakePreparer struct {
+	rows *fakeRows
+}
+
+func (p fakePreparer) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return nil, nil
+}
+
+func (p fakePreparer) QueryContext(ctx context.Context, query string, args ...any) (scan.Rows, error) {
+	return p.rows, nil
+}
+
+func (p fakePreparer) PrepareContext(ctx context.Context, query string) (fakeStmt, error) {
+	return fakeStmt{rows: p.rows}, nil
+}
+
+type testStmtQuery struct{}
+
+func (testStmtQuery) WriteSQL(ctx context.Context, w io.StringWriter, d Dialect, start int) ([]any, error) {
+	w.WriteString("SELECT 1")
+	return nil, nil
+}
+
+func (testStmtQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	w.WriteString("SELECT 1")
+	return nil, nil
+}
+
+func (testStmtQuery) Type() QueryType { return QueryTypeSelect }
+
+var testIntMapper = scan.Mapper[int](func(ctx context.Context, cols []string) (scan.BeforeFunc, func(any) (int, error)) {
+	return func(r *scan.Row) (any, error) {
+			v := new(int)
+			r.ScheduleScanByName("id", v)
+			return v, nil
+		}, func(link any) (int, error) {
+			return *(link.(*int)), nil
+		}
+})
+
+func prepareIntStmt(t *testing.T, rows *fakeRows) QueryStmt[int, int, []int] {
+	t.Helper()
+
+	stmt, err := PrepareQueryx[int, fakeStmt, int, []int](
+		context.Background(), fakePreparer{rows: rows}, testStmtQuery{}, testIntMapper,
+	)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	return stmt
+}
+
+func TestQueryStmtOneClosesRows(t *testing.T) {
+	rows := &fakeRows{vals: []int{42}}
+	stmt := prepareIntStmt(t, rows)
+
+	got, err := stmt.One(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("one: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+	if !rows.closed {
+		t.Fatal("One did not close rows")
+	}
+}
+
+func TestQueryStmtOneClosesRowsOnNoRows(t *testing.T) {
+	rows := &fakeRows{}
+	stmt := prepareIntStmt(t, rows)
+
+	if _, err := stmt.One(context.Background(), 0); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+	if !rows.closed {
+		t.Fatal("One did not close rows on the no-rows path")
+	}
+}
+
+func TestQueryStmtAllClosesRows(t *testing.T) {
+	rows := &fakeRows{vals: []int{1, 2, 3}}
+	stmt := prepareIntStmt(t, rows)
+
+	got, err := stmt.All(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("all: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(got))
+	}
+	if !rows.closed {
+		t.Fatal("All did not close rows")
+	}
+}
+
+func TestQueryStmtAllClosesRowsOnScanError(t *testing.T) {
+	rows := &fakeRows{vals: []int{1}, scanErr: errors.New("scan failed")}
+	stmt := prepareIntStmt(t, rows)
+
+	if _, err := stmt.All(context.Background(), 0); err == nil {
+		t.Fatal("expected scan error")
+	}
+	if !rows.closed {
+		t.Fatal("All did not close rows on the scan-error path")
+	}
+}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -65,7 +65,7 @@ func (p fakePreparer) QueryContext(ctx context.Context, query string, args ...an
 }
 
 func (p fakePreparer) PrepareContext(ctx context.Context, query string) (fakeStmt, error) {
-	return fakeStmt{rows: p.rows}, nil
+	return fakeStmt(p), nil
 }
 
 type testStmtQuery struct{}


### PR DESCRIPTION
## Summary

`QueryStmt.One` (the prepared-statement query path) leaks the `sql.Rows` —
and with `database/sql`, the pool connection holding them — on **every call**.

`One` passes the rows from `stmt.QueryContext` to `scan.OneFromRows`, which by
contract does not close caller-owned rows (`scan.One` does, `scan.OneFromRows`
does not), and `One` never closes them itself:

```go
rows, err := s.stmt.QueryContext(ctx, args...)
if err != nil {
    return t, err
}

t, err = scan.OneFromRows(ctx, s.mapper, rows)   // rows never closed
```

Because `One` reads a single row and never exhausts the result set,
`database/sql` cannot auto-release the connection. Each call permanently
holds one pool connection; a service using a prepared `One` in a request
handler exhausts the pool and PostgreSQL starts rejecting connections:

```
pq: sorry, too many clients already (53300)
```

This reproduces on every released version (verified on v0.42.0 and main)
against a real PostgreSQL 17 with a plain `bob.PrepareQueryx(...).One(...)`
loop.

## Changes

- `QueryStmt.One`: close the rows as soon as `scan.OneFromRows` returns
  (before the extra loaders run, matching the ordering of the non-prepared
  exec path where `scan.One` closes rows before `bob`'s loaders execute).
  A close error is returned if scanning itself succeeded.
- `QueryStmt.All`: the happy path exhausts the rows so `database/sql`
  auto-releases the connection, but a scan error mid-iteration leaked them —
  now closed explicitly on every path.
- `QueryStmt.Cursor`: rows ownership moves to the returned cursor, but when
  `scan.CursorFromRows` itself fails the rows leaked — now closed on that
  error path.
- `stmt_test.go` (new): regression tests using a fake `Preparer`/`Rows` that
  record whether `Close` was called — happy path, `sql.ErrNoRows` path,
  `All` happy path and `All` scan-error path. All four fail without this fix.

## Testing

- The four new regression tests fail on current main and pass with the fix.
- End-to-end: on a `MaxOpenConns(1)` pool, 10 consecutive `One` calls block
  forever without the fix (the leaked connection is never returned) and pass
  with it.
- `go test .` / `go vet .` pass.