### PR TITLE
Fix doubled parentheses in Exists/Any/All with query operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Exists`, `Any` and `All` (in the `psql`, `mysql` and `sqlite` dialects) wrapping a query operand in an extra parenthesis group, producing invalid SQL like `EXISTS ((SELECT ...))`. A `bob.Query` already writes its own parentheses when rendered as an expression, so it is no longer wrapped again; non-query operands (e.g. `Arg`, `Raw`) keep the surrounding parentheses. This also fixes the generated relationship `Where` filters from [#722](https://github.com/stephenafamo/bob/pull/722), which failed to execute on SQLite ([#742](https://github.com/stephenafamo/bob/issues/742)).
+
 ### Changed
 
 - PostgreSQL single-column slice relationship loaders (`<Parent>Slice.<Rel>`) and batch counts (`<Parent>Slice.LoadCount<Rel>`) now de-duplicate the key array bound to `= ANY($1)` when the key column can contain duplicates (a non-unique foreign key). The array is only a semi-join filter, so query results are unchanged — a slice of 10,000 parents sharing 50 related rows now binds 50 keys instead of 10,000. Keys that are unique by construction (the parent's own primary key or a uniquely-constrained column) and key types not comparable with `==` keep the previous plain loop, decided at codegen time ([#740](https://github.com/stephenafamo/bob/pull/740)). (thanks @sandonemaki)

--- a/dialect/mysql/starters.go
+++ b/dialect/mysql/starters.go
@@ -108,7 +108,7 @@ func Case() expr.CaseChain[Expression, Expression] {
 	return expr.NewCase[Expression, Expression]()
 }
 
-// SQL: EXISTS ((SELECT 1))
+// SQL: EXISTS (SELECT 1)
 // Go: mysql.Exists(mysql.Select(sm.Columns("1")))
 func Exists(exp bob.Expression) Expression {
 	return bmod.Exists(exp)
@@ -120,13 +120,13 @@ func Minus(exp bob.Expression) Expression {
 	return bmod.Minus(exp)
 }
 
-// SQL: a = ANY((SELECT name FROM users))
+// SQL: a = ANY(SELECT name FROM users)
 // Go: mysql.Quote("a").EQ(mysql.Any(mysql.Select(sm.Columns("name"), sm.From("users"))))
 func Any(exp bob.Expression) bob.Expression {
 	return bmod.Any(exp)
 }
 
-// SQL: a = ALL((SELECT name FROM users))
+// SQL: a = ALL(SELECT name FROM users)
 // Go: mysql.Quote("a").EQ(mysql.All(mysql.Select(sm.Columns("name"), sm.From("users"))))
 func All(exp bob.Expression) bob.Expression {
 	return bmod.All(exp)

--- a/dialect/psql/starters.go
+++ b/dialect/psql/starters.go
@@ -115,7 +115,7 @@ func Case() expr.CaseChain[Expression, Expression] {
 	return expr.NewCase[Expression, Expression]()
 }
 
-// SQL: EXISTS ((SELECT 1))
+// SQL: EXISTS (SELECT 1)
 // Go: psql.Exists(psql.Select(sm.Columns("1")))
 func Exists(exp bob.Expression) Expression {
 	return bmod.Exists(exp)
@@ -127,13 +127,13 @@ func Minus(exp bob.Expression) Expression {
 	return bmod.Minus(exp)
 }
 
-// SQL: a = ANY((SELECT name FROM users))
+// SQL: a = ANY(SELECT name FROM users)
 // Go: psql.Quote("a").EQ(psql.Any(psql.Select(sm.Columns("name"), sm.From("users"))))
 func Any(exp bob.Expression) bob.Expression {
 	return bmod.Any(exp)
 }
 
-// SQL: a = ALL((SELECT name FROM users))
+// SQL: a = ALL(SELECT name FROM users)
 // Go: psql.Quote("a").EQ(psql.All(psql.Select(sm.Columns("name"), sm.From("users"))))
 func All(exp bob.Expression) bob.Expression {
 	return bmod.All(exp)

--- a/dialect/sqlite/select_test.go
+++ b/dialect/sqlite/select_test.go
@@ -156,6 +156,23 @@ func TestSelect(t *testing.T) {
                 WHERE ("id" = ?2)`,
 			ExpectedArgs: []any{"123", 100},
 		},
