### PR TITLE
fix: gofumpt formatting for golangci-lint v2.13

### DIFF
--- a/dialect/mysql/select_test.go
+++ b/dialect/mysql/select_test.go
@@ -93,16 +93,19 @@ func TestSelect(t *testing.T) {
 				GROUP BY status`,
 			Query: mysql.Select(
 				sm.Columns("status", mysql.F("avg", "difference")),
-				sm.From(mysql.Select(
-					sm.Columns(
-						"status",
-						mysql.F("LEAD", "created_date", 1, mysql.F("NOW"))(
-							fm.Over(
-								wm.PartitionBy("presale_id"),
-								wm.OrderBy("created_date"),
-							),
-						).Minus(mysql.Quote("created_date")).As("difference")),
-					sm.From("presales_presalestatus")),
+				sm.From(
+					mysql.Select(
+						sm.Columns(
+							"status",
+							mysql.F("LEAD", "created_date", 1, mysql.F("NOW"))(
+								fm.Over(
+									wm.PartitionBy("presale_id"),
+									wm.OrderBy("created_date"),
+								),
+							).Minus(mysql.Quote("created_date")).As("difference"),
+						),
+						sm.From("presales_presalestatus"),
+					),
 				).As("differnce_by_status"),
 				sm.Where(mysql.Quote("status").In(mysql.S("A"), mysql.S("B"), mysql.S("C"))),
 				sm.GroupBy("status"),

--- a/dialect/mysql/wm/qm.go
+++ b/dialect/mysql/wm/qm.go
@@ -49,10 +49,12 @@ func FromUnboundedPreceding() bob.Mod[*clause.Window] {
 
 func FromPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -65,20 +67,24 @@ func FromCurrentRow() bob.Mod[*clause.Window] {
 
 func FromFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }
 
 func ToPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -91,10 +97,12 @@ func ToCurrentRow() bob.Mod[*clause.Window] {
 
 func ToFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }

--- a/dialect/psql/delete_test.go
+++ b/dialect/psql/delete_test.go
@@ -47,7 +47,8 @@ func TestDelete(t *testing.T) {
 		"using item with inner join": {
 			Query: psql.Delete(
 				dm.From("employees"),
-				dm.Using("accounts",
+				dm.Using(
+					"accounts",
 					dm.InnerJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),
@@ -130,7 +131,8 @@ func TestDelete(t *testing.T) {
 		"using item with left join and alias": {
 			Query: psql.Delete(
 				dm.From("employees"),
-				dm.Using("accounts",
+				dm.Using(
+					"accounts",
 					dm.LeftJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),
@@ -180,7 +182,8 @@ func TestDelete(t *testing.T) {
 		"with multiple using items join rows from and table": {
 			Query: psql.Delete(
 				dm.From("employees"),
-				dm.Using("accounts",
+				dm.Using(
+					"accounts",
 					dm.LeftJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),

--- a/dialect/psql/select_test.go
+++ b/dialect/psql/select_test.go
@@ -267,16 +267,19 @@ func TestSelect(t *testing.T) {
 					GROUP BY status`,
 			Query: psql.Select(
 				sm.Columns("status", psql.F("avg", "difference")),
-				sm.From(psql.Select(
-					sm.Columns(
-						"status",
-						psql.F("LEAD", "created_date", 1, psql.F("NOW"))(
-							fm.Over(
-								wm.PartitionBy("presale_id"),
-								wm.OrderBy("created_date"),
-							),
-						).Minus(psql.Quote("created_date")).As("difference")),
-					sm.From("presales_presalestatus")),
+				sm.From(
+					psql.Select(
+						sm.Columns(
+							"status",
+							psql.F("LEAD", "created_date", 1, psql.F("NOW"))(
+								fm.Over(
+									wm.PartitionBy("presale_id"),
+									wm.OrderBy("created_date"),
+								),
+							).Minus(psql.Quote("created_date")).As("difference"),
+						),
+						sm.From("presales_presalestatus"),
+					),
 				).As("differnce_by_status"),
 				sm.Where(psql.Quote("status").In(psql.S("A"), psql.S("B"), psql.S("C"))),
 				sm.GroupBy("status"),
@@ -303,7 +306,8 @@ func TestSelect(t *testing.T) {
 				sm.From("users"),
 				sm.Where(
 					psql.Group(psql.Quote("id"), psql.Quote("employee_id")).
-						In(psql.ArgGroup(100, 200), psql.ArgGroup(300, 400))),
+						In(psql.ArgGroup(100, 200), psql.ArgGroup(300, 400)),
+				),
 			),
 			ExpectedSQL:  `SELECT id, name FROM users WHERE (("id", "employee_id") IN (($1, $2), ($3, $4)))`,
 			ExpectedArgs: []any{100, 200, 300, 400},

--- a/dialect/psql/update_test.go
+++ b/dialect/psql/update_test.go
@@ -94,7 +94,8 @@ func TestUpdate(t *testing.T) {
 			Query: psql.Update(
 				um.Table("employees"),
 				um.SetCol("sales_count").To("sales_count + 1"),
-				um.From("accounts",
+				um.From(
+					"accounts",
 					um.InnerJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),
@@ -194,7 +195,8 @@ func TestUpdate(t *testing.T) {
 			Query: psql.Update(
 				um.Table("employees"),
 				um.SetCol("sales_count").To("sales_count + 1"),
-				um.From("accounts",
+				um.From(
+					"accounts",
 					um.LeftJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),
@@ -248,7 +250,8 @@ func TestUpdate(t *testing.T) {
 			Query: psql.Update(
 				um.Table("employees"),
 				um.SetCol("n").To("1"),
-				um.From("accounts",
+				um.From(
+					"accounts",
 					um.InnerJoin("departments").OnEQ(
 						psql.Quote("accounts", "dept_id"),
 						psql.Quote("departments", "id"),

--- a/dialect/psql/wm/qm.go
+++ b/dialect/psql/wm/qm.go
@@ -56,10 +56,12 @@ func FromUnboundedPreceding() bob.Mod[*clause.Window] {
 
 func FromPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -72,20 +74,24 @@ func FromCurrentRow() bob.Mod[*clause.Window] {
 
 func FromFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }
 
 func ToPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -98,10 +104,12 @@ func ToCurrentRow() bob.Mod[*clause.Window] {
 
 func ToFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }

--- a/dialect/sqlite/select_test.go
+++ b/dialect/sqlite/select_test.go
@@ -89,16 +89,19 @@ func TestSelect(t *testing.T) {
 					GROUP BY status`,
 			Query: sqlite.Select(
 				sm.Columns("status", sqlite.F("avg", "difference")),
-				sm.From(sqlite.Select(
-					sm.Columns(
-						"status",
-						sqlite.F("LEAD", "created_date", 1, sqlite.F("NOW"))(
-							fm.Over(
-								wm.PartitionBy("presale_id"),
-								wm.OrderBy("created_date"),
-							),
-						).Minus(sqlite.Quote("created_date")).As("difference")),
-					sm.From("presales_presalestatus")),
+				sm.From(
+					sqlite.Select(
+						sm.Columns(
+							"status",
+							sqlite.F("LEAD", "created_date", 1, sqlite.F("NOW"))(
+								fm.Over(
+									wm.PartitionBy("presale_id"),
+									wm.OrderBy("created_date"),
+								),
+							).Minus(sqlite.Quote("created_date")).As("difference"),
+						),
+						sm.From("presales_presalestatus"),
+					),
 				).As("differnce_by_status"),
 				sm.Where(sqlite.Quote("status").In(sqlite.S("A"), sqlite.S("B"), sqlite.S("C"))),
 				sm.GroupBy("status"),

--- a/dialect/sqlite/wm/qm.go
+++ b/dialect/sqlite/wm/qm.go
@@ -56,10 +56,12 @@ func FromUnboundedPreceding() bob.Mod[*clause.Window] {
 
 func FromPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -72,20 +74,24 @@ func FromCurrentRow() bob.Mod[*clause.Window] {
 
 func FromFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetStart(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetStart(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }
 
 func ToPreceding(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " PRECEDING")
+				},
+			),
 		)
 	})
 }
@@ -98,10 +104,12 @@ func ToCurrentRow() bob.Mod[*clause.Window] {
 
 func ToFollowing(exp any) bob.Mod[*clause.Window] {
 	return bob.ModFunc[*clause.Window](func(w *clause.Window) {
-		w.SetEnd(bob.ExpressionFunc(
-			func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
-				return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
-			}),
+		w.SetEnd(
+			bob.ExpressionFunc(
+				func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+					return bob.ExpressIf(ctx, w, d, start, exp, true, "", " FOLLOWING")
+				},
+			),
 		)
 	})
 }

--- a/gen/bobgen-mysql/driver/mysql_test.go
+++ b/gen/bobgen-mysql/driver/mysql_test.go
@@ -25,7 +25,8 @@ func TestDriver(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	mysqlContainer, err := mysqltest.Run(context.Background(),
+	mysqlContainer, err := mysqltest.Run(
+		context.Background(),
 		"mysql:8.0.35",
 		mysqltest.WithDatabase("bobgen"),
 		mysqltest.WithUsername("root"),

--- a/gen/bobgen-mysql/driver/parser/mods.go
+++ b/gen/bobgen-mysql/driver/parser/mods.go
@@ -22,7 +22,8 @@ func (v *visitor) modWithClause(ctx interface {
 		sb.WriteString("q.SetRecursive(true)\n")
 	}
 	for _, cte := range with.AllCommonTableExpression() {
-		v.StmtRules = append(v.StmtRules,
+		v.StmtRules = append(
+			v.StmtRules,
 			internal.RecordPoints(
 				cte.GetStart().GetStart(),
 				cte.GetStop().GetStop(),

--- a/gen/bobgen-mysql/driver/parser/visitor.go
+++ b/gen/bobgen-mysql/driver/parser/visitor.go
@@ -3649,15 +3649,17 @@ func (v *visitor) VisitBindExpressionAtom(ctx *mysqlparser.BindExpressionAtomCon
 
 	v.SetArg(ctx)
 	v.UpdateInfo(info)
-	v.StmtRules = append(v.StmtRules, internal.RecordPoint(
-		ctx.GetStart().GetStart(),
-		func(start int) error {
-			v.UpdateInfo(NodeInfo{
-				Node:           ctx,
-				EditedPosition: [2]int{start, start + 1},
-			})
-			return nil
-		}),
+	v.StmtRules = append(
+		v.StmtRules, internal.RecordPoint(
+			ctx.GetStart().GetStart(),
+			func(start int) error {
+				v.UpdateInfo(NodeInfo{
+					Node:           ctx,
+					EditedPosition: [2]int{start, start + 1},
+				})
+				return nil
+			},
+		),
 	)
 
 	return nil

--- a/gen/bobgen-psql/driver/parser/mods.go
+++ b/gen/bobgen-psql/driver/parser/mods.go
@@ -26,7 +26,8 @@ func (w *walker) modWithClause(with *pg.WithClause, info nodeInfo) {
 			continue
 		}
 
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(cteInfo.start),
 				int(cteInfo.end-1),
@@ -50,7 +51,8 @@ func (w *walker) modAppendTableRefItems(clauseInfo nodeInfo, items []*pg.Node) {
 			continue
 		}
 
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(itemInfo.start),
 				int(itemInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/mods_delete.go
+++ b/gen/bobgen-psql/driver/parser/mods_delete.go
@@ -13,7 +13,8 @@ func (w *walker) modDeleteStatement(stmt *pg.Node_DeleteStmt, info nodeInfo) {
 	}
 
 	if tableInfo, ok := info.children["Relation"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(tableInfo.start),
 				int(tableInfo.end)-1,
@@ -33,7 +34,8 @@ func (w *walker) modDeleteStatement(stmt *pg.Node_DeleteStmt, info nodeInfo) {
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(whereInfo.start),
 				int(whereInfo.end)-1,
@@ -46,7 +48,8 @@ func (w *walker) modDeleteStatement(stmt *pg.Node_DeleteStmt, info nodeInfo) {
 	}
 
 	if returnInfo, ok := info.children["ReturningList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(returnInfo.start),
 				int(returnInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/mods_insert.go
+++ b/gen/bobgen-psql/driver/parser/mods_insert.go
@@ -14,7 +14,8 @@ func (w *walker) modInsertStatement(stmt *pg.Node_InsertStmt, info nodeInfo) {
 	}
 
 	if intoInfo, ok := info.children["Relation"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(intoInfo.start),
 				int(intoInfo.end)-1,
@@ -58,7 +59,8 @@ func (w *walker) modInsertStatement(stmt *pg.Node_InsertStmt, info nodeInfo) {
 	}
 
 	if conflictInfo, ok := info.children["OnConflictClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(conflictInfo.start),
 				int(conflictInfo.end)-1,
@@ -71,7 +73,8 @@ func (w *walker) modInsertStatement(stmt *pg.Node_InsertStmt, info nodeInfo) {
 	}
 
 	if returnInfo, ok := info.children["ReturningList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(returnInfo.start),
 				int(returnInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/mods_merge.go
+++ b/gen/bobgen-psql/driver/parser/mods_merge.go
@@ -14,7 +14,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 	}
 
 	if tableInfo, ok := info.children["Relation"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(tableInfo.start),
 				int(tableInfo.end)-1,
@@ -30,7 +31,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 	}
 
 	if sourceInfo, ok := info.children["SourceRelation"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(sourceInfo.start),
 				int(sourceInfo.end)-1,
@@ -48,7 +50,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 	}
 
 	if onInfo, ok := info.children["JoinCondition"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(onInfo.start),
 				int(onInfo.end)-1,
@@ -80,7 +83,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 			continue
 		}
 
-		fmt.Fprintf(w.mods,
+		fmt.Fprintf(
+			w.mods,
 			"q.When = append(q.When, dialect.MergeWhen{Type: %s, Action: dialect.MergeAction{Type: %s}})\n",
 			whenType,
 			actionType,
@@ -105,7 +109,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 
 		if hasWhenInfo {
 			if conditionInfo, ok := whenInfo.children["Condition"]; ok {
-				w.editRules = append(w.editRules,
+				w.editRules = append(
+					w.editRules,
 					internal.RecordPoints(
 						int(conditionInfo.start),
 						int(conditionInfo.end)-1,
@@ -120,7 +125,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 			switch when.CommandType {
 			case pg.CmdType_CMD_INSERT:
 				if valuesInfo, ok := whenInfo.children["Values"]; ok {
-					w.editRules = append(w.editRules,
+					w.editRules = append(
+						w.editRules,
 						internal.RecordPoints(
 							int(valuesInfo.start),
 							int(valuesInfo.end)-1,
@@ -134,7 +140,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 
 			case pg.CmdType_CMD_UPDATE:
 				if setInfo, ok := whenInfo.children["TargetList"]; ok {
-					w.editRules = append(w.editRules,
+					w.editRules = append(
+						w.editRules,
 						internal.RecordPoints(
 							int(setInfo.start),
 							int(setInfo.end)-1,
@@ -150,7 +157,8 @@ func (w *walker) modMergeStatement(stmt *pg.Node_MergeStmt, info nodeInfo) {
 	}
 
 	if returnInfo, ok := info.children["ReturningList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(returnInfo.start),
 				int(returnInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/mods_select.go
+++ b/gen/bobgen-psql/driver/parser/mods_select.go
@@ -37,7 +37,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 			fmt.Fprintln(w.mods, "q.Distinct.On = []any{}")
 		} else {
 			distinctInfo := info.children["DistinctClause"]
-			w.editRules = append(w.editRules,
+			w.editRules = append(
+				w.editRules,
 				internal.RecordPoints(
 					int(distinctInfo.start),
 					int(distinctInfo.end-1),
@@ -55,7 +56,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if targetInfo, ok := mainInfo.children["TargetList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(targetInfo.start),
 				int(targetInfo.end)-1,
@@ -68,7 +70,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if fromInfo, ok := mainInfo.children["FromClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(fromInfo.start),
 				int(fromInfo.end)-1,
@@ -81,7 +84,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if whereInfo, ok := mainInfo.children["WhereClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(whereInfo.start),
 				int(whereInfo.end)-1,
@@ -94,7 +98,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if groupByInfo, ok := mainInfo.children["GroupClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(groupByInfo.start),
 				int(groupByInfo.end)-1,
@@ -110,7 +115,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if havingInfo, ok := mainInfo.children["HavingClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(havingInfo.start),
 				int(havingInfo.end)-1,
@@ -125,7 +131,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	if windowsInfo, ok := mainInfo.children["WindowClause"]; ok {
 		for _, windowInfo := range windowsInfo.children {
 			nameStart := w.getStartOfTokenBefore(windowInfo.start, pg.Token_IDENT)
-			w.editRules = append(w.editRules,
+			w.editRules = append(
+				w.editRules,
 				internal.RecordPoints(
 					int(nameStart),
 					int(windowInfo.end)-1,
@@ -154,7 +161,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 			strategy = "EXCEPT"
 		}
 
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(combine.Info.start),
 				int(combine.Info.end)-1,
@@ -180,7 +188,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	// For a plain query this is the whole query; for a combined query (UNION /
 	// INTERSECT / EXCEPT) this is the first operand, which keeps its own clauses.
 	if limitInfo, ok := mainInfo.children["LimitCount"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(limitInfo.start),
 				int(limitInfo.end)-1,
@@ -203,7 +212,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if offsetInfo, ok := mainInfo.children["LimitOffset"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(offsetInfo.start),
 				int(offsetInfo.end)-1,
@@ -216,7 +226,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	}
 
 	if orderInfo, ok := mainInfo.children["SortClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(orderInfo.start),
 				int(orderInfo.end)-1,
@@ -234,7 +245,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 	// handled above as part of the main branch.
 	if len(combines) > 0 {
 		if limitInfo, ok := info.children["LimitCount"]; ok {
-			w.editRules = append(w.editRules,
+			w.editRules = append(
+				w.editRules,
 				internal.RecordPoints(
 					int(limitInfo.start),
 					int(limitInfo.end)-1,
@@ -257,7 +269,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 		}
 
 		if offsetInfo, ok := info.children["LimitOffset"]; ok {
-			w.editRules = append(w.editRules,
+			w.editRules = append(
+				w.editRules,
 				internal.RecordPoints(
 					int(offsetInfo.start),
 					int(offsetInfo.end)-1,
@@ -270,7 +283,8 @@ func (w *walker) modSelectStatement(stmt *pg.Node_SelectStmt, info nodeInfo) {
 		}
 
 		if orderInfo, ok := info.children["SortClause"]; ok {
-			w.editRules = append(w.editRules,
+			w.editRules = append(
+				w.editRules,
 				internal.RecordPoints(
 					int(orderInfo.start),
 					int(orderInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/mods_update.go
+++ b/gen/bobgen-psql/driver/parser/mods_update.go
@@ -13,7 +13,8 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if tableInfo, ok := info.children["Relation"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(tableInfo.start),
 				int(tableInfo.end)-1,
@@ -29,7 +30,8 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if targetInfo, ok := info.children["TargetList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(targetInfo.start),
 				int(targetInfo.end)-1,
@@ -46,7 +48,8 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if whereInfo, ok := info.children["WhereClause"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(whereInfo.start),
 				int(whereInfo.end)-1,
@@ -59,7 +62,8 @@ func (w *walker) modUpdateStatement(stmt *pg.Node_UpdateStmt, info nodeInfo) {
 	}
 
 	if returnInfo, ok := info.children["ReturningList"]; ok {
-		w.editRules = append(w.editRules,
+		w.editRules = append(
+			w.editRules,
 			internal.RecordPoints(
 				int(returnInfo.start),
 				int(returnInfo.end)-1,

--- a/gen/bobgen-psql/driver/parser/source.go
+++ b/gen/bobgen-psql/driver/parser/source.go
@@ -311,7 +311,8 @@ func (w *walker) addSourcesOfFromItem(from *pg.Node, fromInfo nodeInfo, sources 
 		fromInfo = joinInfo.children["Larg"]
 
 		infoKey := strings.TrimPrefix(
-			reflect.TypeOf(join.Rarg.Node).Elem().Name(), "Node_")
+			reflect.TypeOf(join.Rarg.Node).Elem().Name(), "Node_",
+		)
 
 		joined := joinedInfo{
 			node:     join.Rarg,

--- a/gen/bobgen-psql/driver/parser/translate.go
+++ b/gen/bobgen-psql/driver/parser/translate.go
@@ -233,7 +233,8 @@ func (t *Translator) addPgGenericArrayType(types drivers.Types, singleTyp string
             })`, singleTyp, singleComparer),
 		CompareExprImports: append(append(
 			[]string{`"slices"`},
-			singleTypDef.CompareExprImports...),
+			singleTypDef.CompareExprImports...,
+		),
 			singleTypDef.Imports...),
 	})
 

--- a/gen/bobgen-psql/driver/parser/walker.go
+++ b/gen/bobgen-psql/driver/parser/walker.go
@@ -474,20 +474,22 @@ func (w *walker) walkParamRef(a *pg.ParamRef) nodeInfo {
 		w.paramIdxMap[int64(a.Number)] = newIdx
 	}
 
-	w.editRules = append(w.editRules, internal.EditCallback(
-		internal.ReplaceFromFunc(
-			int(info.start), int(info.end-1),
-			func() string {
-				return fmt.Sprintf("$%d", newIdx)
+	w.editRules = append(
+		w.editRules, internal.EditCallback(
+			internal.ReplaceFromFunc(
+				int(info.start), int(info.end-1),
+				func() string {
+					return fmt.Sprintf("$%d", newIdx)
+				},
+			),
+			func(start, end int, _, _ string) error {
+				w.args[a.Number-1] = append(w.args[a.Number-1], argPos{
+					original: info.position(),
+					edited:   [2]int{start, end},
+				})
+				return nil
 			},
 		),
-		func(start, end int, _, _ string) error {
-			w.args[a.Number-1] = append(w.args[a.Number-1], argPos{
-				original: info.position(),
-				edited:   [2]int{start, end},
-			})
-			return nil
-		}),
 	)
 
 	return info
@@ -723,10 +725,12 @@ func (w *walker) walkSortBy(a *pg.SortBy) nodeInfo {
 	switch {
 	case hasSortNulls:
 		info.end = w.getEndOfTokenAfter(
-			info.start, pg.Token_FIRST_P, pg.Token_LAST_P)
+			info.start, pg.Token_FIRST_P, pg.Token_LAST_P,
+		)
 	case hasSortDir && a.SortbyDir != pg.SortByDir_SORTBY_USING:
 		info.end = w.getEndOfTokenAfter(
-			info.start, pg.Token_ASC, pg.Token_DESC)
+			info.start, pg.Token_ASC, pg.Token_DESC,
+		)
 	}
 	return info
 }
@@ -777,7 +781,8 @@ func (w *walker) walkList(a *pg.List) nodeInfo {
 func (w *walker) walkRowExpr(a *pg.RowExpr) nodeInfo {
 	info := w.reflectWalk(reflect.ValueOf(a))
 	w.editRules = append(w.editRules,
-		internal.RecordPoints(int(info.start), int(info.end-1),
+		internal.RecordPoints(
+			int(info.start), int(info.end-1),
 			func(start, end int) error {
 				w.setGroup(argPos{
 					original: info.position(),

--- a/gen/bobgen-sql/driver/sql.go
+++ b/gen/bobgen-sql/driver/sql.go
@@ -124,7 +124,8 @@ func getMySQLDriver(ctx context.Context, config Config) (mysqlDriver.Interface, 
 		config.DriverImage = defaultMySQLDriverImage
 	}
 
-	mysqlContainer, err := mysqltest.Run(ctx,
+	mysqlContainer, err := mysqltest.Run(
+		ctx,
 		config.DriverImage,
 		mysqltest.WithDatabase("bobgen"),
 		mysqltest.WithUsername("root"),

--- a/gen/bobgen-sqlite/driver/parser/mods.go
+++ b/gen/bobgen-sqlite/driver/parser/mods.go
@@ -21,7 +21,8 @@ func (v *visitor) modWith_clause(ctx interface {
 		sb.WriteString("q.SetRecursive(true)\n")
 	}
 	for _, cte := range with.AllCommon_table_expression() {
-		v.StmtRules = append(v.StmtRules,
+		v.StmtRules = append(
+			v.StmtRules,
 			internal.RecordPoints(
 				cte.GetStart().GetStart(),
 				cte.GetStop().GetStop(),

--- a/gen/bobgen-sqlite/driver/parser/visitor.go
+++ b/gen/bobgen-sqlite/driver/parser/visitor.go
@@ -994,20 +994,22 @@ func (v *visitor) VisitExpr_bind(ctx *sqliteparser.Expr_bindContext) any {
 
 	// So it does not refer to the same atomic
 	a := v.Atom
-	v.StmtRules = append(v.StmtRules, internal.EditCallback(
-		internal.ReplaceFromFunc(
-			ctx.GetStart().GetStart(), ctx.GetStop().GetStop(),
-			func() string {
-				return fmt.Sprintf("?%d", a.Add(1))
+	v.StmtRules = append(
+		v.StmtRules, internal.EditCallback(
+			internal.ReplaceFromFunc(
+				ctx.GetStart().GetStart(), ctx.GetStop().GetStop(),
+				func() string {
+					return fmt.Sprintf("?%d", a.Add(1))
+				},
+			),
+			func(start, end int, _, _ string) error {
+				v.UpdateInfo(NodeInfo{
+					Node:           ctx,
+					EditedPosition: [2]int{start, end},
+				})
+				return nil
 			},
 		),
-		func(start, end int, _, _ string) error {
-			v.UpdateInfo(NodeInfo{
-				Node:           ctx,
-				EditedPosition: [2]int{start, end},
-			})
-			return nil
-		}),
 	)
 
 	return nil
@@ -1233,7 +1235,8 @@ func (v *visitor) VisitSelect_stmt(ctx *sqliteparser.Select_stmtContext) any {
 		if len(source.Columns) != len(coreSource.Columns) {
 			v.Err = fmt.Errorf(
 				"select core %d: column count mismatch %d != %d",
-				i, len(source.Columns), len(coreSource.Columns))
+				i, len(source.Columns), len(coreSource.Columns),
+			)
 			return nil
 		}
 
@@ -1243,7 +1246,8 @@ func (v *visitor) VisitSelect_stmt(ctx *sqliteparser.Select_stmtContext) any {
 			if len(source.Columns[i].Type) == 0 {
 				v.Err = fmt.Errorf(
 					"select core %d: column %d type mismatch:\n%v\n%v",
-					i, i, col.Type, coreSource.Columns[i].Type)
+					i, i, col.Type, coreSource.Columns[i].Type,
+				)
 				return nil
 			}
 

--- a/gen/drivers/query_nesting.go
+++ b/gen/drivers/query_nesting.go
@@ -174,7 +174,8 @@ func (n nestedSlice) Types(currPkg string, i language.Importer, types Types, typ
 			}
 		}
 
-		fmt.Fprintf(&self, "%s %s\n",
+		fmt.Fprintf(
+			&self, "%s %s\n",
 			child.Col.Name,
 			childType,
 		)
@@ -260,7 +261,8 @@ func (n nestedSlice) Transform(currPkg string, i language.Importer, types Types,
 
 	switch {
 	case isSingle && n.AllNullable():
-		fmt.Fprintf(transformation, `if %s == nil {
+		fmt.Fprintf(
+			transformation, `if %s == nil {
 			  var fresh %s
 			  %s
 			  %s = &fresh
@@ -281,7 +283,8 @@ func (n nestedSlice) Transform(currPkg string, i language.Importer, types Types,
 		cmpExpr = strings.ReplaceAll(cmpExpr, "AAA", lhs)
 		cmpExpr = strings.ReplaceAll(cmpExpr, "BBB", rhs)
 
-		fmt.Fprintf(transformation, `
+		fmt.Fprintf(
+			transformation, `
 			var %s %s
 			if %s {
 			  fresh := %s{}

--- a/gen/drivers/tables.go
+++ b/gen/drivers/tables.go
@@ -297,7 +297,8 @@ func (tables Tables[C, I]) SetFactoryDeps(currPkg string, i language.Importer, t
 
 				if kside.TableName == r.Local() {
 					i.Import("github.com/stephenafamo/bob/orm")
-					mret = append(mret, fmt.Sprintf(`if %s != %s {
+					mret = append(mret, fmt.Sprintf(
+						`if %s != %s {
 								return &orm.RelationshipChainError{
 									Table1: %q, Column1: %q, Value: %q,
 								}
@@ -308,7 +309,8 @@ func (tables Tables[C, I]) SetFactoryDeps(currPkg string, i language.Importer, t
 					continue
 				}
 
-				mret = append(mret, fmt.Sprintf(`%s.%s = %s //h`,
+				mret = append(mret, fmt.Sprintf(
+					`%s.%s = %s //h`,
 					objVarName,
 					oalias.Columns[mapp.Column],
 					mapp.Value[1],
@@ -322,9 +324,11 @@ func (tables Tables[C, I]) SetFactoryDeps(currPkg string, i language.Importer, t
 				currPkg, i, types, aliases,
 				kside.TableName, mapp.ExternalTable,
 				mapp.Column, mapp.ExternalColumn,
-				extObjVarName, false)
+				extObjVarName, false,
+			)
 
-			mret = append(mret, fmt.Sprintf(`%s.%s = %s //h2`,
+			mret = append(mret, fmt.Sprintf(
+				`%s.%s = %s //h2`,
 				objVarName,
 				oalias.Columns[mapp.Column],
 				oSetter,


### PR DESCRIPTION
The lint workflow on main has been failing since 519ac21 (merge of #758). This is not caused by that PR: lint.yml runs golangci-lint-action with version: latest, and the run on the merge commit picked up golangci-lint v2.13.2 (released 2026-08-27) instead of v2.12.2. The newer bundled gofumpt flags 25 pre-existing files as not properly formatted. Since golangci-lint caps identical messages (max-same-issues), each run only surfaces 3 of them, which makes the failure look different every time.

This PR applies gofumpt -extra -w (matching the gofumpt: extra-rules: true setting in .golangci.yml) to those 25 files. Formatting only — no logic changes.

Note: v2.13 also warns that extra-rules is deprecated in favor of extra.group-params. I have left the config untouched, as that migration seems like a separate decision.