### PR TITLE
fix(factory): compose relationship creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed generated factories issuing an unnecessary update when creating an optional direct parent relationship. The parent is now created before its child so the child is inserted with the correct foreign key; this avoids triggering update side effects in temporal or versioned tables.
+
 - Fixed the generated `<Table>Slice.copyMatchingRows` (used by `UpdateAll`, `ReloadAll`, and the `UpdateMod`/`DeleteMod`/`MergeMod` loaders) dropping relationship and plugin caches when refreshing a slice in place. It used to swap each slice element for a freshly scanned model after copying over only `.R`, silently losing `.C` and any other non-column field. It now copies just the column fields onto the existing model instead, so the slice keeps its original pointers and all its cached fields. See [#759](https://github.com/stephenafamo/bob/pull/759) for the full rationale. Note: code relying on pointer identity changing across `UpdateAll`/`ReloadAll` will now observe the same pointer, and models returned by a caller-driven `.All()` call are no longer mutated with `.R`.
 
 - **BREAKING:** Fixed the generated single-model `(*Foo).Update` and `(*Foo).Reload` silently clearing relationship and plugin caches on every call. Both methods used to overwrite the receiver wholesale (`*o = *v`) with the freshly scanned row, which zeroed out every non-column field — the relationship cache `.R` (including `R.Loaded`), the counts plugin's `.C`, and anything a plugin adds via `model/fields/additional`. They now copy only the column fields instead, so those caches survive. See [#758](https://github.com/stephenafamo/bob/pull/758) for the full rationale.

--- a/gen/templates/factory/table/003_create.go.tpl
+++ b/gen/templates/factory/table/003_create.go.tpl
@@ -28,10 +28,13 @@ func (o *{{$tAlias.UpSingular}}Template) insertOptRels(ctx context.Context, exec
 	var err error
 
 	{{range $index, $rel := $.Relationships.Get $table.Key -}}{{if not ($.Tables.RelIsView $rel) -}}
-		{{- if ($table.RelIsRequired $rel)}}{{continue}}{{end -}}
+		{{- $firstSide := index $rel.Sides 0 -}}
+		{{- $directParent := and (not $rel.IsToMany) (eq (len $rel.Sides) 1) (eq $firstSide.Modify "from") -}}
+		{{- if or ($table.RelIsRequired $rel) $directParent}}{{continue}}{{end -}}
 		{{- $relAlias := $tAlias.Relationship .Name -}}
 		{{- $invRel := $.Relationships.GetInverse . -}}
 		{{- $ftable := $.Aliases.Table $rel.Foreign -}}
+		{{- $directChild := and (eq (len $rel.Sides) 1) (eq $firstSide.Modify "to") $invRel.Name -}}
 		{{- $invAlias := "" -}}
     {{- if and (not $.NoBackReferencing) $invRel.Name -}}
 			{{- $invAlias = $ftable.Relationship $invRel.Name -}}
@@ -62,10 +65,15 @@ func (o *{{$tAlias.UpSingular}}Template) insertOptRels(ctx context.Context, exec
               return err
             }
 
-            err = m.Attach{{$relAlias}}(ctx, exec, {{$.Tables.RelArgs $.Aliases $rel}} rel{{$index}}...)
-            if err != nil {
-              return err
-            }
+				{{if $directChild -}}
+					m.R.{{$relAlias}} = append(m.R.{{$relAlias}}, rel{{$index}}...)
+					m.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
+				{{else -}}
+					err = m.Attach{{$relAlias}}(ctx, exec, {{$.Tables.RelArgs $.Aliases $rel}} rel{{$index}}...)
+					if err != nil {
+						return err
+					}
+				{{end -}}
 					}
 				}
 		{{- else -}}
@@ -90,10 +98,15 @@ func (o *{{$tAlias.UpSingular}}Template) insertOptRels(ctx context.Context, exec
         if err != nil {
           return err
         }
-        err = m.Attach{{$relAlias}}(ctx, exec, {{$.Tables.RelArgs $.Aliases $rel}} rel{{$index}})
-        if err != nil {
-          return err
-        }
+			{{if $directChild -}}
+				m.R.{{$relAlias}} = rel{{$index}}
+				m.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
+			{{else -}}
+				err = m.Attach{{$relAlias}}(ctx, exec, {{$.Tables.RelArgs $.Aliases $rel}} rel{{$index}})
+				if err != nil {
+					return err
+				}
+			{{end -}}
 			}
 		{{end}}
 		}