+		"select where exists": {
+			Doc: "Select where an EXISTS subquery matches",
+			ExpectedSQL: `SELECT id FROM users WHERE EXISTS (
+                  SELECT 1
+                  FROM orders
+                  WHERE ("orders"."user_id" = "users"."id")
+                )`,
+			Query: sqlite.Select(
+				sm.Columns("id"),
+				sm.From("users"),
+				sm.Where(sqlite.Exists(sqlite.Select(
+					sm.Columns("1"),
+					sm.From("orders"),
+					sm.Where(sqlite.Quote("orders", "user_id").EQ(sqlite.Quote("users", "id"))),
+				))),
+			),
+		},
 	}
 
 	testutils.RunTests(t, examples, formatter)

--- a/dialect/sqlite/starters.go
+++ b/dialect/sqlite/starters.go
@@ -108,7 +108,7 @@ func Case() expr.CaseChain[Expression, Expression] {
 	return expr.NewCase[Expression, Expression]()
 }
 
-// SQL: EXISTS ((SELECT 1))
+// SQL: EXISTS (SELECT 1)
 // Go: sqlite.Exists(sqlite.Select(sm.Columns("1")))
 func Exists(exp bob.Expression) Expression {
 	return bmod.Exists(exp)

--- a/expr/builder.go
+++ b/expr/builder.go
@@ -46,7 +46,7 @@ func Not[T bob.Expression, B builder[T]](exp bob.Expression) T {
 // Exists expression
 func Exists[T bob.Expression, B builder[T]](exp bob.Expression) T {
 	var b B
-	return b.New(Join{Exprs: []bob.Expression{exists, group{exp}}})
+	return b.New(Join{Exprs: []bob.Expression{exists, subquery(exp)}})
 }
 
 // prefix the expression with a - (minus)
@@ -58,13 +58,26 @@ func Minus[T bob.Expression, B builder[T]](exp bob.Expression) T {
 // ANY expression
 func Any[T bob.Expression, B builder[T]](exp bob.Expression) T {
 	var b B
-	return b.New(Join{Exprs: []bob.Expression{anyOp, group{exp}}})
+	return b.New(Join{Exprs: []bob.Expression{anyOp, subquery(exp)}})
 }
 
 // ALL expression
 func All[T bob.Expression, B builder[T]](exp bob.Expression) T {
 	var b B
-	return b.New(Join{Exprs: []bob.Expression{all, group{exp}}})
+	return b.New(Join{Exprs: []bob.Expression{all, subquery(exp)}})
+}
+
+// A [bob.Query] writes its own surrounding parentheses when rendered as an
+// expression (see [bob.BaseQuery.WriteSQL]), so wrapping it in a group would
+// produce doubled parentheses such as EXISTS ((SELECT ...)).
+// Any other expression is wrapped in a group since EXISTS/ANY/ALL require
+// parentheses around their operand.
+func subquery(exp bob.Expression) bob.Expression {
+	if _, ok := exp.(bob.Query); ok {
+		return exp
+	}
+
+	return group{exp}
 }
 
 // To be embedded in query mods

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -1,0 +1,68 @@
+package expr
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stephenafamo/bob"
+)
+
+type chain struct {
+	Chain[chain, chain]
+}
+
+func (chain) New(exp bob.Expression) chain {
+	var c chain
+	c.Base = exp
+	return c
+}
+
+// Mimics bob.BaseQuery, which writes its own surrounding parentheses when
+// rendered as an expression.
+type selfWrappingQuery struct{ sql string }
+
+func (q selfWrappingQuery) WriteSQL(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+	w.WriteString("(")
+	w.WriteString(q.sql)
+	w.WriteString(")")
+	return nil, nil
+}
+
+func (q selfWrappingQuery) WriteQuery(ctx context.Context, w io.StringWriter, start int) ([]any, error) {
+	return q.WriteSQL(ctx, w, dialect{}, start)
+}
+
+func (q selfWrappingQuery) Type() bob.QueryType { return bob.QueryTypeSelect }
+
+// The expected SQL is compared exactly, without normalization, because
+// the doubled parentheses that https://github.com/stephenafamo/bob/issues/742
+// guards against would be collapsed by testutils.Clean.
+func TestPrefixedSubqueryParens(t *testing.T) {
+	query := selfWrappingQuery{sql: "SELECT 1 FROM users"}
+
+	cases := map[string]struct {
+		expr bob.Expression
+		want string
+	}{
+		"exists query":     {Exists[chain, chain](query), "EXISTS (SELECT 1 FROM users)"},
+		"any query":        {Any[chain, chain](query), "ANY (SELECT 1 FROM users)"},
+		"all query":        {All[chain, chain](query), "ALL (SELECT 1 FROM users)"},
+		"exists non-query": {Exists[chain, chain](Raw("SELECT 1")), "EXISTS (SELECT 1)"},
+		"any arg":          {Any[chain, chain](Arg(1)), "ANY (?1)"},
+		"all arg":          {All[chain, chain](Arg(1)), "ALL (?1)"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := &strings.Builder{}
+			if _, err := tc.expr.WriteSQL(context.Background(), w, dialect{}, 1); err != nil {
+				t.Fatal(err)
+			}
+			if got := w.String(); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #742

## The bug

`Exists`, `Any` and `All` in `expr/builder.go` wrapped their operand in `group{}` unconditionally. But a `bob.Query` operand (such as the `bob.BaseQuery` returned by `psql.Select`/`sqlite.Select`/`mysql.Select`) already writes its own surrounding parentheses when rendered as an expression (`bob.BaseQuery.WriteSQL`). The two stacked into invalid SQL like `EXISTS ((SELECT ...))`, which fails to execute on SQLite and broke the generated relationship `Where` filters from #722 (`Parents.R.HasEndpoints(...)` etc., which return `dialect.Exists(q)`).

## The fix

`Exists`/`Any`/`All` now skip the extra `group{}` when the operand implements `bob.Query`, relying on the query to write its own parentheses — the same assumption `bob.BaseQuery.WriteSQL` already makes for nested queries.

I deliberately did **not** reuse the `ShouldOmitParens` guard from `X()` as the issue first suggested: `Arg`, `Raw`, `Clause` etc. report `ShouldOmitParens() == true` but do not write their own parentheses, and `EXISTS`/`ANY`/`ALL` require parentheses around their operand — so routing through that check would have turned `ANY ($1)` into invalid `ANY $1`. Non-query operands keep the group exactly as before.

Also updated the doc comments in the three dialects' `starters.go`, which documented the doubled form (`EXISTS ((SELECT 1))`).

## Tests

- `expr/builder_test.go`: exact-string assertions that a query operand renders as `EXISTS (SELECT ...)` / `ANY (...)` / `ALL (...)` with a single set of parentheses, and that non-query operands (`Raw`, `Arg`) still get wrapped. Exact matching matters here because `testutils.Clean` collapses doubled parentheses, which would mask this regression.
- `dialect/sqlite/select_test.go`: an end-to-end `WHERE EXISTS (subquery)` case validated by the SQLite grammar parser.

`go test ./...` passes except the pre-existing `TestLibSQL` container failure in `gen/bobgen-sqlite/driver`, which fails identically on a clean checkout of `main` (Docker/testcontainers environment issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)