### PR TITLE
fix!: append to to-many back-references in generated Preload/Load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **BREAKING:** The generated `Preload(name, retrieved)` method and the single-model `Load<Rel>` methods now **append** the current parent to a to-many back-reference instead of replacing it with a one-element slice holding only that parent. This is a regression fix, not a new choice of semantics: `orm.Preload` shares one related-struct instance across every parent row with the same join key ("dedup"), added opt-in as `orm.PreloadDedup` in commit `8d9485c` (2026-07-12) and made unconditional four days later by commit `76abd64` (2026-07-16), which dropped the opt-in gate so `buildPreloader` takes the dedup path whenever the join key is resolvable. Both commits shipped as [PR #736](https://github.com/stephenafamo/bob/pull/736) in **v0.50.0** — not v0.49.0, even though the closest CHANGELOG description of dedup ("`Preload` now shares a single related-struct instance...", still above) is filed under the already-released v0.49.0 section, a merge artifact from PR #736 landing after the v0.49.0 tag. That description also never mentions that dedup started as opt-in or that removing the gate changes what a to-many back-reference can hold — the gap this entry fills.
+
+  Before dedup, `Preload` and the single-model `Load<Rel>` methods built a fresh child instance per parent, so overwriting the back-reference with `<Parent>Slice{o}` and appending to it produced the same result — the choice between them was an invisible implementation detail. Once dedup shares a child across parents (which is now the default path for any to-one relationship whose inverse is to-many — the common case, since a to-one relationship's inverse is a to-many "has many" back-reference), the overwrite branch replaces the shared child's back-reference on every write, so only the last parent to process it survives; every other parent silently disappears from `R.<Parents>`. The slice loaders (`<Parent>Slice.Load<Rel>`) never had this bug — they always appended. All four overwrite sites now use that same plain `append` form, so every path agrees on what a to-many back-reference holds, and the result matches what `ThenLoad` has always produced for the same data.
+
+  **Breaking change:** now that a shared child is bob's default outcome for a dedup-eligible relationship (not just a caller-constructed edge case), any caller relying on the previous overwrite behaviour — including plain default-configuration JOIN `Preload` calls that happen to preload a relationship shared by multiple parents — will see every parent accumulate in the back-reference instead of just the last one. Calling `Preload` twice with the same parent adds that parent twice, matching the pre-existing non-deduplicating behaviour of the slice loaders and `ThenLoad`.
+
 ## [v0.50.0] - 2026-08-11
 
 ### Added

--- a/gen/templates/loaders/table/110_loaders.go.tpl
+++ b/gen/templates/loaders/table/110_loaders.go.tpl
@@ -34,7 +34,7 @@ func (o *{{$tAlias.UpSingular}}) Preload(name string, retrieved any) error {
 			for _, rel := range rels {
 				if rel != nil {
 					{{if $invRel.IsToMany -}}
-						rel.R.{{$invAlias}} = {{$tAlias.UpSingular}}Slice{o}
+						rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
 					{{- else -}}
 						rel.R.{{$invAlias}} =  o
 						rel.R.{{$.RelationLoadedName}}.{{$invAlias}} = true
@@ -56,7 +56,7 @@ func (o *{{$tAlias.UpSingular}}) Preload(name string, retrieved any) error {
 			{{- $invAlias := $fAlias.Relationship $invRel.Name -}}
 				if rel != nil {
 					{{if $invRel.IsToMany -}}
-						rel.R.{{$invAlias}} = {{$tAlias.UpSingular}}Slice{o}
+						rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
 					{{- else -}}
 						rel.R.{{$invAlias}} =  o
 						rel.R.{{$.RelationLoadedName}}.{{$invAlias}} = true
@@ -206,7 +206,7 @@ func (o *{{$tAlias.UpSingular}}) Load{{$relAlias}}(ctx context.Context, exec bob
 	{{if $rel.IsToMany -}}
 		for _, rel := range related {
 			{{if $invRel.IsToMany -}}
-				rel.R.{{$invAlias}} = {{$tAlias.UpSingular}}Slice{o}
+				rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
 			{{- else -}}
 				rel.R.{{$invAlias}} =  o
 				rel.R.{{$.RelationLoadedName}}.{{$invAlias}} = true
@@ -214,7 +214,7 @@ func (o *{{$tAlias.UpSingular}}) Load{{$relAlias}}(ctx context.Context, exec bob
 		}
 	{{else -}}
 		{{if $invRel.IsToMany -}}
-			related.R.{{$invAlias}} = {{$tAlias.UpSingular}}Slice{o}
+			related.R.{{$invAlias}} = append(related.R.{{$invAlias}}, o)
 		{{else -}}
 			related.R.{{$invAlias}} =  o
 			related.R.{{$.RelationLoadedName}}.{{$invAlias}} = true


### PR DESCRIPTION
> ⚠️ **Silent data loss regression in v0.50.0.** Any caller using the default-configuration generated `Preload` (or the single-model `Load<Rel>` methods) on a to-one relationship whose inverse is to-many can lose parents from `R.<Parents>` with no error. If you have upgraded to v0.50.0, you are likely affected.

## Summary

The generated `Preload(name, retrieved)` method and the single-model `Load<Rel>` methods write a to-many back-reference by **overwriting** it: `rel.R.<Rel> = <Parent>Slice{o}`. That single-element slice discards whatever was already in `R.<Rel>` before assigning it. The slice loaders (`<Parent>Slice.Load<Rel>`) never had this problem — they always `append`ed.

Until recently this discrepancy was invisible: each parent got its own freshly-built child instance, so overwriting a one-element slice with another one-element slice produced the same result as appending. That stopped being true in v0.50.0.

## Root cause

`orm.Preload`'s shared-child (dedup) mechanism was added opt-in as `orm.PreloadDedup` in commit `8d9485c` (2026-07-12), then made unconditional four days later in commit `76abd64` (2026-07-16), which removed the opt-in gate so `buildPreloader` takes the dedup path whenever the join key is resolvable. Both commits shipped together as #736 in **v0.50.0**.

With dedup on by default, every parent row that shares the same join key now shares **one** child struct instance. The four `<Parent>Slice{o}` overwrite sites in `110_loaders.go.tpl` each replace that shared child's back-reference on every write, so only the **last** parent processed survives in `R.<Parents>`; every earlier parent silently disappears — no error, no warning.

This affects any to-one relationship whose inverse side is to-many (i.e. a "has many" back-reference), which is the common shape for a foreign key relationship. Plain default-configuration JOIN `Preload` calls trigger it whenever the preloaded relationship is shared by multiple parents.

## Fix

All four overwrite sites in `gen/templates/loaders/table/110_loaders.go.tpl` now use `append` instead of replacing the slice:

```diff
- rel.R.{{$invAlias}} = {{$tAlias.UpSingular}}Slice{o}
+ rel.R.{{$invAlias}} = append(rel.R.{{$invAlias}}, o)
```

(two occurrences in `Preload`, one in the to-many branch of `Load<Rel>`, and one in the to-one branch of `Load<Rel>` operating on `related.R.<invAlias>`.)

This makes all generated loading paths agree on what a to-many back-reference holds: `Preload`, `Load<Rel>`, `<Parent>Slice.Load<Rel>`, and `ThenLoad` now all append.

## Breaking change

Now that a shared child is bob's default outcome for a dedup-eligible relationship (not a caller-constructed edge case), any caller relying on the previous overwrite behavior will observe a change: every parent sharing the child now accumulates in the back-reference, instead of only the last one. Calling `Preload` twice with the same parent now adds that parent twice to the back-reference, matching the pre-existing non-deduplicating behavior of the slice loaders and `ThenLoad`.

## Verification

- Confirmed via the four modified template sites in `gen/templates/loaders/table/110_loaders.go.tpl` that all to-many back-reference writes in generated `Preload`/`Load<Rel>` now use the same `append` form already used by the slice loaders.
- Confirmed the dedup mechanism this interacts with (`orm.PreloadDedup` → unconditional) via commits `8d9485c` and `76abd64`, both part of #736, released in v0.50.0.

## Checklist

- [x] Template change only (`gen/templates/loaders/table/110_loaders.go.tpl`), no manual edits to generated code needed by consumers — regenerate to pick up the fix
- [x] CHANGELOG.md updated under `[Unreleased]` with a `BREAKING` entry explaining the regression and its history
