### PR TITLE
fix(psql): handle duplicate parameter refs ($N) in query parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostgreSQL single-column slice relationship loaders (`<Parent>Slice.<Rel>`) and batch counts (`<Parent>Slice.LoadCount<Rel>`) now de-duplicate the key array bound to `= ANY($1)` when the key column can contain duplicates (a non-unique foreign key). The array is only a semi-join filter, so query results are unchanged — a slice of 10,000 parents sharing 50 related rows now binds 50 keys instead of 10,000. Keys that are unique by construction (the parent's own primary key or a uniquely-constrained column) and key types not comparable with `==` keep the previous plain loop, decided at codegen time ([#740](https://github.com/stephenafamo/bob/pull/740)). (thanks @sandonemaki)
 - Generated through-relationship loaders (`Load<Rel>`) no longer apply every query mod twice (once against a throwaway query to detect whether the user set columns, then again for real). The default columns are now added by a deferred `bob.ModFunc` during the single real application — the same pattern `View.Query` uses — and the join-key slice is pre-allocated to the parent slice length. Generated SQL is unchanged ([#740](https://github.com/stephenafamo/bob/pull/740)). (thanks @sandonemaki)
 
+### Fixed
+
+- Fixed the PostgreSQL code generator's query parser renumbering each reference to a repeated query parameter (`$N`) as a distinct argument (e.g. `id = $1 OR parent_id = $1` generating `$1`/`$2`), which changed the meaning of the generated query mods. Repeated `$N` references now map to a single generated parameter ([#745](https://github.com/stephenafamo/bob/pull/745)). (thanks @dmakushin)
+
 ## [v0.49.0] - 2026-07-20
 
 ### Added

--- a/gen/bobgen-psql/driver/parser/param_repro_test.go
+++ b/gen/bobgen-psql/driver/parser/param_repro_test.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	pgparse "github.com/wasilibs/go-pgquery"
+)
+
+var paramRe = regexp.MustCompile(`\$\d+`)
+
+func TestDuplicateParamRef(t *testing.T) {
+	input := "SELECT id FROM users WHERE id = $1 OR parent_id = $1"
+
+	scanResult, err := pgparse.Scan(input)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	parseResult, err := pgparse.Parse(input)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(parseResult.Stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(parseResult.Stmts))
+	}
+
+	w := walker{
+		input:       input,
+		tokens:      scanResult.GetTokens(),
+		names:       make(map[position]string),
+		nullability: make(map[position]nullable),
+		groups:      make(map[argPos]struct{}),
+		multiple:    make(map[[2]int]struct{}),
+		atom:        &atomic.Int64{},
+		paramIdxMap: make(map[int64]int64),
+	}
+
+	stmt := parseResult.Stmts[0]
+	w.walk(stmt.Stmt)
+
+	formatted, err := w.formattedQuery()
+	if err != nil {
+		t.Fatalf("formattedQuery: %v", err)
+	}
+
+	t.Logf("formatted: %s", formatted)
+	t.Logf("len(w.args): %d", len(w.args))
+
+	// Collect unique $N params
+	uniqueParams := make(map[string]int)
+	for _, m := range paramRe.FindAllString(formatted, -1) {
+		uniqueParams[m]++
+	}
+
+	t.Logf("unique $N in formatted: %d", len(uniqueParams))
+	for k, v := range uniqueParams {
+		t.Logf("  %s: %d occurrences", k, v)
+	}
+
+	if len(w.args) != len(uniqueParams) {
+		t.Errorf("walker has %d unique args but formatted query has %d unique $N params",
+			len(w.args), len(uniqueParams))
+	}
+
+	// The original $1 should appear only as $1 in the formatted query
+	if strings.Count(formatted, "$1") != 2 {
+		t.Errorf("expected 2 occurrences of $1 in formatted query, got %d", strings.Count(formatted, "$1"))
+	}
+}

--- a/gen/bobgen-psql/driver/parser/parser.go
+++ b/gen/bobgen-psql/driver/parser/parser.go
@@ -101,6 +101,7 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 		groups:       make(map[argPos]struct{}),
 		multiple:     make(map[[2]int]struct{}),
 		atom:         &atomic.Int64{},
+		paramIdxMap:  make(map[int64]int64),
 	}
 
 	stmt := parseResult.Stmts[0]
@@ -152,7 +153,7 @@ func (p *Parser) ParseQuery(ctx context.Context, input string) (drivers.Query, e
 	}
 
 	if len(w.args) != len(argTypes) {
-		return drivers.Query{}, fmt.Errorf("expected %d args, got %d", len(resTypes), len(source.columns))
+		return drivers.Query{}, fmt.Errorf("expected %d args, got %d", len(argTypes), len(w.args))
 	}
 
 	comment, err := w.getQueryComment(info.start)

--- a/gen/bobgen-psql/driver/parser/walker.go
+++ b/gen/bobgen-psql/driver/parser/walker.go
@@ -92,8 +92,9 @@ type walker struct {
 	imports   [][]string
 	mods      *strings.Builder
 
-	atom *atomic.Int64
-	args [][]argPos
+	atom        *atomic.Int64
+	paramIdxMap map[int64]int64
+	args        [][]argPos
 
 	errors []error
 }
@@ -466,11 +467,18 @@ func (w *walker) walkParamRef(a *pg.ParamRef) nodeInfo {
 	if len(w.args) < int(a.Number) {
 		w.args = append(w.args, make([][]argPos, int(a.Number)-len(w.args))...)
 	}
+
+	newIdx, ok := w.paramIdxMap[int64(a.Number)]
+	if !ok {
+		newIdx = w.atom.Add(1)
+		w.paramIdxMap[int64(a.Number)] = newIdx
+	}
+
 	w.editRules = append(w.editRules, internal.EditCallback(
 		internal.ReplaceFromFunc(
 			int(info.start), int(info.end-1),
 			func() string {
-				return fmt.Sprintf("$%d", w.atom.Add(1))
+				return fmt.Sprintf("$%d", newIdx)
 			},
 		),
 		func(start, end int, _, _ string) error {


### PR DESCRIPTION
When a query uses the same placeholder ($1) multiple times, the parser incorrectly renumbered each occurrence sequentially, causing a mismatch between expected args from PostgreSQL PREPARE and the tracked args.

Added paramIdxMap to map each unique original param number to a single sequential index, ensuring duplicate $N references are collapsed into one parameter for type resolution.

Also fixed the error message at args mismatch to print the actual expected/got values (argTypes vs w.args) instead of misleading column counts.

Fixes #744