### PR TITLE
perf(gen): de-duplicate non-unique key arrays for ​= ANY($1)​ loaders & counts on PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `NewViewx` and `NewTablex` in the `psql`, `mysql` and `sqlite` dialects now take a `scan.Mapper[T]` argument used for all queries built from the view/table. Pass `nil` to keep the previous reflection-based `scan.StructMapper` behaviour. `NewView`/`NewTable` are unchanged. (thanks @sandonemaki)
 - JOIN a DISTINCT unnest(...) for composite-key relationship loaders & counts on PostgreSQL. (thanks @sandonemaki)
+- PostgreSQL single-column slice relationship loaders (`<Parent>Slice.<Rel>`) and batch counts (`<Parent>Slice.LoadCount<Rel>`) now de-duplicate the key array bound to `= ANY($1)` when the key column can contain duplicates (a non-unique foreign key). The array is only a semi-join filter, so query results are unchanged — a slice of 10,000 parents sharing 50 related rows now binds 50 keys instead of 10,000. Keys that are unique by construction (the parent's own primary key or a uniquely-constrained column) and key types not comparable with `==` keep the previous plain loop, decided at codegen time ([#740](https://github.com/stephenafamo/bob/pull/740)). (thanks @sandonemaki)
+- Generated through-relationship loaders (`Load<Rel>`) no longer apply every query mod twice (once against a throwaway query to detect whether the user set columns, then again for real). The default columns are now added by a deferred `bob.ModFunc` during the single real application — the same pattern `View.Query` uses — and the join-key slice is pre-allocated to the parent slice length. Generated SQL is unchanged ([#740](https://github.com/stephenafamo/bob/pull/740)). (thanks @sandonemaki)
 
 ### Fixed
 

--- a/gen/templates/counts/table/115_counts.go.tpl
+++ b/gen/templates/counts/table/115_counts.go.tpl
@@ -193,6 +193,39 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 	{{- $fromCol := index $firstFrom.Columns $local}}
 	pk{{$fromCol}} := make(pgtypes.Array[{{$colTyp}}], 0, len(os))
 	{{- end}}
+	{{- if eq (len $firstSide.FromColumns) 1}}
+	{{- $local := index $firstSide.FromColumns 0 -}}
+	{{- $column := $.Table.GetColumn $local -}}
+	{{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable -}}
+	{{- $fromCol := index $firstFrom.Columns $local}}
+	{{- /* keys that are unique by construction (the parent's own PK or a
+	       unique column) never contain duplicates, so the seen-map would be
+	       pure overhead; dedup only de-duplicatable, ==-comparable keys */ -}}
+	{{- $canDedup := and (not ($.Table.HasExactUnique $local)) ($.Types.CanCompareWithEquals $.CurrentPackage $column.Type)}}
+	{{- if $canDedup}}
+	// the array is only a filter (semi-join), so duplicate keys can be
+	// dropped before they are sent over the wire
+	seen{{$fromCol}} := make(map[{{$colTyp}}]struct{}, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		if _, ok := seen{{$fromCol}}[o.{{$fromCol}}]; ok {
+			continue
+		}
+		seen{{$fromCol}}[o.{{$fromCol}}] = struct{}{}
+		pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
+	}
+	{{- else}}
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
+	}
+	{{- end}}
+	PKArgExpr := {{$.Dialect}}.Any({{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
+	{{- else}}
 	for _, o := range os {
 		if o == nil {
 			continue
@@ -202,19 +235,6 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
 		{{- end}}
 	}
-	{{- if eq (len $firstSide.FromColumns) 1}}
-	{{- $local := index $firstSide.FromColumns 0 -}}
-	{{- $column := $.Table.GetColumn $local -}}
-	{{- $fromCol := index $firstFrom.Columns $local}}
-	PKArgExpr := {{$.Dialect}}.Any({{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
-	{{- else}}
-	PKArgExpr := {{$.Dialect}}.Select(sm.Columns(
-		{{- range $index, $local := $firstSide.FromColumns -}}
-		{{- $column := $.Table.GetColumn $local -}}
-		{{- $fromCol := index $firstFrom.Columns $local}}
-		{{$.Dialect}}.F("unnest", {{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]")),
-		{{- end}}
-	))
 	{{- end}}
 	{{- end}}
 
@@ -286,6 +306,36 @@ func (os {{$tAlias.UpSingular}}Slice) LoadCount{{$relAlias}}(ctx context.Context
 		{{- else -}}
 		sm.Where({{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.OP("IN", PKArgExpr)),
 		{{- end}}
+		{{- else if eq $.Dialect "psql" -}}
+		sm.InnerJoin({{$.Dialect}}.Select(
+			sm.Distinct(),
+			sm.Columns(
+				{{range $index, $local := $firstSide.FromColumns -}}
+				{{$toLocal := index $firstSide.ToColumns $index -}}
+				{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+				{{$.Dialect}}.Quote("bob_rel_keys_src", {{quote $firstToColAlias}}),
+				{{end -}}
+			),
+			sm.From({{$.Dialect}}.F("unnest",
+				{{range $index, $local := $firstSide.FromColumns -}}
+				{{$column := $.Table.GetColumn $local -}}
+				{{$fromCol := index $firstFrom.Columns $local -}}
+				{{$.Dialect}}.Cast({{$.Dialect}}.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"),
+				{{end -}}
+			)).As("bob_rel_keys_src"
+				{{- range $index, $local := $firstSide.FromColumns -}}
+				{{- $toLocal := index $firstSide.ToColumns $index -}}
+				{{- $firstToColAlias := index $firstTo.Columns $toLocal -}}
+				, {{quote $firstToColAlias}}
+				{{- end -}}
+			),
+		)).As("bob_rel_keys").On(
+			{{range $index, $local := $firstSide.FromColumns -}}
+			{{$toLocal := index $firstSide.ToColumns $index -}}
+			{{$firstToColAlias := index $firstTo.Columns $toLocal -}}
+			{{$firstTo.UpPlural}}.Columns.{{$firstToColAlias}}.EQ({{$.Dialect}}.Quote("bob_rel_keys", {{quote $firstToColAlias}})),
+			{{end -}}
+		),
 		{{- else -}}
 		sm.Where({{$.Dialect}}.Group(
 			{{range $index, $local := $firstSide.FromColumns -}}

--- a/gen/templates/loaders/table/110_loaders.go.tpl
+++ b/gen/templates/loaders/table/110_loaders.go.tpl
@@ -382,18 +382,16 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
 	  return nil
 	}
 
-  // since we are changing the columns, we need to check if the original columns were set or add the defaults
-  sq := dialect.SelectQuery{}
-  for _, mod := range mods {
-   mod.Apply(&sq)
-  }
-
-	if len(sq.SelectList.Columns) == 0 {
-		mods = append(mods, sm.Columns({{$fAlias.UpPlural}}.Columns))
-	}
-
 	q := os.{{relQueryMethodName $tAlias $relAlias}}(append(
 		mods,
+		// since we are changing the columns, the defaults must be added if the
+		// original mods did not set any; this runs after the user mods and
+		// before the related_* columns below, so it sees exactly what they set
+		bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
+			if len(q.SelectList.Columns) == 0 {
+				sm.Columns({{$fAlias.UpPlural}}.Columns).Apply(q)
+			}
+		}),
 		{{range $index, $local := $firstSide.FromColumns -}}
 			{{- $toCol := index $firstTo.Columns (index $firstSide.ToColumns $index) -}}
 			{{- $fromCol := index $firstFrom.Columns $local -}}
@@ -405,18 +403,38 @@ func (os {{$tAlias.UpSingular}}Slice) Load{{$relAlias}}(ctx context.Context, exe
     {{- $fromColAlias := index $firstFrom.Columns $local -}}
     {{- $fromCol := $.Tables.GetColumn $firstSide.From $local -}}
     {{- $fromTyp := $.Types.Get $.CurrentPackage $.Importer $fromCol.Type -}}
-    {{$fromColAlias}}Slice := []{{$fromTyp}}{}
+    {{$fromColAlias}}Slice := make([]{{$fromTyp}}, 0, len(os))
   {{end}}
 
 	{{$.Importer.Import "github.com/stephenafamo/scan" -}}
   mapper := scan.Mod(q.Scanner, func(ctx context.Context, cols []string) (scan.BeforeFunc, func(any, any) error) {
+    // Resolve each joined key column name to its index once per query. The
+    // previous code scanned by name on every row, which meant a linear column
+    // search per row; the columns are added by this loader so they are always
+    // present, but an unselected column simply stays unresolved and is skipped.
+    {{range $index, $local := $firstSide.FromColumns -}}
+      {{- $fromColAlias := index $firstFrom.Columns $local -}}
+    {{$fromColAlias}}Idx := -1
+    {{end -}}
+    for i, col := range cols {
+      switch col {
+      {{range $index, $local := $firstSide.FromColumns -}}
+        {{- $fromColAlias := index $firstFrom.Columns $local -}}
+      case "related_{{$firstSide.From}}.{{$fromColAlias}}":
+        {{$fromColAlias}}Idx = i
+      {{end -}}
+      }
+    }
+
     return func(row *scan.Row) (any, error) {
       {{range $index, $local := $firstSide.FromColumns -}}
         {{- $fromColAlias := index $firstFrom.Columns $local -}}
         {{- $fromCol := $.Tables.GetColumn $firstSide.From $local -}}
         {{- $fromTyp := $.Types.Get $.CurrentPackage $.Importer $fromCol.Type -}}
         {{$fromColAlias}}Slice = append({{$fromColAlias}}Slice, *new({{$fromTyp}}))
-        row.ScheduleScanByName("related_{{$firstSide.From}}.{{$fromColAlias}}", &{{$fromColAlias}}Slice[len({{$fromColAlias}}Slice)-1])
+        if {{$fromColAlias}}Idx >= 0 {
+          row.ScheduleScanByIndex({{$fromColAlias}}Idx, &{{$fromColAlias}}Slice[len({{$fromColAlias}}Slice)-1])
+        }
       {{end}}
 
       return nil, nil

--- a/gen/templates/models/table/009_rel_query.go.tpl
+++ b/gen/templates/models/table/009_rel_query.go.tpl
@@ -78,6 +78,39 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
 			{{$fromCol := index $firstFrom.Columns $local -}}
       pk{{$fromCol}} := make(pgtypes.Array[{{$colTyp}}], 0, len(os))
 		{{- end}}
+    {{if eq (len $firstSide.FromColumns) 1}}
+    {{- $local := index $firstSide.FromColumns 0}}
+    {{- $column := $.Table.GetColumn $local}}
+    {{- $colTyp := $.Types.GetNullable $.CurrentPackage $.Importer $column.Type $column.Nullable}}
+    {{- $fromCol := index $firstFrom.Columns $local}}
+    {{- /* keys that are unique by construction (the parent's own PK or a
+           unique column) never contain duplicates, so the seen-map would be
+           pure overhead; dedup only de-duplicatable, ==-comparable keys */ -}}
+    {{- $canDedup := and (not ($.Table.HasExactUnique $local)) ($.Types.CanCompareWithEquals $.CurrentPackage $column.Type)}}
+    {{- if $canDedup}}
+    // the array is only a filter (semi-join), so duplicate keys can be
+    // dropped before they are sent over the wire
+    seen{{$fromCol}} := make(map[{{$colTyp}}]struct{}, len(os))
+    for _, o := range os {
+      if o == nil {
+        continue
+      }
+      if _, ok := seen{{$fromCol}}[o.{{$fromCol}}]; ok {
+        continue
+      }
+      seen{{$fromCol}}[o.{{$fromCol}}] = struct{}{}
+      pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
+    }
+    {{- else}}
+    for _, o := range os {
+      if o == nil {
+        continue
+      }
+      pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
+    }
+    {{- end}}
+    PKArgExpr := psql.Any(psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
+    {{else}}
     for _, o := range os {
       if o == nil {
         continue
@@ -87,19 +120,6 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
         pk{{$fromCol}} = append(pk{{$fromCol}}, o.{{$fromCol}})
       {{- end}}
     }
-    {{if eq (len $firstSide.FromColumns) 1}}
-    {{- $local := index $firstSide.FromColumns 0}}
-    {{- $column := $.Table.GetColumn $local}}
-    {{- $fromCol := index $firstFrom.Columns $local}}
-    PKArgExpr := psql.Any(psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"))
-    {{else}}
-    PKArgExpr := psql.Select(sm.Columns(
-      {{- range $index, $local := $firstSide.FromColumns -}}
-        {{$column := $.Table.GetColumn $local}}
-        {{$fromCol := index $firstFrom.Columns $local -}}
-        psql.F("unnest", psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]")),
-      {{- end}}
-    ))
     {{end}}
   {{end}}
 	{{- end}}
@@ -135,6 +155,33 @@ func (os {{$tAlias.UpSingular}}Slice) {{relQueryMethodName $tAlias $relAlias}}(m
 				{{if and (eq $.Dialect "psql") (eq (len $side.FromColumns) 1) -}}
 					{{- $toCol := index $to.Columns (index $side.ToColumns 0) -}}
 					sm.Where({{$to.UpPlural}}.Columns.{{$toCol}}.EQ(PKArgExpr)),
+				{{- else if eq $.Dialect "psql" -}}
+					sm.InnerJoin(psql.Select(
+						sm.Distinct(),
+						sm.Columns(
+							{{- range $index, $local := $side.FromColumns -}}
+							{{- $toCol := index $to.Columns (index $side.ToColumns $index) -}}
+							psql.Quote("bob_rel_keys_src", {{quote $toCol}}),
+							{{- end}}
+						),
+						sm.From(psql.F("unnest",
+							{{- range $index, $local := $side.FromColumns -}}
+							{{- $fromCol := index $from.Columns $local -}}
+							{{- $column := $.Table.GetColumn $local -}}
+							psql.Cast(psql.Arg(pk{{$fromCol}}), "{{$column.DBType}}[]"),
+							{{- end}}
+						)).As("bob_rel_keys_src"
+							{{- range $index, $local := $side.FromColumns -}}
+							{{- $toCol := index $to.Columns (index $side.ToColumns $index) -}}
+							, {{quote $toCol}}
+							{{- end -}}
+						),
+					)).As("bob_rel_keys").On(
+						{{- range $index, $local := $side.FromColumns -}}
+						{{- $toCol := index $to.Columns (index $side.ToColumns $index) -}}
+						{{$to.UpPlural}}.Columns.{{$toCol}}.EQ(psql.Quote("bob_rel_keys", {{quote $toCol}})),
+						{{- end}}
+					),
 				{{- else -}}
 					sm.Where({{$.Dialect}}.Group(
 					{{- range $index, $local := $side.FromColumns -}}


### PR DESCRIPTION

> Follow-up to #714 (`col = ANY($1)`) and #718 (composite keys via `DISTINCT unnest`).
> This PR trims the **bound argument** of the single-column form; the SQL text is unchanged.

## Summary

Generated single-column relationship Slice loaders
(`gen/templates/models/table/009_rel_query.go.tpl`) and batch counts
(`gen/templates/counts/table/115_counts.go.tpl`) bind one key per parent to
`= ANY($1)`:

```go
pkGroupID := make(pgtypes.Array[int64], 0, len(os))
for _, o := range os {
    if o == nil {
        continue
    }
    pkGroupID = append(pkGroupID, o.GroupID) // one entry per parent, duplicates included
}
```

For a **to-one** relationship the keys are foreign key values, so parents that
share a related row all contribute the same key. One of our production shapes:
10,000 `tasks` rows pointing at 50 `groups` send a 10,000-element `bigint[]`
(~120KB on the pgx binary wire format) where 50 distinct keys (~0.6KB) produce
the exact same result — the array is only a semi-join filter, so duplicates
change nothing about the rows that come back.

This PR de-duplicates the array with a seen-map before binding it:

```go
pkGroupID := make(pgtypes.Array[int64], 0, len(os))
// the array is only a filter (semi-join), so duplicate keys can be
// dropped before they are sent over the wire
seenGroupID := make(map[int64]struct{}, len(os))
for _, o := range os {
    if o == nil {
        continue
    }
    if _, ok := seenGroupID[o.GroupID]; ok {
        continue
    }
    seenGroupID[o.GroupID] = struct{}{}
    pkGroupID = append(pkGroupID, o.GroupID)
}
```

To be clear about the relationship to #718's review discussion: as concluded
there, the semi-join does **not** need de-duplication for correctness. This
change is purely about the bytes bound to the query and the size of the hash
the planner builds on the DB side.

## When the seen-map is generated (and when it is not)

The map is only worth its cost when the key column can actually contain
duplicates, so codegen gates it on the schema:

| key column | example | generated |
| --- | --- | --- |
| non-unique FK (to-one, high fan-in possible) | `videos.user_id` | **seen-map dedup** |
| parent's own PK (to-many loaders, `LoadCount<Rel>`) | `videos.id` | plain loop (unchanged) |
| uniquely-constrained FK (one-to-one) | `videos.sponsor_id unique` | plain loop (unchanged) |
| type not comparable with `==` | custom `compare_expr` types | plain loop (unchanged) |
| composite keys | — | unchanged (#718's `DISTINCT unnest` already de-duplicates in SQL) |
| non-PostgreSQL dialects | — | unchanged (row-value `IN` list) |

Uniqueness is checked with the existing `drivers.Table.HasExactUnique` (primary
key or unique constraint), and `==`-comparability with `Types.CanCompareWithEquals`
— the same gating as the `copyMatchingRows` map-stitch (#729).

## Why the uniqueness gate

Benchmarking the two generated fill-loop shapes at 10,000 parents:

```
no dedup (before)               53µs    82KB/op
seen-map, fan-in 50 (after)    455µs   377KB/op   → binds 50 keys instead of 10,000
seen-map on unique keys      1,256µs               → zero wire savings
```

On keys that are unique by construction the map is ~1.2ms of pure overhead per
10,000 parents, so those call sites keep the previous code — the gate is decided
at codegen time and costs nothing at runtime.

## Also included: two small cleanups in the through-loader template

`gen/templates/loaders/table/110_loaders.go.tpl` (`Load<Rel>` for through
relationships) applied every query mod **twice**: once against a throwaway
`SelectQuery` just to check whether the user set any columns, then again for
real:

```go
sq := dialect.SelectQuery{}
for _, mod := range mods {
    mod.Apply(&sq)          // full apply, result discarded
}
if len(sq.SelectList.Columns) == 0 {
    mods = append(mods, sm.Columns(Tags.Columns))
}
q := os.Tags(append(mods, ...)...)  // full apply again
```

The throwaway pass is replaced with a deferred `bob.ModFunc` placed after the
user mods and before the loader's `related_*` columns, so it makes the same
decision at the same point during the single real application:

```go
q := os.Tags(append(
    mods,
    bob.ModFunc[*dialect.SelectQuery](func(q *dialect.SelectQuery) {
        if len(q.SelectList.Columns) == 0 {
            sm.Columns(Tags.Columns).Apply(q)
        }
    }),
    sm.Columns(VideoTags.Columns.VideoID.As("related_videos.ID")),
)...)
```

This is the same deferred-default-columns pattern `View.Query` itself already
uses (`dialect/psql/view.go`), and it sees exactly what the old check saw: the
`SelectQuery` starts with no columns and, at that position in the mod list, only
the user's mods have been applied.

The same template also grows the join-key slice from zero capacity; it is now
pre-allocated to `len(os)` as a lower-bound hint.

## Behavior (no functional change)

- **Results are identical.** The array only filters (`WHERE key = ANY($1)`);
  duplicates in it cannot multiply rows, and counts group over child rows, so
  `LoadCount` values are unchanged too.
- **NULL semantics preserved** — `= ANY` never matches NULL; at most the array
  now carries one NULL instead of many.
- **SQL text is unchanged** — only the bound array shrinks, so prepared
  statements and plans are unaffected.
- **Column-defaulting decision unchanged** — verified against `View.Query`'s
  mod-application order (see above).

## Verification

- Generated against the test schema plus a composite-FK pair
  (`comp_children(parent_region, parent_code) → comp_parents`): dedup appears
  exactly on non-unique FK keys (`videos.user_id`, self-referencing FKs,
  join-table FKs), and **not** on PK keys, on `videos.sponsor_id` (unique), or
  on composite keys; everything compiles (`go build ./models/...`).
- `go test ./gen/bobgen-psql/...` — full suite (golden files + generated-code
  tests against a real PostgreSQL) passes.
- `go test ./gen/bobgen-sqlite/...` (modernc/ncruces) passes — the through-loader
  change is dialect-independent, non-psql loader output is otherwise unchanged.
- Fill-loop micro-benchmarks above.