@@ -109,7 +122,6 @@ func (o *{{$tAlias.UpSingular}}Template) insertOptRels(ctx context.Context, exec
 func (o *{{$tAlias.UpSingular}}Template) Create(ctx context.Context, exec bob.Executor) (*models.{{$tAlias.UpSingular}}, error) {
 	var err error
 	opt := o.BuildSetter()
-	ensureCreatable{{$tAlias.UpSingular}}(opt)
 
 	// Retrieve ancestor models from context to avoid duplicate parent creation.
 	// Parents are keyed by "parent_table:child_table:child_rel_name".
@@ -117,35 +129,48 @@ func (o *{{$tAlias.UpSingular}}Template) Create(ctx context.Context, exec bob.Ex
 	mInCreation, _ := modelsInCreationCtx.Value(ctx)
 
 	{{range $index, $rel := $.Relationships.Get $table.Key -}}
-		{{- if not ($table.RelIsRequired $rel)}}{{continue}}{{end -}}
+		{{- $firstSide := index $rel.Sides 0 -}}
+		{{- $directParent := and (not $rel.IsToMany) (eq (len $rel.Sides) 1) (eq $firstSide.Modify "from") -}}
+		{{- if not $directParent}}{{continue}}{{end -}}
+		{{- $required := $table.RelIsRequired $rel -}}
 		{{- $ftable := $.Aliases.Table .Foreign -}}
 		{{- $relAlias := $tAlias.Relationship .Name -}}
 
 		var rel{{$index}} *models.{{$ftable.UpSingular}}
 
-		if o.r.{{$relAlias}} == nil {
       if parentModel, found := mInCreation["{{$rel.Foreign}}:{{$table.Key}}:{{$rel.Name}}"]; found {
         if pModel, ok := parentModel.(*models.{{$ftable.UpSingular}}); ok {
           rel{{$index}} = pModel
         }
       }
-		}
-
-		if rel{{$index}} == nil {
-			if o.r.{{$relAlias}} == nil {
-				{{$tAlias.UpSingular}}Mods.WithNew{{$relAlias}}().Apply(ctx, o)
-			}
-
+		if rel{{$index}} == nil && o.r.{{$relAlias}} != nil {
 			if o.r.{{$relAlias}}.o.alreadyPersisted {
 				rel{{$index}} = o.r.{{$relAlias}}.o.Build()
 			} else {
-				rel{{$index}}, err = o.r.{{$relAlias}}.o.Create(ctx, exec)
+				relCtx := {{$tAlias.DownSingular}}Rel{{$relAlias}}Ctx.WithValue(ctx, true)
+				rel{{$index}}, err = o.r.{{$relAlias}}.o.Create(relCtx, exec)
 				if err != nil {
 					return nil, err
 				}
 			}
 		}
-	
+
+		{{if $required -}}
+		if rel{{$index}} == nil {
+			{{$tAlias.UpSingular}}Mods.WithNew{{$relAlias}}().Apply(ctx, o)
+			if o.r.{{$relAlias}}.o.alreadyPersisted {
+				rel{{$index}} = o.r.{{$relAlias}}.o.Build()
+			} else {
+				relCtx := {{$tAlias.DownSingular}}Rel{{$relAlias}}Ctx.WithValue(ctx, true)
+				rel{{$index}}, err = o.r.{{$relAlias}}.o.Create(relCtx, exec)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		{{end -}}
+
+		if rel{{$index}} != nil {
 		{{range $rel.ValuedSides -}}
 			{{- if ne .TableName $table.Key}}{{continue}}{{end -}}
 			{{range .Mapped}}
@@ -155,7 +180,10 @@ func (o *{{$tAlias.UpSingular}}Template) Create(ctx context.Context, exec bob.Ex
 				opt.{{$fromColA}} = {{$.Tables.ColumnAssigner $.CurrentPackage $.Importer $.Types $.Aliases $.Table.Key $rel.Foreign .Column .ExternalColumn $relIndex true}}
 			{{end}}
 		{{- end}}
+		}
 	{{end}}
+
+	ensureCreatable{{$tAlias.UpSingular}}(opt)
 
 	m, err := models.{{$tAlias.UpPlural}}.Insert(opt).One(ctx, exec)
 	if err != nil {
@@ -180,11 +208,15 @@ func (o *{{$tAlias.UpSingular}}Template) Create(ctx context.Context, exec bob.Ex
   ctx = modelsInCreationCtx.WithValue(ctx, newMInCreation)
 
 	{{range $index, $rel := $.Relationships.Get $table.Key -}}
-		{{- if not ($table.RelIsRequired $rel) -}}{{continue}}{{end -}}
+		{{- $firstSide := index $rel.Sides 0 -}}
+		{{- $directParent := and (not $rel.IsToMany) (eq (len $rel.Sides) 1) (eq $firstSide.Modify "from") -}}
+		{{- if not $directParent}}{{continue}}{{end -}}
 		{{- $ftable := $.Aliases.Table .Foreign -}}
 		{{- $relAlias := $tAlias.Relationship .Name -}}
-		m.R.{{$relAlias}} = rel{{$index}}
-		m.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
+		if rel{{$index}} != nil {
+			m.R.{{$relAlias}} = rel{{$index}}
+			m.R.{{$.RelationLoadedName}}.{{$relAlias}} = true
+		}
 	{{end}}
 
   if err := o.insertOptRels(ctx, exec, m); err != nil {

--- a/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/mysql/bobfactory_runtime.bob_test.go.tpl
@@ -1902,6 +1902,7 @@ func TestLoadedFactoryBuildToMany(t *testing.T) {
 		t.Fatalf("Expected 2 Videos, got %d", len(user.R.Videos))
 	}
 }
+
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}

--- a/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/psql/bobfactory_runtime.bob_test.go.tpl
@@ -1902,6 +1902,48 @@ func TestLoadedFactoryBuildToMany(t *testing.T) {
 		t.Fatalf("Expected 2 Videos, got %d", len(user.R.Videos))
 	}
 }
+
+// TestFactoryCreateWithOptionalParentDoesNotUpdateChild checks that creating
+// an optional direct parent does not require a second update of the child.
+func TestFactoryCreateWithOptionalParentDoesNotUpdateChild(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx := context.Background()
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TEMP TABLE video_updates (id INT);
+		CREATE FUNCTION record_video_update() RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			INSERT INTO video_updates VALUES (NEW.id);
+			RETURN NEW;
+		END;
+		$$;
+		CREATE TRIGGER record_video_update AFTER UPDATE ON videos
+		FOR EACH ROW EXECUTE FUNCTION record_video_update();
+	`); err != nil {
+		t.Fatalf("Error creating update trigger: %v", err)
+	}
+
+	video := New().NewVideoWithContext(ctx, VideoMods.WithNewSponsor()).CreateOrFail(ctx, t, tx)
+	if video.R.Sponsor == nil {
+		t.Fatal("Expected created Video to include its Sponsor")
+	}
+
+	var updates int
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM video_updates").Scan(&updates); err != nil {
+		t.Fatalf("Error counting video updates: %v", err)
+	}
+	if updates != 0 {
+		t.Fatalf("Expected no update after creating Video with Sponsor, got %d", updates)
+	}
+}
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}

--- a/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
+++ b/test/gen/templates/factory/sqlite/bobfactory_runtime.bob_test.go.tpl
@@ -1902,6 +1902,7 @@ func TestLoadedFactoryBuildToMany(t *testing.T) {
 		t.Fatalf("Expected 2 Videos, got %d", len(user.R.Videos))
 	}
 }
+
 {{- end }}
 
 {{- if and $hasVideos $hasSponsors }}


### PR DESCRIPTION
## Problem

Creating an optional direct parent relationship through a factory currently writes the child once, creates the parent, then writes the child again to set its foreign key. The final data is correct, but the second write is unnecessary and triggers observable update side effects.

This is not the best behavior for temporal or versioned tables, audit triggers, and any other database feature that reacts to updates.

## Minimal reproduction

Generate factories for these two tables:

```sql
CREATE TABLE sponsors (
    id INTEGER PRIMARY KEY
);

CREATE TABLE videos (
    id INTEGER PRIMARY KEY,
    sponsor_id INTEGER UNIQUE REFERENCES sponsors(id)
);
```

Create an update-audit trigger on `videos`, then create a video with a new sponsor:

```go
video := factory.New().NewVideo(
    factory.VideoMods.WithNewSponsor(),
).CreateOrFail(ctx, t, db)
```

Expected: the returned video includes its sponsor and no `videos` update occurs.

Actual on `main`: the video includes its sponsor, but the audit trigger records one `UPDATE` after both records have been created.

I reproduced this on local PostgreSQL 18.4: upstream `main` recorded one update; this branch recorded zero.

## Fix

Create direct parent and child relationships as part of one creation flow whenever the relationship is represented by the child foreign key. The factory inserts the child with the parent foreign key already set, avoiding the follow-up relationship update. Explicit foreign-key values remain sufficient to reference an existing parent, and cascading parent setup only fills relationships that are required.

